### PR TITLE
readme: easier clone with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Switch platforms anytime. Your `.prose` files work everywhere.
 ## Install (Claude Code)
 
 ```bash
-/plugin marketplace add git@github.com:openprose/prose.git
+/plugin marketplace add https://github.com/openprose/prose.git
 /plugin install open-prose@prose
 ```
 


### PR DESCRIPTION
ran into this by default (tries ssh auth). tested cloning with https change instead and it works better

```
     Original error: Cloning into <path redacted>
     git@github.com: Permission denied (publickey).
     fatal: Could not read from remote repository.
```