### PR TITLE
Add Codex support docs and AGENTS entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# OpenProse for Codex
+
+This repository includes the full OpenProse specification and skill content needed to run OpenProse workflows in Codex.
+
+## When to activate
+
+Treat OpenProse as active when the user:
+
+- runs any `prose` command such as `prose run`, `prose compile`, `prose migrate`, `prose help`, or `prose test`
+- asks to execute a `.prose` or OpenProse `.md` program
+- mentions OpenProse, Prose programs, Forme, or multi-agent orchestration defined by contracts
+
+## Entry point
+
+Read `skills/open-prose/SKILL.md` first. It is the canonical router for all `prose` commands and points to the minimum additional files required for each task.
+
+Do not search the workspace for alternate copies of the OpenProse documentation. The canonical files are the ones bundled under `skills/open-prose/`.
+
+## Execution model
+
+OpenProse assumes a Prose Complete environment:
+
+- the agent can read and write files
+- the agent can execute tool calls
+- the agent can spawn or coordinate subagents when available
+
+If those capabilities are available, use the bundled specifications directly. No separate runtime is required.
+
+## File routing
+
+- For `.md` programs, follow the two-phase routing described in `skills/open-prose/SKILL.md`.
+- For `.prose` programs, use the legacy v0 routing described there.
+- For authoring new programs, load the guidance files referenced by the skill before writing code.
+
+## Scope
+
+The files in `commands/` are Claude Code slash-command wrappers. They are optional convenience entry points, not the language runtime itself.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** March 2025
+**Last updated:** March 2026
 
 ## Overview
 
@@ -12,7 +12,7 @@ OpenProse is an open-source programming language for AI sessions. This privacy p
 
 ## Third-Party Services
 
-OpenProse runs within AI assistant environments (Claude Code, OpenCode, Amp). Your use of those platforms is governed by their respective privacy policies. OpenProse does not control or have access to data processed by those platforms.
+OpenProse runs within AI assistant environments (Claude Code, Codex, OpenCode, Amp). Your use of those platforms is governed by their respective privacy policies. OpenProse does not control or have access to data processed by those platforms.
 
 ## Open Source
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ OpenProse is a programming language for AI sessions. Programs are Markdown files
 
 This is the intelligent inversion of control: a container that understands context and intent, not just configuration.
 
-OpenProse runs on any **Prose Complete** system — a model and harness combination capable of simulating the VM upon reading its specification. Currently supported: Claude Code + Opus, OpenCode + Opus, Amp + Opus. Your programs are portable across all of them; there is no library lock-in.
+OpenProse runs on any **Prose Complete** system — a model and harness combination capable of simulating the VM upon reading its specification. Currently supported: Claude Code + Opus, Codex, OpenCode + Opus, Amp + Opus. Your programs are portable across all of them; there is no library lock-in.
 
 Legacy `.prose` programs still run via v0 mode (`prose run file.prose`). Use `prose migrate` to convert them to the new `.md` format.
 
@@ -47,6 +47,8 @@ Legacy `.prose` programs still run via v0 mode (`prose run file.prose`). Use `pr
 ```bash
 npx skills add openprose/prose
 ```
+
+In Codex, open this repository in your workspace and use the bundled [`AGENTS.md`](AGENTS.md) entry point, which routes `prose` requests to the canonical OpenProse skill and specs under `skills/open-prose/`.
 
 > **By installing, you agree to the [Privacy Policy](PRIVACY.md) and [Terms of Service](TERMS.md).**
 
@@ -129,14 +131,15 @@ See the [Language Reference](skills/open-prose/prose.md) for the VM spec and [Fo
 
 ## Getting Started
 
-1. Install the skill:
+1. Make the OpenProse skill available in your assistant environment:
    ```bash
    npx skills add openprose/prose
    ```
+   In Codex, opening this repository is sufficient because [`AGENTS.md`](AGENTS.md) routes `prose` requests to the bundled skill files.
 
 2. Write an `.md` program or open one from `skills/open-prose/examples/`.
 
-3. Run it inside a Prose Complete environment (Claude Code, OpenCode, or Amp with Opus):
+3. Run it inside a Prose Complete environment (Claude Code, Codex, OpenCode, or Amp with Opus):
    ```
    prose run my-program.md
    ```

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,5 +1,5 @@
 ---
-purpose: Bundled Claude Code skills distributed with the prose repo — open-prose VM
+purpose: Bundled OpenProse skill definitions distributed with the prose repo — open-prose VM
 related:
   - ../README.md
   - ./open-prose/README.md
@@ -8,7 +8,7 @@ related:
 
 # skills
 
-Claude Code skills bundled with the OpenProse language specification repo. Each subdirectory is a self-contained skill that can be installed via `npx skills add`.
+Bundled OpenProse skill definitions shipped with the language specification repo. In environments with `npx skills`, each subdirectory can be installed as a skill; in Codex, the same files can be loaded through the repository-local `AGENTS.md` entry point.
 
 ## Contents
 


### PR DESCRIPTION
## Summary
- add a repository-local `AGENTS.md` entrypoint so Codex can route `prose` requests to the bundled OpenProse skill and specs
- document Codex alongside other supported Prose Complete environments in the main README
- align privacy and skill documentation with the new Codex support wording

## Notes
- this PR is intentionally scoped to support discovery and repo-local integration, not a separate Codex runtime
- Claude-specific slash-command wrappers remain in `commands/` as optional convenience interfaces
