### PR TITLE
Make services a Contract Markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@ The program declares **what** should happen. The runtime figures out **how**.
 ---
 name: hunter
 kind: program
-services: [analyst, ranker, compiler]
 ---
+
+### Services
+
+- `analyst`
+- `ranker`
+- `compiler`
 
 ### Requires
 
@@ -95,7 +100,9 @@ OpenProse gives agents a small set of primitives that fit naturally in a repo:
 |-----------|-------------------|
 | `### Requires` | Inputs the caller, host, or upstream services must provide |
 | `### Ensures` | Outputs the component promises to produce |
-| `services:` | Named components Forme can auto-wire by semantic contract |
+| `### Services` | Named components Forme can auto-wire by semantic contract |
+| `### Runtime` | Execution hints such as persistence or model choice |
+| `### Shape` | Capability boundaries: what a service may do, delegate, or avoid |
 | `### Strategies` | Judgment rules for edge cases and degraded conditions |
 | `### Execution` | Optional ProseScript when you want exact order, loops, branches, or retries |
 | `.prose/runs/` | Auditable filesystem state for every run |

--- a/skills/open-prose/README.md
+++ b/skills/open-prose/README.md
@@ -9,7 +9,7 @@ related:
   - ./state/README.md
   - ./primitives/README.md
 glossary:
-  Contract Markdown: The `.md` program format with frontmatter and `###` contract sections.
+  Contract Markdown: The `.md` program format with tiny identity frontmatter and `###` contract sections.
   ProseScript: The imperative scripting layer used in `.prose` files and `### Execution` blocks.
   Forme: The semantic dependency-injection container described by `forme.md`.
   Prose VM: The execution engine described by `prose.md`.

--- a/skills/open-prose/SKILL.md
+++ b/skills/open-prose/SKILL.md
@@ -65,9 +65,9 @@ There is one skill: `open-prose`. Do not look for separate `prose-run`,
 For `.md` files:
 
 1. Read YAML frontmatter.
-2. If `kind: program` has a non-empty `services:` list, load `forme.md` to produce a manifest.
+2. If `kind: program` has a non-empty `### Services` section, load `forme.md` to produce a manifest.
 3. Load `prose.md` and `state/filesystem.md` to execute the manifest.
-4. If the file is a single component (`kind: service` or `kind: program` without `services:`), skip Forme and execute the component directly.
+4. If the file is a single component (`kind: service` or `kind: program` without `### Services`), skip Forme and execute the component directly.
 
 For `.prose` files:
 
@@ -92,6 +92,14 @@ Contract Markdown uses Markdown headers as the canonical human-facing syntax:
 
 - when sources are thin: broaden search terms
 
+### Runtime
+
+- `persist`: project
+
+### Shape
+
+- `self`: research, synthesize, cite sources
+
 ### Execution
 
 ```prose
@@ -106,7 +114,8 @@ Header hierarchy:
 
 - `#` is optional human title.
 - `##` starts an inline component in multi-service files.
-- Inline components may have a YAML block immediately after the `##` heading.
+- Historical inline components may have a YAML block immediately after the `##`
+  heading; canonical files put readable behavior in `###` sections.
 - `###` starts a section inside the current component.
 - Lowercase compatibility blocks (`requires:`, `ensures:`, etc.) remain accepted, but the header form is canonical.
 

--- a/skills/open-prose/contract-markdown.md
+++ b/skills/open-prose/contract-markdown.md
@@ -14,8 +14,9 @@ see-also:
 # Contract Markdown
 
 Contract Markdown is the human-facing `.md` format for OpenProse programs,
-services, tests, and composites. It combines YAML frontmatter with Markdown
-sections that describe what a component requires, ensures, and how it behaves.
+services, tests, and composites. It uses tiny YAML frontmatter for file
+identity, then Markdown sections for the human-facing language: services,
+contracts, runtime hints, shape, and execution.
 
 The format optimizes for two readers:
 
@@ -71,12 +72,16 @@ Forme and the Prose VM recognize these `###` sections case-insensitively:
 
 | Section | Applies To | Purpose |
 |---------|------------|---------|
+| `### Description` | program, service, test, composite | Human summary. Preserved for readers; not used as a contract |
+| `### Services` | program | Components Forme should resolve and wire |
 | `### Requires` | program, service, test, composite slots | Inputs or dependencies the caller/container must provide |
 | `### Ensures` | program, service, composite | Outputs or postconditions the component commits to |
 | `### Errors` | program, service | Declared failures the component may signal |
 | `### Invariants` | program, service, composite | Properties that must hold regardless of outcome |
 | `### Strategies` | program, service, test | Guidance for judgment calls and edge cases |
 | `### Environment` | program, service | Runtime variables supplied by host infrastructure |
+| `### Runtime` | program, service | Execution hints such as `persist` and `model` |
+| `### Shape` | service | Capability boundaries: self, delegates, and prohibited work |
 | `### Wiring` | program | Explicit Level 2 wiring declaration |
 | `### Execution` | program, service | ProseScript choreography that pins execution |
 | `### Fixtures` | test | Test inputs supplied without prompting |
@@ -91,7 +96,8 @@ sections unless a future spec names them.
 
 ## Compatibility Block Syntax
 
-Older OpenProse files and generated drafts may use lowercase colon blocks:
+Older OpenProse files and generated drafts may use lowercase colon blocks for
+contract sections:
 
 ```markdown
 requires:
@@ -106,19 +112,21 @@ same section in the same component, the `###` section wins and the lowercase
 block should produce a warning.
 
 Canonical docs, examples, and generated migrations should use `###` headers.
+The same rule applies to program topology and service behavior: use
+`### Services`, `### Runtime`, and `### Shape` instead of large YAML values.
 
 ## Component Extraction
 
 Forme parses a file in this order:
 
-1. Read YAML frontmatter.
+1. Read YAML frontmatter for identity metadata (`name`, `kind`) and compatibility fields.
 2. Create the file-level component from the frontmatter.
 3. Attach all `###` sections before the first `##` to the file-level component.
 4. For every `## {name}` heading, create an inline component named `{name}`.
 5. If the heading is immediately followed by a YAML block delimited by `---`,
-   parse it as inline component frontmatter. `name` must match the heading when
-   present; `kind` defaults to `service`; fields such as `shape`, `persist`,
-   `model`, and `delegates` apply only to that inline component.
+   parse it as inline component frontmatter for compatibility. `name` must match
+   the heading when present; `kind` defaults to `service`. Canonical files should
+   prefer `### Runtime` and `### Shape` sections for behavior.
 6. Attach subsequent `###` sections to that inline component until the next `##`.
 
 Example:
@@ -127,8 +135,12 @@ Example:
 ---
 name: content-pipeline
 kind: program
-services: [review, polish]
 ---
+
+### Services
+
+- `review`
+- `polish`
 
 ### Requires
 
@@ -140,11 +152,10 @@ services: [review, polish]
 
 ## review
 
----
-shape:
-  self: [read draft, write feedback]
-  prohibited: [editing final copy]
----
+### Shape
+
+- `self`: read draft, write feedback
+- `prohibited`: editing final copy
 
 ### Requires
 
@@ -169,9 +180,60 @@ shape:
 The file-level program requires `draft` and ensures `final`. It also
 contains inline services `review` and `polish`.
 
+## Services
+
+Declare a program's component graph with `### Services`:
+
+```markdown
+### Services
+
+- `researcher`
+- `writer`
+```
+
+Simple service names are Markdown list items. Structured service declarations
+use a fenced YAML list:
+
+````markdown
+### Services
+
+```yaml
+- name: reviewed-result
+  compose: std/composites/worker-critic
+  with:
+    worker: writer
+    critic: reviewer
+    max_rounds: 4
+```
+````
+
+`services:` in frontmatter remains accepted for compatibility, but canonical
+OpenProse programs should use `### Services`.
+
+## Runtime and Shape
+
+Runtime hints and behavioral boundaries are also sections:
+
+```markdown
+### Runtime
+
+- `persist`: project
+- `model`: sonnet
+
+### Shape
+
+- `self`: evaluate sources, score confidence
+- `delegates`:
+  - `summarizer`: compression
+- `prohibited`: direct web scraping
+```
+
+The old `persist:`, `model:`, and `shape:` frontmatter fields remain accepted
+for compatibility.
+
 ## Frontmatter
 
-Every component should declare:
+Every component should declare identity only:
 
 ```yaml
 ---
@@ -180,26 +242,8 @@ kind: program | service | test | composite
 ---
 ```
 
-Programs may declare:
-
-```yaml
-services: [researcher, writer]
-```
-
-Services may declare:
-
-```yaml
-shape:
-  self: [evaluate, decide]
-  delegates:
-    researcher: [source discovery]
-  prohibited: [direct web scraping]
-persist: true | project | user
-model: sonnet | opus | haiku
-```
-
-Frontmatter should stay structural. Contracts belong in Markdown sections, not
-large YAML values.
+Frontmatter should stay structural. If a field would be useful to read, review,
+or discuss, it should usually be a `###` section.
 
 ## Contract Item Style
 

--- a/skills/open-prose/deps.md
+++ b/skills/open-prose/deps.md
@@ -70,7 +70,7 @@ use "alice/research-pipeline" as research
 let result = research(topic: "quantum computing")
 ```
 
-In `services:` lists, use the full path — aliases are for execution blocks only.
+In `### Services`, use the full path — aliases are for execution blocks only.
 
 ---
 
@@ -97,7 +97,7 @@ Scans the project for dependency references and clones missing dependencies.
 
 1. **Scan** all `.md` and `.prose` files in the project for:
    - `use "owner/repo/path"` statements
-   - service names in `services:` that start with `std/` or `owner/repo/`
+   - service names in `### Services` that start with `std/` or `owner/repo/`
    - `compose:` paths that start with `std/` or `owner/repo/`
 2. **Parse** each dependency path to extract `owner/repo` pairs
 3. **Expand** `std/` shorthand to `openprose/std/`
@@ -236,14 +236,14 @@ If `prose.lock` exists but `.deps/` is missing or incomplete, the same error app
 
 ## Interaction with Forme
 
-When Forme resolves a service listed in `services:`, it checks `.deps/` as part of its resolution order (see `forme.md`, Step 2):
+When Forme resolves a service listed in `### Services`, it checks `.deps/` as part of its resolution order (see `forme.md`, Step 2):
 
 1. Same directory as the entry point: `./researcher.md`
 2. A subdirectory matching the name: `./researcher/index.md`
 3. **`.deps/` directory:** `.deps/{owner}/{repo}/{path}.md`
 4. Registry shorthand (if contains `/`): fetch from `https://p.prose.md/{path}` (compatibility path)
 
-A service name like `std/evals/inspector` in a `services:` list resolves to `.deps/openprose/std/evals/inspector.md` after `std/` shorthand expansion.
+A service name like `std/evals/inspector` in `### Services` resolves to `.deps/openprose/std/evals/inspector.md` after `std/` shorthand expansion.
 
 ---
 

--- a/skills/open-prose/examples/01-hello-world.md
+++ b/skills/open-prose/examples/01-hello-world.md
@@ -9,4 +9,4 @@ kind: service
 
 ### Ensures
 
-- greeting: a warm hello and brief self-introduction
+- `greeting`: a warm hello and brief self-introduction

--- a/skills/open-prose/examples/02-research-and-summarize.md
+++ b/skills/open-prose/examples/02-research-and-summarize.md
@@ -5,12 +5,12 @@ kind: service
 
 ### Requires
 
-- topic: a research question or area to investigate (default: "latest developments in AI agents and multi-agent systems")
+- `topic`: a research question or area to investigate (default: "latest developments in AI agents and multi-agent systems")
 
 ### Ensures
 
-- summary: 5 bullet points covering key findings with practical implications for developers
-- each bullet point: grounded in specific papers or announcements from the past 6 months
+- `summary`: 5 bullet points covering key findings with practical implications for developers
+- each bullet point is: grounded in specific papers or announcements from the past 6 months
 
 ### Strategies
 

--- a/skills/open-prose/examples/03-code-review.md
+++ b/skills/open-prose/examples/03-code-review.md
@@ -5,12 +5,12 @@ kind: service
 
 ### Requires
 
-- code: source code or directory to review
+- `code`: source code or directory to review
 
 ### Ensures
 
-- report: a unified code review covering security, performance, and maintainability
-- each issue: has a severity rating (critical, high, medium, low) and actionable recommendation
+- `report`: a unified code review covering security, performance, and maintainability
+- each issue has: a severity rating (critical, high, medium, low) and actionable recommendation
 - issues are prioritized by severity
 
 ### Strategies

--- a/skills/open-prose/examples/04-write-and-refine.md
+++ b/skills/open-prose/examples/04-write-and-refine.md
@@ -5,12 +5,12 @@ kind: service
 
 ### Requires
 
-- topic: what to write about (default: "a README.md for this project")
+- `topic`: what to write about (default: "a README.md for this project")
 
 ### Ensures
 
-- document: a polished, publication-ready document covering the topic
-- includes: overview, key sections appropriate to the topic, and code examples where relevant
+- `document`: a polished, publication-ready document covering the topic
+- `includes`: overview, key sections appropriate to the topic, and code examples where relevant
 
 ### Strategies
 

--- a/skills/open-prose/examples/09-research-with-agents/index.md
+++ b/skills/open-prose/examples/09-research-with-agents/index.md
@@ -1,16 +1,20 @@
 ---
 name: research-with-agents
 kind: program
-services: [researcher, writer]
 ---
+
+### Services
+
+- `researcher`
+- `writer`
 
 ### Requires
 
-- topic: a research question to investigate (default: "recent developments in renewable energy storage technologies")
+- `topic`: a research question to investigate (default: "recent developments in renewable energy storage technologies")
 
 ### Ensures
 
-- report: an executive-ready summary of research findings
+- `report`: an executive-ready summary of research findings
 
 ### Strategies
 

--- a/skills/open-prose/examples/09-research-with-agents/researcher.md
+++ b/skills/open-prose/examples/09-research-with-agents/researcher.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- topic: a research question to investigate
+- `topic`: a research question to investigate
 
 ### Ensures
 
-- findings: comprehensive research covering recent developments, key players, and promising directions
-- analysis: evaluation of the top 3 most promising approaches with impact assessment
+- `findings`: comprehensive research covering recent developments, key players, and promising directions
+- `analysis`: evaluation of the top 3 most promising approaches with impact assessment

--- a/skills/open-prose/examples/09-research-with-agents/writer.md
+++ b/skills/open-prose/examples/09-research-with-agents/writer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- findings: research results to synthesize
-- analysis: detailed analysis of key approaches
+- `findings`: research results to synthesize
+- `analysis`: detailed analysis of key approaches
 
 ### Ensures
 
-- report: a clear, concise executive summary suitable for non-technical stakeholders
+- `report`: a clear, concise executive summary suitable for non-technical stakeholders

--- a/skills/open-prose/examples/11-skills-and-imports.md
+++ b/skills/open-prose/examples/11-skills-and-imports.md
@@ -1,15 +1,21 @@
 ---
 name: skills-and-imports-demo
 kind: program
-services: [researcher, documenter]
 ---
 
-Demonstrates how Contract Markdown programs import services from the registry. Historical `import` and `skills:` declarations become entries in the `services:` list.
+### Services
+
+- `researcher`
+- `documenter`
+
+### Description
+
+Demonstrates how Contract Markdown programs import services from the registry. Historical `import` and `skills:` declarations become entries in `### Services`.
 
 ### Requires
 
-- topic: a research question (default: "recent developments in renewable energy storage")
+- `topic`: a research question (default: "recent developments in renewable energy storage")
 
 ### Ensures
 
-- summary: a technical summary incorporating research findings
+- `summary`: a technical summary incorporating research findings

--- a/skills/open-prose/examples/12-secure-agent-permissions.md
+++ b/skills/open-prose/examples/12-secure-agent-permissions.md
@@ -1,52 +1,53 @@
 ---
 name: secure-permissions-demo
 kind: program
-services: [code-reviewer, doc-writer]
 ---
 
-Demonstrates shapes as permission boundaries. Historical `permissions:` declarations become `shape.prohibited` and `shape.self` declarations that the VM enforces.
+### Services
+
+- `code-reviewer`
+- `doc-writer`
+
+### Description
+
+Demonstrates shapes as permission boundaries. Historical `permissions:`
+declarations become `### Shape` sections that the VM enforces.
 
 ### Requires
 
-- codebase: source code to review
+- `codebase`: source code to review
 
 ### Ensures
 
-- review: security review findings
-- documentation: updated documentation based on review findings
+- `review`: security review findings
+- `documentation`: updated documentation based on review findings
 
 ## code-reviewer
 
----
-name: code-reviewer
-kind: service
-shape:
-  self: [read source files, analyze code patterns, identify vulnerabilities]
-  prohibited: [modifying source files, running shell commands, writing to any directory]
----
+### Shape
+
+- `self`: read source files, analyze code patterns, identify vulnerabilities
+- `prohibited`: modifying source files, running shell commands, writing to any directory
 
 ### Requires
 
-- codebase: source code to review
+- `codebase`: source code to review
 
 ### Ensures
 
-- review: security issues and best practices findings with file paths cited
+- `review`: security issues and best practices findings with file paths cited
 
 ## doc-writer
 
----
-name: doc-writer
-kind: service
-shape:
-  self: [read source files and docs, write documentation]
-  prohibited: [modifying source code, running shell commands, writing outside docs/]
----
+### Shape
+
+- `self`: read source files and docs, write documentation
+- `prohibited`: modifying source code, running shell commands, writing outside docs/
 
 ### Requires
 
-- review: code review findings
+- `review`: code review findings
 
 ### Ensures
 
-- documentation: updated documentation reflecting review findings
+- `documentation`: updated documentation reflecting review findings

--- a/skills/open-prose/examples/13-variables-and-context.md
+++ b/skills/open-prose/examples/13-variables-and-context.md
@@ -1,16 +1,23 @@
 ---
 name: variables-and-context
 kind: program
-services: [researcher, analyst, writer]
 ---
+
+### Services
+
+- `researcher`
+- `analyst`
+- `writer`
+
+### Description
 
 Demonstrates how Contract Markdown auto-wiring can replace explicit ProseScript `let` bindings and `context:` passing. Forme matches `### Requires` to `### Ensures` automatically.
 
 ### Requires
 
-- topic: a research question (default: "current state of quantum computing")
+- `topic`: a research question (default: "current state of quantum computing")
 
 ### Ensures
 
-- report: comprehensive executive summary covering research, analysis, and market trends
-- deep-dive: polished technical deep-dive section
+- `report`: comprehensive executive summary covering research, analysis, and market trends
+- `deep-dive`: polished technical deep-dive section

--- a/skills/open-prose/examples/16-parallel-reviews/index.md
+++ b/skills/open-prose/examples/16-parallel-reviews/index.md
@@ -1,13 +1,19 @@
 ---
 name: parallel-reviews
 kind: program
-services: [security-reviewer, perf-reviewer, style-reviewer, synthesizer]
 ---
+
+### Services
+
+- `security-reviewer`
+- `perf-reviewer`
+- `style-reviewer`
+- `synthesizer`
 
 ### Requires
 
-- code: the code to review
+- `code`: the code to review
 
 ### Ensures
 
-- report: a unified code review report covering security, performance, and style
+- `report`: a unified code review report covering security, performance, and style

--- a/skills/open-prose/examples/16-parallel-reviews/perf-reviewer.md
+++ b/skills/open-prose/examples/16-parallel-reviews/perf-reviewer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- code: source code to review
+- `code`: source code to review
 
 ### Ensures
 
-- perf-findings: identified performance issues with impact ratings
+- `perf-findings`: identified performance issues with impact ratings

--- a/skills/open-prose/examples/16-parallel-reviews/security-reviewer.md
+++ b/skills/open-prose/examples/16-parallel-reviews/security-reviewer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- code: source code to review
+- `code`: source code to review
 
 ### Ensures
 
-- security-findings: identified security vulnerabilities with severity ratings
+- `security-findings`: identified security vulnerabilities with severity ratings

--- a/skills/open-prose/examples/16-parallel-reviews/style-reviewer.md
+++ b/skills/open-prose/examples/16-parallel-reviews/style-reviewer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- code: source code to review
+- `code`: source code to review
 
 ### Ensures
 
-- style-findings: identified code style and readability issues
+- `style-findings`: identified code style and readability issues

--- a/skills/open-prose/examples/16-parallel-reviews/synthesizer.md
+++ b/skills/open-prose/examples/16-parallel-reviews/synthesizer.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- security-findings: security review results
-- perf-findings: performance review results
-- style-findings: style review results
+- `security-findings`: security review results
+- `perf-findings`: performance review results
+- `style-findings`: style review results
 
 ### Ensures
 
-- report: unified code review report with issues prioritized by severity
+- `report`: unified code review report with issues prioritized by severity

--- a/skills/open-prose/examples/22-error-handling/config-parser.md
+++ b/skills/open-prose/examples/22-error-handling/config-parser.md
@@ -5,13 +5,13 @@ kind: service
 
 ### Requires
 
-- config-path: path to configuration file
+- `config-path`: path to configuration file
 
 ### Ensures
 
-- config: parsed and validated configuration
+- `config`: parsed and validated configuration
 - if config is invalid: default configuration with warning about which fields used defaults
 
 ### Errors
 
-- no-config: configuration file not found and no defaults available
+- `no-config`: configuration file not found and no defaults available

--- a/skills/open-prose/examples/22-error-handling/data-fetcher.md
+++ b/skills/open-prose/examples/22-error-handling/data-fetcher.md
@@ -5,16 +5,16 @@ kind: service
 
 ### Requires
 
-- api-endpoint: the API to query
+- `api-endpoint`: the API to query
 
 ### Ensures
 
-- data: fetched API response data
+- `data`: fetched API response data
 - if api is unavailable: cached data flagged as stale
 
 ### Errors
 
-- no-data: neither live nor cached data available
+- `no-data`: neither live nor cached data available
 
 ### Strategies
 

--- a/skills/open-prose/examples/22-error-handling/db-worker.md
+++ b/skills/open-prose/examples/22-error-handling/db-worker.md
@@ -5,17 +5,17 @@ kind: service
 
 ### Requires
 
-- data: data to process
-- config: database configuration
+- `data`: data to process
+- `config`: database configuration
 
 ### Ensures
 
-- result: processed and stored data with confirmation
+- `result`: processed and stored data with confirmation
 - if database is unreachable: error report with connection diagnostics
 
 ### Errors
 
-- db-failure: database connection failed after all retry attempts
+- `db-failure`: database connection failed after all retry attempts
 
 ### Strategies
 

--- a/skills/open-prose/examples/22-error-handling/index.md
+++ b/skills/open-prose/examples/22-error-handling/index.md
@@ -1,24 +1,29 @@
 ---
 name: error-handling-demo
 kind: program
-services: [data-fetcher, config-parser, db-worker]
 ---
+
+### Services
+
+- `data-fetcher`
+- `config-parser`
+- `db-worker`
 
 ### Requires
 
-- api-endpoint: the API to fetch data from
-- config-path: path to configuration file
+- `api-endpoint`: the API to fetch data from
+- `config-path`: path to configuration file
 
 ### Ensures
 
-- data: fetched and parsed data from the API
+- `data`: fetched and parsed data from the API
 - if api is unavailable: cached data with staleness warning
 - if config is invalid: partial result with default configuration applied
 - if database is unreachable: error report with connection diagnostics
 
 ### Errors
 
-- unrecoverable: all fallback paths exhausted
+- `unrecoverable`: all fallback paths exhausted
 
 ### Invariants
 

--- a/skills/open-prose/examples/23-retry-with-backoff.md
+++ b/skills/open-prose/examples/23-retry-with-backoff.md
@@ -3,21 +3,23 @@ name: retry-with-backoff
 kind: service
 ---
 
+### Description
+
 Demonstrates strategies for resilient API calls. Retry/backoff logic is expressed declaratively via `### Strategies` rather than imperative `retry:` and `backoff:` keywords.
 
 ### Requires
 
-- api-endpoint: the API to call
-- payload: data to send
+- `api-endpoint`: the API to call
+- `payload`: data to send
 
 ### Ensures
 
-- response: successful API response data
+- `response`: successful API response data
 - if primary endpoint is unavailable: response from backup endpoint with source noted
 
 ### Errors
 
-- all-endpoints-exhausted: neither primary nor backup responded after all retries
+- `all-endpoints-exhausted`: neither primary nor backup responded after all retries
 
 ### Strategies
 

--- a/skills/open-prose/examples/24-choice-blocks.md
+++ b/skills/open-prose/examples/24-choice-blocks.md
@@ -3,15 +3,17 @@ name: choice-blocks-demo
 kind: service
 ---
 
+### Description
+
 Demonstrates conditional ensures and strategies as declarative alternatives to ProseScript `choice` blocks. N-way branching becomes conditional ensures with strategies guiding behavior.
 
 ### Requires
 
-- codebase: the codebase to analyze
+- `codebase`: the codebase to analyze
 
 ### Ensures
 
-- action-plan: a prioritized plan for addressing issues found
+- `action-plan`: a prioritized plan for addressing issues found
 - if critical issues found: immediate fix plan with incident report
 - if moderate issues found: sprint-scheduled fix plan
 - if minor issues found: technical debt backlog entries

--- a/skills/open-prose/examples/25-conditionals.md
+++ b/skills/open-prose/examples/25-conditionals.md
@@ -3,15 +3,17 @@ name: conditionals-demo
 kind: service
 ---
 
+### Description
+
 Demonstrates conditional ensures as declarative alternatives to ProseScript `if/elif/else` patterns. Conditions become output variants.
 
 ### Requires
 
-- project: the project to evaluate
+- `project`: the project to evaluate
 
 ### Ensures
 
-- status-report: project status with recommended actions
+- `status-report`: project status with recommended actions
 - if project is ahead of schedule: report documenting success factors with stretch goal recommendations
 - if project is on track: standard status report with current plan confirmation
 - if project is slightly delayed: bottleneck analysis with adjusted timeline and stakeholder communication

--- a/skills/open-prose/examples/29-captains-chair/captain.md
+++ b/skills/open-prose/examples/29-captains-chair/captain.md
@@ -1,21 +1,26 @@
 ---
 name: captain
 kind: service
-persist: true
-shape:
-  self: [break down tasks, validate results, synthesize outputs, make technical decisions]
-  delegates:
-    researcher: [information gathering, codebase exploration]
-    coder: [code implementation]
-    critic: [quality review, issue identification]
-    tester: [test writing, validation]
-  prohibited: [writing code directly, executing tasks, running tests]
 ---
+
+### Runtime
+
+- `persist`: true
+
+### Shape
+
+- `self`: break down tasks, validate results, synthesize outputs, make technical decisions
+- `delegates`:
+  - `researcher`: information gathering, codebase exploration
+  - `coder`: code implementation
+  - `critic`: quality review, issue identification
+  - `tester`: test writing, validation
+- `prohibited`: writing code directly, executing tasks, running tests
 
 ### Requires
 
-- task: what to plan, validate, or synthesize
+- `task`: what to plan, validate, or synthesize
 
 ### Ensures
 
-- output: strategic plan, validated synthesis, or final summary depending on the phase
+- `output`: strategic plan, validated synthesis, or final summary depending on the phase

--- a/skills/open-prose/examples/29-captains-chair/coder.md
+++ b/skills/open-prose/examples/29-captains-chair/coder.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- plan: implementation plan to execute
+- `plan`: implementation plan to execute
 
 ### Ensures
 
-- implementation: clean, idiomatic code following existing codebase patterns
+- `implementation`: clean, idiomatic code following existing codebase patterns
 
 ### Strategies
 

--- a/skills/open-prose/examples/29-captains-chair/critic.md
+++ b/skills/open-prose/examples/29-captains-chair/critic.md
@@ -5,13 +5,13 @@ kind: service
 
 ### Requires
 
-- artifact: code or plan to review
-- focus: what aspects to prioritize
+- `artifact`: code or plan to review
+- `focus`: what aspects to prioritize
 
 ### Ensures
 
-- review: issues found prioritized by severity (critical, high, medium, low)
-- each issue: has specific location, description, and suggested fix
+- `review`: issues found prioritized by severity (critical, high, medium, low)
+- each issue has: specific location, description, and suggested fix
 
 ### Strategies
 

--- a/skills/open-prose/examples/29-captains-chair/index.md
+++ b/skills/open-prose/examples/29-captains-chair/index.md
@@ -1,17 +1,24 @@
 ---
 name: captains-chair
 kind: program
-services: [captain, researcher, coder, critic, tester]
 ---
+
+### Services
+
+- `captain`
+- `researcher`
+- `coder`
+- `critic`
+- `tester`
 
 ### Requires
 
-- task: the feature or task to implement
-- codebase-context: brief description of the codebase and relevant files
+- `task`: the feature or task to implement
+- `codebase-context`: brief description of the codebase and relevant files
 
 ### Ensures
 
-- result: completed, reviewed, and tested implementation with summary of changes
+- `result`: completed, reviewed, and tested implementation with summary of changes
 
 ### Execution
 

--- a/skills/open-prose/examples/29-captains-chair/researcher.md
+++ b/skills/open-prose/examples/29-captains-chair/researcher.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- topic: what to research
-- focus: specific aspect to investigate
+- `topic`: what to research
+- `focus`: specific aspect to investigate
 
 ### Ensures
 
-- findings: concise, actionable findings with file paths and line numbers cited
+- `findings`: concise, actionable findings with file paths and line numbers cited

--- a/skills/open-prose/examples/29-captains-chair/tester.md
+++ b/skills/open-prose/examples/29-captains-chair/tester.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- plan: what was planned
-- implementation: the code to test
+- `plan`: what was planned
+- `implementation`: the code to test
 
 ### Ensures
 
-- tests: comprehensive test suite covering unit tests, edge cases, and failure modes
-- test-results: pass/fail status with details on any failures
+- `tests`: comprehensive test suite covering unit tests, edge cases, and failure modes
+- `test-results`: pass/fail status with details on any failures

--- a/skills/open-prose/examples/30-captains-chair-simple/captain.md
+++ b/skills/open-prose/examples/30-captains-chair-simple/captain.md
@@ -1,19 +1,21 @@
 ---
 name: captain
 kind: service
-shape:
-  self: [break down tasks, validate results, synthesize outputs]
-  delegates:
-    executor: [task execution, implementation]
-    critic: [quality review, issue identification]
-  prohibited: [writing code directly, executing tasks]
 ---
+
+### Shape
+
+- `self`: break down tasks, validate results, synthesize outputs
+- `delegates`:
+  - `executor`: task execution, implementation
+  - `critic`: quality review, issue identification
+- `prohibited`: writing code directly, executing tasks
 
 ### Requires
 
-- task: what to accomplish
+- `task`: what to accomplish
 
 ### Ensures
 
-- plan: discrete work items with dependencies
-- result: validated and synthesized work product incorporating executor output and critic feedback
+- `plan`: discrete work items with dependencies
+- `result`: validated and synthesized work product incorporating executor output and critic feedback

--- a/skills/open-prose/examples/30-captains-chair-simple/critic.md
+++ b/skills/open-prose/examples/30-captains-chair-simple/critic.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- plan: the approach to critique
+- `plan`: the approach to critique
 
 ### Ensures
 
-- review: identified issues and improvement suggestions, prioritized by severity
+- `review`: identified issues and improvement suggestions, prioritized by severity

--- a/skills/open-prose/examples/30-captains-chair-simple/executor.md
+++ b/skills/open-prose/examples/30-captains-chair-simple/executor.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- plan: the work items to execute
+- `plan`: the work items to execute
 
 ### Ensures
 
-- work: completed implementation of the plan
+- `work`: completed implementation of the plan

--- a/skills/open-prose/examples/30-captains-chair-simple/index.md
+++ b/skills/open-prose/examples/30-captains-chair-simple/index.md
@@ -1,16 +1,21 @@
 ---
 name: captains-chair-simple
 kind: program
-services: [captain, executor, critic]
 ---
+
+### Services
+
+- `captain`
+- `executor`
+- `critic`
 
 ### Requires
 
-- task: what to accomplish
+- `task`: what to accomplish
 
 ### Ensures
 
-- result: completed and validated work product
+- `result`: completed and validated work product
 
 ### Strategies
 

--- a/skills/open-prose/examples/32-automated-pr-review/index.md
+++ b/skills/open-prose/examples/32-automated-pr-review/index.md
@@ -1,13 +1,19 @@
 ---
 name: automated-pr-review
 kind: program
-services: [reviewer, security-expert, performance-expert, synthesizer]
 ---
+
+### Services
+
+- `reviewer`
+- `security-expert`
+- `performance-expert`
+- `synthesizer`
 
 ### Requires
 
-- changes: the code changes to review (PR diff or directory)
+- `changes`: the code changes to review (PR diff or directory)
 
 ### Ensures
 
-- recommendation: a clear Approve, Request Changes, or Comment verdict with unified review
+- `recommendation`: a clear Approve, Request Changes, or Comment verdict with unified review

--- a/skills/open-prose/examples/32-automated-pr-review/performance-expert.md
+++ b/skills/open-prose/examples/32-automated-pr-review/performance-expert.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- changes: code changes to analyze
-- overview: architectural context
+- `changes`: code changes to analyze
+- `overview`: architectural context
 
 ### Ensures
 
-- perf-findings: performance implications, bottlenecks, and potential regressions
+- `perf-findings`: performance implications, bottlenecks, and potential regressions

--- a/skills/open-prose/examples/32-automated-pr-review/reviewer.md
+++ b/skills/open-prose/examples/32-automated-pr-review/reviewer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- changes: code changes to review
+- `changes`: code changes to review
 
 ### Ensures
 
-- overview: high-level summary of architectural impact
-- style-review: code style, maintainability, and best practices assessment
+- `overview`: high-level summary of architectural impact
+- `style-review`: code style, maintainability, and best practices assessment

--- a/skills/open-prose/examples/32-automated-pr-review/security-expert.md
+++ b/skills/open-prose/examples/32-automated-pr-review/security-expert.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- changes: code changes to audit
-- overview: architectural context
+- `changes`: code changes to audit
+- `overview`: architectural context
 
 ### Ensures
 
-- security-findings: OWASP top 10 issues and other security vulnerabilities found
+- `security-findings`: OWASP top 10 issues and other security vulnerabilities found

--- a/skills/open-prose/examples/32-automated-pr-review/synthesizer.md
+++ b/skills/open-prose/examples/32-automated-pr-review/synthesizer.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- overview: architectural impact summary
-- security-findings: security audit results
-- perf-findings: performance analysis results
-- style-review: code style assessment
+- `overview`: architectural impact summary
+- `security-findings`: security audit results
+- `perf-findings`: performance analysis results
+- `style-review`: code style assessment
 
 ### Ensures
 
-- recommendation: unified PR review with clear Approve, Request Changes, or Comment verdict
+- `recommendation`: unified PR review with clear Approve, Request Changes, or Comment verdict

--- a/skills/open-prose/examples/33-pr-review-autofix/captain.md
+++ b/skills/open-prose/examples/33-pr-review-autofix/captain.md
@@ -1,20 +1,25 @@
 ---
 name: captain
 kind: service
-persist: true
-shape:
-  self: [track issues, prioritize, decide when PR is ready]
-  delegates:
-    reviewer: [code review]
-    security-reviewer: [security audit]
-    fixer: [implementing fixes]
-  prohibited: [writing code directly]
 ---
+
+### Runtime
+
+- `persist`: true
+
+### Shape
+
+- `self`: track issues, prioritize, decide when PR is ready
+- `delegates`:
+  - `reviewer`: code review
+  - `security-reviewer`: security audit
+  - `fixer`: implementing fixes
+- `prohibited`: writing code directly
 
 ### Requires
 
-- task: what to coordinate or decide
+- `task`: what to coordinate or decide
 
 ### Ensures
 
-- output: issue prioritization, tracking update, or final report depending on phase
+- `output`: issue prioritization, tracking update, or final report depending on phase

--- a/skills/open-prose/examples/33-pr-review-autofix/fixer.md
+++ b/skills/open-prose/examples/33-pr-review-autofix/fixer.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- issue: the specific issue to fix
+- `issue`: the specific issue to fix
 
 ### Ensures
 
-- fix-result: minimal fix addressing exactly the reported issue with verification
+- `fix-result`: minimal fix addressing exactly the reported issue with verification
 
 ### Strategies
 

--- a/skills/open-prose/examples/33-pr-review-autofix/index.md
+++ b/skills/open-prose/examples/33-pr-review-autofix/index.md
@@ -1,16 +1,22 @@
 ---
 name: pr-review-autofix
 kind: program
-services: [reviewer, security-reviewer, fixer, captain]
 ---
+
+### Services
+
+- `reviewer`
+- `security-reviewer`
+- `fixer`
+- `captain`
 
 ### Requires
 
-- pr: the pull request to review and fix
+- `pr`: the pull request to review and fix
 
 ### Ensures
 
-- report: final PR review report with issues found, issues fixed, and MERGE/NEEDS_ATTENTION/BLOCK recommendation
+- `report`: final PR review report with issues found, issues fixed, and MERGE/NEEDS_ATTENTION/BLOCK recommendation
 
 ### Execution
 

--- a/skills/open-prose/examples/33-pr-review-autofix/reviewer.md
+++ b/skills/open-prose/examples/33-pr-review-autofix/reviewer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- pr: code changes to review
+- `pr`: code changes to review
 
 ### Ensures
 
-- review: structured list of issues covering correctness, logic, style, and readability, each with file path and line number
+- `review`: structured list of issues covering correctness, logic, style, and readability, each with file path and line number

--- a/skills/open-prose/examples/33-pr-review-autofix/security-reviewer.md
+++ b/skills/open-prose/examples/33-pr-review-autofix/security-reviewer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- pr: code changes to audit
+- `pr`: code changes to audit
 
 ### Ensures
 
-- security-review: HIGH priority findings covering injection, auth, data exposure, and crypto weaknesses
+- `security-review`: HIGH priority findings covering injection, auth, data exposure, and crypto weaknesses

--- a/skills/open-prose/examples/34-content-pipeline/editor.md
+++ b/skills/open-prose/examples/34-content-pipeline/editor.md
@@ -1,20 +1,25 @@
 ---
 name: editor
 kind: service
-persist: true
-shape:
-  self: [review clarity, check accuracy, evaluate engagement]
-  prohibited: [rewriting the article directly]
 ---
+
+### Runtime
+
+- `persist`: true
+
+### Shape
+
+- `self`: review clarity, check accuracy, evaluate engagement
+- `prohibited`: rewriting the article directly
 
 ### Requires
 
-- article: the article to review
+- `article`: the article to review
 
 ### Ensures
 
-- critique: specific, actionable editorial feedback covering clarity, accuracy, engagement, and structure
-- verdict: READY or NEEDS_REVISION
+- `critique`: specific, actionable editorial feedback covering clarity, accuracy, engagement, and structure
+- `verdict`: READY or NEEDS_REVISION
 
 ### Strategies
 

--- a/skills/open-prose/examples/34-content-pipeline/index.md
+++ b/skills/open-prose/examples/34-content-pipeline/index.md
@@ -1,18 +1,24 @@
 ---
 name: content-pipeline
 kind: program
-services: [researcher, writer, editor, social-strategist]
 ---
+
+### Services
+
+- `researcher`
+- `writer`
+- `editor`
+- `social-strategist`
 
 ### Requires
 
-- topic: the topic to create content about
-- audience: target audience (e.g., "developers", "executives", "general")
+- `topic`: the topic to create content about
+- `audience`: target audience (e.g., "developers", "executives", "general")
 
 ### Ensures
 
-- article: a polished, publication-ready blog post of 1500-2000 words
-- social: platform-specific social media content for Twitter/X, LinkedIn, and Hacker News
+- `article`: a polished, publication-ready blog post of 1500-2000 words
+- `social`: platform-specific social media content for Twitter/X, LinkedIn, and Hacker News
 
 ### Strategies
 

--- a/skills/open-prose/examples/34-content-pipeline/researcher.md
+++ b/skills/open-prose/examples/34-content-pipeline/researcher.md
@@ -1,17 +1,19 @@
 ---
 name: researcher
 kind: service
-shape:
-  self: [find sources, extract facts, identify angles]
-  prohibited: [writing articles, creating social media content]
 ---
+
+### Shape
+
+- `self`: find sources, extract facts, identify angles
+- `prohibited`: writing articles, creating social media content
 
 ### Requires
 
-- topic: the topic to research
+- `topic`: the topic to research
 
 ### Ensures
 
-- research-brief: unified research covering current state of the art, competitive landscape, and human interest stories
-- each claim: has a citation
-- narrative-suggestions: potential hooks, angles, and headline ideas
+- `research-brief`: unified research covering current state of the art, competitive landscape, and human interest stories
+- each claim has: a citation
+- `narrative-suggestions`: potential hooks, angles, and headline ideas

--- a/skills/open-prose/examples/34-content-pipeline/social-strategist.md
+++ b/skills/open-prose/examples/34-content-pipeline/social-strategist.md
@@ -5,13 +5,13 @@ kind: service
 
 ### Requires
 
-- article: the published article content
+- `article`: the published article content
 
 ### Ensures
 
-- twitter-content: main announcement tweet, 5-tweet thread, and 3 standalone insight tweets
-- linkedin-post: professional post (150-300 words) ending with engagement question
-- hn-submission: factual title under 80 chars with genuine, non-promotional comment
+- `twitter-content`: main announcement tweet, 5-tweet thread, and 3 standalone insight tweets
+- `linkedin-post`: professional post (150-300 words) ending with engagement question
+- `hn-submission`: factual title under 80 chars with genuine, non-promotional comment
 
 ### Strategies
 

--- a/skills/open-prose/examples/34-content-pipeline/writer.md
+++ b/skills/open-prose/examples/34-content-pipeline/writer.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- research-brief: research findings with citations
-- audience: target audience for tone and complexity
-- narrative-suggestions: potential article angles
+- `research-brief`: research findings with citations
+- `audience`: target audience for tone and complexity
+- `narrative-suggestions`: potential article angles
 
 ### Ensures
 
-- article: a 1500-2000 word blog post with hook, context, main points, examples, and conclusion
+- `article`: a 1500-2000 word blog post with hook, context, main points, examples, and conclusion
 - sources cited where appropriate

--- a/skills/open-prose/examples/35-feature-factory/architect.md
+++ b/skills/open-prose/examples/35-feature-factory/architect.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- feature: what to design
-- codebase-analysis: existing patterns and structure
+- `feature`: what to design
+- `codebase-analysis`: existing patterns and structure
 
 ### Ensures
 
-- design: technical design with file paths, interfaces, integration points, and risks
+- `design`: technical design with file paths, interfaces, integration points, and risks
 - design is: simple, extensible, and consistent with existing patterns

--- a/skills/open-prose/examples/35-feature-factory/captain.md
+++ b/skills/open-prose/examples/35-feature-factory/captain.md
@@ -1,21 +1,26 @@
 ---
 name: captain
 kind: service
-persist: project
-shape:
-  self: [coordinate, review, make technical decisions, track progress]
-  delegates:
-    architect: [system design]
-    implementer: [code writing]
-    tester: [test creation and execution]
-    documenter: [documentation]
-  prohibited: [writing implementation code, writing tests directly]
 ---
+
+### Runtime
+
+- `persist`: project
+
+### Shape
+
+- `self`: coordinate, review, make technical decisions, track progress
+- `delegates`:
+  - `architect`: system design
+  - `implementer`: code writing
+  - `tester`: test creation and execution
+  - `documenter`: documentation
+- `prohibited`: writing implementation code, writing tests directly
 
 ### Requires
 
-- task: what to coordinate, review, or decide
+- `task`: what to coordinate, review, or decide
 
 ### Ensures
 
-- output: plan, review, or summary appropriate to the phase
+- `output`: plan, review, or summary appropriate to the phase

--- a/skills/open-prose/examples/35-feature-factory/documenter.md
+++ b/skills/open-prose/examples/35-feature-factory/documenter.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- design: the feature design
-- focus: what documentation to produce
+- `design`: the feature design
+- `focus`: what documentation to produce
 
 ### Ensures
 
-- documentation: clear documentation matching existing project style
-- includes: function signatures, parameters, return values, and usage examples where appropriate
+- `documentation`: clear documentation matching existing project style
+- `includes`: function signatures, parameters, return values, and usage examples where appropriate

--- a/skills/open-prose/examples/35-feature-factory/implementer.md
+++ b/skills/open-prose/examples/35-feature-factory/implementer.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- task: what to implement or fix
+- `task`: what to implement or fix
 
 ### Ensures
 
-- implementation: clean, idiomatic code following existing project patterns
+- `implementation`: clean, idiomatic code following existing project patterns
 
 ### Strategies
 

--- a/skills/open-prose/examples/35-feature-factory/index.md
+++ b/skills/open-prose/examples/35-feature-factory/index.md
@@ -1,17 +1,24 @@
 ---
 name: feature-factory
 kind: program
-services: [captain, architect, implementer, tester, documenter]
 ---
+
+### Services
+
+- `captain`
+- `architect`
+- `implementer`
+- `tester`
+- `documenter`
 
 ### Requires
 
-- feature: description of the feature to implement
-- codebase-context: brief description of the codebase (optional)
+- `feature`: description of the feature to implement
+- `codebase-context`: brief description of the codebase (optional)
 
 ### Ensures
 
-- summary: completed feature with implementation, tests, and documentation
+- `summary`: completed feature with implementation, tests, and documentation
 
 ### Execution
 

--- a/skills/open-prose/examples/35-feature-factory/tester.md
+++ b/skills/open-prose/examples/35-feature-factory/tester.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- design: what was designed
+- `design`: what was designed
 
 ### Ensures
 
-- tests: unit tests, integration tests, and edge case tests using the project's test framework
-- test-results: pass/fail status for the full test suite
+- `tests`: unit tests, integration tests, and edge case tests using the project's test framework
+- `test-results`: pass/fail status for the full test suite

--- a/skills/open-prose/examples/36-bug-hunter/detective.md
+++ b/skills/open-prose/examples/36-bug-hunter/detective.md
@@ -1,20 +1,27 @@
 ---
 name: detective
 kind: service
-persist: true
-shape:
-  self: [gather evidence, form hypotheses, test theories, document findings]
-  delegates:
-    surgeon: [implementing fixes]
-  prohibited: [implementing fixes directly]
 ---
+
+### Description
+
+Follows data, not assumptions. Verifies each hypothesis with tests. Documents reasoning for future reference.
+
+### Runtime
+
+- `persist`: true
+
+### Shape
+
+- `self`: gather evidence, form hypotheses, test theories, document findings
+- `delegates`:
+  - `surgeon`: implementing fixes
+- `prohibited`: implementing fixes directly
 
 ### Requires
 
-- task: what to investigate, analyze, or document
+- `task`: what to investigate, analyze, or document
 
 ### Ensures
 
-- output: evidence, hypotheses, test results, or investigation report depending on phase
-
-Follows data, not assumptions. Verifies each hypothesis with tests. Documents reasoning for future reference.
+- `output`: evidence, hypotheses, test results, or investigation report depending on phase

--- a/skills/open-prose/examples/36-bug-hunter/index.md
+++ b/skills/open-prose/examples/36-bug-hunter/index.md
@@ -1,16 +1,20 @@
 ---
 name: bug-hunter
 kind: program
-services: [detective, surgeon]
 ---
+
+### Services
+
+- `detective`
+- `surgeon`
 
 ### Requires
 
-- bug-report: error message, stack trace, or bug description
+- `bug-report`: error message, stack trace, or bug description
 
 ### Ensures
 
-- report: investigation report with root cause, fix applied, tests added, and lessons learned
+- `report`: investigation report with root cause, fix applied, tests added, and lessons learned
 
 ### Execution
 

--- a/skills/open-prose/examples/36-bug-hunter/surgeon.md
+++ b/skills/open-prose/examples/36-bug-hunter/surgeon.md
@@ -1,17 +1,19 @@
 ---
 name: surgeon
 kind: service
-shape:
-  self: [make precise, minimal code fixes, add regression tests]
-  prohibited: [drive-by refactoring, changing unrelated code]
 ---
+
+### Shape
+
+- `self`: make precise, minimal code fixes, add regression tests
+- `prohibited`: drive-by refactoring, changing unrelated code
 
 ### Requires
 
-- diagnosis: root cause analysis
-- code-context: relevant codebase files
+- `diagnosis`: root cause analysis
+- `code-context`: relevant codebase files
 
 ### Ensures
 
-- fix: minimal fix addressing the root cause with regression test added
+- `fix`: minimal fix addressing the root cause with regression test added
 - code left cleaner than found

--- a/skills/open-prose/examples/37-the-forge/crucible.md
+++ b/skills/open-prose/examples/37-the-forge/crucible.md
@@ -1,18 +1,25 @@
 ---
 name: crucible
 kind: service
-persist: true
-shape:
-  self: [coordinate JavaScript engine design, analyze JS engine bugs]
-  prohibited: [implementing non-JS components]
 ---
+
+### Description
+
+The Crucible is the hottest part of The Forge. Specializes in lexical scoping, closures, prototype chains, and the event loop. Memory persists to build on prior JS engine work.
+
+### Runtime
+
+- `persist`: true
+
+### Shape
+
+- `self`: coordinate JavaScript engine design, analyze JS engine bugs
+- `prohibited`: implementing non-JS components
 
 ### Requires
 
-- task: what to coordinate or analyze in the JS engine
+- `task`: what to coordinate or analyze in the JS engine
 
 ### Ensures
 
-- output: JS engine coordination decisions or bug analysis with fix recommendations
-
-The Crucible is the hottest part of The Forge. Specializes in lexical scoping, closures, prototype chains, and the event loop. Memory persists to build on prior JS engine work.
+- `output`: JS engine coordination decisions or bug analysis with fix recommendations

--- a/skills/open-prose/examples/37-the-forge/hammer.md
+++ b/skills/open-prose/examples/37-the-forge/hammer.md
@@ -1,16 +1,18 @@
 ---
 name: hammer
 kind: service
-shape:
-  self: [write working Rust code from designs]
-  prohibited: [designing architecture, writing tests]
 ---
+
+### Shape
+
+- `self`: write working Rust code from designs
+- `prohibited`: designing architecture, writing tests
 
 ### Requires
 
-- task: what to implement
+- `task`: what to implement
 
 ### Ensures
 
-- code: clean, idiomatic Rust that compiles and works
+- `code`: clean, idiomatic Rust that compiles and works
 - code uses: minimal unsafe blocks (each documented), no external dependencies except winit and softbuffer

--- a/skills/open-prose/examples/37-the-forge/index.md
+++ b/skills/open-prose/examples/37-the-forge/index.md
@@ -1,16 +1,23 @@
 ---
 name: the-forge
 kind: program
-services: [smith, smelter, hammer, quench, crucible]
 ---
+
+### Services
+
+- `smith`
+- `smelter`
+- `hammer`
+- `quench`
+- `crucible`
 
 ### Requires
 
-- test-url: URL to test the browser against (default: https://prose.md)
+- `test-url`: URL to test the browser against (default: https://prose.md)
 
 ### Ensures
 
-- browser: a working web browser in Rust that can fetch, parse HTML/CSS, execute JavaScript, and render to a native window
+- `browser`: a working web browser in Rust that can fetch, parse HTML/CSS, execute JavaScript, and render to a native window
 
 ### Execution
 

--- a/skills/open-prose/examples/37-the-forge/quench.md
+++ b/skills/open-prose/examples/37-the-forge/quench.md
@@ -1,16 +1,18 @@
 ---
 name: quench
 kind: service
-shape:
-  self: [write tests, find bugs, verify correctness]
-  prohibited: [fixing bugs, implementing features]
 ---
+
+### Shape
+
+- `self`: write tests, find bugs, verify correctness
+- `prohibited`: fixing bugs, implementing features
 
 ### Requires
 
-- task: what to test
+- `task`: what to test
 
 ### Ensures
 
-- test-results: pass/fail status with details on any failures
+- `test-results`: pass/fail status with details on any failures
 - tests cover: unit tests, integration tests, edge cases, and regression tests

--- a/skills/open-prose/examples/37-the-forge/smelter.md
+++ b/skills/open-prose/examples/37-the-forge/smelter.md
@@ -1,16 +1,18 @@
 ---
 name: smelter
 kind: service
-shape:
-  self: [read specifications, produce technical designs]
-  prohibited: [writing implementation code]
 ---
+
+### Shape
+
+- `self`: read specifications, produce technical designs
+- `prohibited`: writing implementation code
 
 ### Requires
 
-- task: what to design
+- `task`: what to design
 
 ### Ensures
 
-- design: precise technical blueprint with Rust types, algorithms, and interface boundaries
+- `design`: precise technical blueprint with Rust types, algorithms, and interface boundaries
 - design is: precise enough that implementation is mechanical

--- a/skills/open-prose/examples/37-the-forge/smith.md
+++ b/skills/open-prose/examples/37-the-forge/smith.md
@@ -1,23 +1,30 @@
 ---
 name: smith
 kind: service
-persist: project
-shape:
-  self: [coordinate the build, make technical decisions, track progress, maintain vision]
-  delegates:
-    smelter: [design from specifications]
-    hammer: [code implementation]
-    quench: [testing and validation]
-    crucible: [JavaScript engine specialist work]
-  prohibited: [writing implementation code, writing tests]
 ---
+
+### Description
+
+The Smith is the master of The Forge. Speaks in the language of metalworking but means code, architecture, implementation, testing. Maintains vision of the complete browser across all phases.
+
+### Runtime
+
+- `persist`: project
+
+### Shape
+
+- `self`: coordinate the build, make technical decisions, track progress, maintain vision
+- `delegates`:
+  - `smelter`: design from specifications
+  - `hammer`: code implementation
+  - `quench`: testing and validation
+  - `crucible`: JavaScript engine specialist work
+- `prohibited`: writing implementation code, writing tests
 
 ### Requires
 
-- task: what to coordinate, decide, or diagnose
+- `task`: what to coordinate, decide, or diagnose
 
 ### Ensures
 
-- output: coordination decision, diagnosis, or project summary
-
-The Smith is the master of The Forge. Speaks in the language of metalworking but means code, architecture, implementation, testing. Maintains vision of the complete browser across all phases.
+- `output`: coordination decision, diagnosis, or project summary

--- a/skills/open-prose/examples/38-skill-scan/discovery.md
+++ b/skills/open-prose/examples/38-skill-scan/discovery.md
@@ -9,6 +9,6 @@ kind: service
 
 ### Ensures
 
-- inventory: structured list of installed skills with path, name, and source tool (claude-code, amp, etc.)
+- `inventory`: structured list of installed skills with path, name, and source tool (claude-code, amp, etc.)
 
 Checks: ~/.claude/skills/, .claude/skills/, ~/.claude/plugins/, .agents/skills/, ~/.config/agents/skills/

--- a/skills/open-prose/examples/38-skill-scan/exfil-scanner.md
+++ b/skills/open-prose/examples/38-skill-scan/exfil-scanner.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- skill-content: full contents of a skill directory
+- `skill-content`: full contents of a skill directory
 
 ### Ensures
 
-- findings: severity rating with identified exfiltration risks, data at risk, and distinction between legitimate API calls and suspicious endpoints
+- `findings`: severity rating with identified exfiltration risks, data at risk, and distinction between legitimate API calls and suspicious endpoints

--- a/skills/open-prose/examples/38-skill-scan/hook-analyzer.md
+++ b/skills/open-prose/examples/38-skill-scan/hook-analyzer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- skill-content: full contents of a skill directory
+- `skill-content`: full contents of a skill directory
 
 ### Ensures
 
-- findings: severity rating with hook triggers, actions, chain/escalation risk assessment
+- `findings`: severity rating with hook triggers, actions, chain/escalation risk assessment

--- a/skills/open-prose/examples/38-skill-scan/index.md
+++ b/skills/open-prose/examples/38-skill-scan/index.md
@@ -1,20 +1,30 @@
 ---
 name: skill-scan
 kind: program
-services: [discovery, triage, malicious-scanner, exfil-scanner, injection-scanner, permission-analyzer, hook-analyzer, synthesizer]
 ---
+
+### Services
+
+- `discovery`
+- `triage`
+- `malicious-scanner`
+- `exfil-scanner`
+- `injection-scanner`
+- `permission-analyzer`
+- `hook-analyzer`
+- `synthesizer`
 
 ### Requires
 
-- mode: scan mode -- "quick" (triage only), "standard" (triage + deep on concerns), or "deep" (full analysis)
-- focus: specific category to focus on (optional: malicious, exfiltration, injection, permissions, hooks)
-- skill-filter: specific skill name or path to scan (optional, default: all discovered)
+- `mode`: scan mode -- "quick" (triage only), "standard" (triage + deep on concerns), or "deep" (full analysis)
+- `focus`: specific category to focus on (optional: malicious, exfiltration, injection, permissions, hooks)
+- `skill-filter`: specific skill name or path to scan (optional, default: all discovered)
 
 ### Ensures
 
-- audit: security audit report with overall risk rating, findings by severity, and remediation recommendations
+- `audit`: security audit report with overall risk rating, findings by severity, and remediation recommendations
 - if no skills found: brief report listing directories checked
-- each skill scanned: has individual risk rating and safe-to-use verdict
+- each skill scanned has: individual risk rating and safe-to-use verdict
 
 ### Strategies
 

--- a/skills/open-prose/examples/38-skill-scan/injection-scanner.md
+++ b/skills/open-prose/examples/38-skill-scan/injection-scanner.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- skill-content: full contents of a skill directory
+- `skill-content`: full contents of a skill directory
 
 ### Ensures
 
-- findings: severity rating with identified prompt injection vulnerabilities including override language, hidden instructions, and jailbreak patterns
+- `findings`: severity rating with identified prompt injection vulnerabilities including override language, hidden instructions, and jailbreak patterns

--- a/skills/open-prose/examples/38-skill-scan/malicious-scanner.md
+++ b/skills/open-prose/examples/38-skill-scan/malicious-scanner.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- skill-content: full contents of a skill directory
+- `skill-content`: full contents of a skill directory
 
 ### Ensures
 
-- findings: severity rating with specific malicious code patterns found (file deletion, miners, backdoors, obfuscation)
+- `findings`: severity rating with specific malicious code patterns found (file deletion, miners, backdoors, obfuscation)

--- a/skills/open-prose/examples/38-skill-scan/permission-analyzer.md
+++ b/skills/open-prose/examples/38-skill-scan/permission-analyzer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- skill-content: full contents of a skill directory
+- `skill-content`: full contents of a skill directory
 
 ### Ensures
 
-- findings: severity rating with requested permissions, excessive permissions, and least-privilege recommendation
+- `findings`: severity rating with requested permissions, excessive permissions, and least-privilege recommendation

--- a/skills/open-prose/examples/38-skill-scan/synthesizer.md
+++ b/skills/open-prose/examples/38-skill-scan/synthesizer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- scan-results: findings from all scanners for all skills
+- `scan-results`: findings from all scanners for all skills
 
 ### Ensures
 
-- audit: comprehensive security audit with executive summary, skills grouped by risk level, common vulnerability patterns, and prioritized remediation actions
+- `audit`: comprehensive security audit with executive summary, skills grouped by risk level, common vulnerability patterns, and prioritized remediation actions

--- a/skills/open-prose/examples/38-skill-scan/triage.md
+++ b/skills/open-prose/examples/38-skill-scan/triage.md
@@ -3,12 +3,14 @@ name: triage
 kind: service
 ---
 
+### Description
+
+Scans for: suspicious URLs, base64 content, shell commands in hooks, overly broad permissions, dangerous keywords.
+
 ### Requires
 
-- skill-content: full contents of a skill directory
+- `skill-content`: full contents of a skill directory
 
 ### Ensures
 
-- triage-result: risk level (critical/high/medium/low/clean), red flags found, whether deep scan is needed, and confidence level
-
-Scans for: suspicious URLs, base64 content, shell commands in hooks, overly broad permissions, dangerous keywords.
+- `triage-result`: risk level (critical/high/medium/low/clean), red flags found, whether deep scan is needed, and confidence level

--- a/skills/open-prose/examples/39-architect-by-simulation/architect.md
+++ b/skills/open-prose/examples/39-architect-by-simulation/architect.md
@@ -1,21 +1,28 @@
 ---
 name: architect
 kind: service
-persist: true
-shape:
-  self: [design systems, synthesize across phases, make architectural decisions]
-  delegates:
-    phase-executor: [detailed phase analysis]
-    reviewer: [independent validation]
-  prohibited: [writing production code]
 ---
+
+### Description
+
+Designs systems by simulating their implementation. Writes specifications precise enough to implement from. Maintains context across all phases and references previous handoffs explicitly.
+
+### Runtime
+
+- `persist`: true
+
+### Shape
+
+- `self`: design systems, synthesize across phases, make architectural decisions
+- `delegates`:
+  - `phase-executor`: detailed phase analysis
+  - `reviewer`: independent validation
+- `prohibited`: writing production code
 
 ### Requires
 
-- task: what to design, synthesize, or decide
+- `task`: what to design, synthesize, or decide
 
 ### Ensures
 
-- output: BUILD_PLAN, phase synthesis, or final specification depending on the phase
-
-Designs systems by simulating their implementation. Writes specifications precise enough to implement from. Maintains context across all phases and references previous handoffs explicitly.
+- `output`: BUILD_PLAN, phase synthesis, or final specification depending on the phase

--- a/skills/open-prose/examples/39-architect-by-simulation/index.md
+++ b/skills/open-prose/examples/39-architect-by-simulation/index.md
@@ -1,20 +1,25 @@
 ---
 name: architect-by-simulation
 kind: program
-services: [architect, phase-executor, reviewer]
 ---
+
+### Services
+
+- `architect`
+- `phase-executor`
+- `reviewer`
 
 ### Requires
 
-- feature: the feature or system to architect
-- context-files: comma-separated list of files to read for context
-- output-dir: directory for the BUILD_PLAN and phase handoffs
+- `feature`: the feature or system to architect
+- `context-files`: comma-separated list of files to read for context
+- `output-dir`: directory for the BUILD_PLAN and phase handoffs
 
 ### Ensures
 
-- spec: complete, implementable specification document
-- handoffs: phase-by-phase design exploration documents
-- review: independent validation of the design
+- `spec`: complete, implementable specification document
+- `handoffs`: phase-by-phase design exploration documents
+- `review`: independent validation of the design
 
 ### Execution
 

--- a/skills/open-prose/examples/39-architect-by-simulation/phase-executor.md
+++ b/skills/open-prose/examples/39-architect-by-simulation/phase-executor.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- task: the phase to execute
-- previous-handoffs: what has been decided in prior phases
+- `task`: the phase to execute
+- `previous-handoffs`: what has been decided in prior phases
 
 ### Ensures
 
-- handoff: document covering what was analyzed, decisions made with rationale, trade-offs considered, and recommendations for the next phase
+- `handoff`: document covering what was analyzed, decisions made with rationale, trade-offs considered, and recommendations for the next phase

--- a/skills/open-prose/examples/39-architect-by-simulation/reviewer.md
+++ b/skills/open-prose/examples/39-architect-by-simulation/reviewer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- handoffs: all phase handoffs to review
+- `handoffs`: all phase handoffs to review
 
 ### Ensures
 
-- review: assessment covering internal consistency, completeness, feasibility, trade-off honesty, and clarity
-- verdict: READY or NEEDS_REVISION with specific critical and minor issues listed
+- `review`: assessment covering internal consistency, completeness, feasibility, trade-off honesty, and clarity
+- `verdict`: READY or NEEDS_REVISION with specific critical and minor issues listed

--- a/skills/open-prose/examples/40-rlm-self-refine/evaluator.md
+++ b/skills/open-prose/examples/40-rlm-self-refine/evaluator.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- artifact: content to evaluate
-- criteria: quality criteria
+- `artifact`: content to evaluate
+- `criteria`: quality criteria
 
 ### Ensures
 
-- score: numeric score 0-100
-- issues: specific issues identified with severity
+- `score`: numeric score 0-100
+- `issues`: specific issues identified with severity

--- a/skills/open-prose/examples/40-rlm-self-refine/index.md
+++ b/skills/open-prose/examples/40-rlm-self-refine/index.md
@@ -1,17 +1,21 @@
 ---
 name: rlm-self-refine
 kind: program
-services: [evaluator, refiner]
 ---
+
+### Services
+
+- `evaluator`
+- `refiner`
 
 ### Requires
 
-- artifact: the artifact to refine
-- criteria: quality criteria to evaluate against
+- `artifact`: the artifact to refine
+- `criteria`: quality criteria to evaluate against
 
 ### Ensures
 
-- result: the refined artifact scoring 85+ against criteria
+- `result`: the refined artifact scoring 85+ against criteria
 
 ### Strategies
 

--- a/skills/open-prose/examples/40-rlm-self-refine/refiner.md
+++ b/skills/open-prose/examples/40-rlm-self-refine/refiner.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- artifact: content to improve
-- issues: specific issues to address
+- `artifact`: content to improve
+- `issues`: specific issues to address
 
 ### Ensures
 
-- improved: the artifact with targeted improvements, preserving what works
+- `improved`: the artifact with targeted improvements, preserving what works

--- a/skills/open-prose/examples/41-rlm-divide-conquer/analyzer.md
+++ b/skills/open-prose/examples/41-rlm-divide-conquer/analyzer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- chunk: a portion of a larger corpus
-- query: what to extract or compute
+- `chunk`: a portion of a larger corpus
+- `query`: what to extract or compute
 
 ### Ensures
 
-- partial-result: information relevant to the query extracted from this chunk
+- `partial-result`: information relevant to the query extracted from this chunk

--- a/skills/open-prose/examples/41-rlm-divide-conquer/chunker.md
+++ b/skills/open-prose/examples/41-rlm-divide-conquer/chunker.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- corpus: text to split
+- `corpus`: text to split
 
 ### Ensures
 
-- chunks: 4-8 semantically coherent pieces that preserve meaning at boundaries
+- `chunks`: 4-8 semantically coherent pieces that preserve meaning at boundaries

--- a/skills/open-prose/examples/41-rlm-divide-conquer/index.md
+++ b/skills/open-prose/examples/41-rlm-divide-conquer/index.md
@@ -1,17 +1,22 @@
 ---
 name: rlm-divide-conquer
 kind: program
-services: [chunker, analyzer, synthesizer]
 ---
+
+### Services
+
+- `chunker`
+- `analyzer`
+- `synthesizer`
 
 ### Requires
 
-- corpus: large corpus to analyze
-- query: what to find or compute
+- `corpus`: large corpus to analyze
+- `query`: what to find or compute
 
 ### Ensures
 
-- answer: comprehensive answer to the query, synthesized from analysis of the full corpus
+- `answer`: comprehensive answer to the query, synthesized from analysis of the full corpus
 
 ### Strategies
 

--- a/skills/open-prose/examples/41-rlm-divide-conquer/synthesizer.md
+++ b/skills/open-prose/examples/41-rlm-divide-conquer/synthesizer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- partial-results: results from analyzing individual chunks
-- query: the original question
+- `partial-results`: results from analyzing individual chunks
+- `query`: the original question
 
 ### Ensures
 
-- answer: unified answer reconciling all partial results, with conflicts noted
+- `answer`: unified answer reconciling all partial results, with conflicts noted

--- a/skills/open-prose/examples/42-rlm-filter-recurse/index.md
+++ b/skills/open-prose/examples/42-rlm-filter-recurse/index.md
@@ -1,17 +1,22 @@
 ---
 name: rlm-filter-recurse
 kind: program
-services: [screener, investigator, reasoner]
 ---
+
+### Services
+
+- `screener`
+- `investigator`
+- `reasoner`
 
 ### Requires
 
-- documents: collection of documents to search
-- question: question requiring multi-source evidence
+- `documents`: collection of documents to search
+- `question`: question requiring multi-source evidence
 
 ### Ensures
 
-- answer: evidence-based answer with reasoning chain and source citations
+- `answer`: evidence-based answer with reasoning chain and source citations
 
 ### Strategies
 

--- a/skills/open-prose/examples/42-rlm-filter-recurse/investigator.md
+++ b/skills/open-prose/examples/42-rlm-filter-recurse/investigator.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- document: a relevant document
-- question: what evidence to extract
+- `document`: a relevant document
+- `question`: what evidence to extract
 
 ### Ensures
 
-- evidence: specific evidence with citations extracted from the document
+- `evidence`: specific evidence with citations extracted from the document

--- a/skills/open-prose/examples/42-rlm-filter-recurse/reasoner.md
+++ b/skills/open-prose/examples/42-rlm-filter-recurse/reasoner.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- evidence: collected evidence from multiple sources
-- question: the original question
+- `evidence`: collected evidence from multiple sources
+- `question`: the original question
 
 ### Ensures
 
-- answer: reasoned answer with explicit chain of reasoning and source citations
+- `answer`: reasoned answer with explicit chain of reasoning and source citations

--- a/skills/open-prose/examples/42-rlm-filter-recurse/screener.md
+++ b/skills/open-prose/examples/42-rlm-filter-recurse/screener.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- documents: collection to screen
-- question: what to look for
+- `documents`: collection to screen
+- `question`: what to look for
 
 ### Ensures
 
-- relevant: documents likely relevant to the question, erring toward inclusion
+- `relevant`: documents likely relevant to the question, erring toward inclusion

--- a/skills/open-prose/examples/43-rlm-pairwise/comparator.md
+++ b/skills/open-prose/examples/43-rlm-pairwise/comparator.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- pair: two items to compare
-- relation: the relationship to analyze
+- `pair`: two items to compare
+- `relation`: the relationship to analyze
 
 ### Ensures
 
-- comparison: the pair, identified relationship, strength rating, and supporting evidence
+- `comparison`: the pair, identified relationship, strength rating, and supporting evidence

--- a/skills/open-prose/examples/43-rlm-pairwise/index.md
+++ b/skills/open-prose/examples/43-rlm-pairwise/index.md
@@ -1,17 +1,21 @@
 ---
 name: rlm-pairwise
 kind: program
-services: [comparator, mapper]
 ---
+
+### Services
+
+- `comparator`
+- `mapper`
 
 ### Requires
 
-- items: items to compare pairwise
-- relation: the relationship to identify between pairs
+- `items`: items to compare pairwise
+- `relation`: the relationship to identify between pairs
 
 ### Ensures
 
-- map: a relationship map showing clusters, anomalies, and relationship strengths
+- `map`: a relationship map showing clusters, anomalies, and relationship strengths
 
 ### Strategies
 

--- a/skills/open-prose/examples/43-rlm-pairwise/mapper.md
+++ b/skills/open-prose/examples/43-rlm-pairwise/mapper.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- items: the original items
-- relationships: pairwise comparison results
+- `items`: the original items
+- `relationships`: pairwise comparison results
 
 ### Ensures
 
-- map: relationship map identifying clusters, central nodes, anomalies, and overall structure
+- `map`: relationship map identifying clusters, central nodes, anomalies, and overall structure

--- a/skills/open-prose/examples/44-run-endpoint-ux-test/file-observer.md
+++ b/skills/open-prose/examples/44-run-endpoint-ux-test/file-observer.md
@@ -1,13 +1,16 @@
 ---
 name: file-observer
 kind: service
-persist: true
 ---
+
+### Runtime
+
+- `persist`: true
 
 ### Requires
 
-- execution: environment ID and API details for filesystem polling
+- `execution`: environment ID and API details for filesystem polling
 
 ### Ensures
 
-- file-feedback: filesystem UX assessment covering directory clarity, file naming, state file readability, and what a file browser UI should highlight
+- `file-feedback`: filesystem UX assessment covering directory clarity, file naming, state file readability, and what a file browser UI should highlight

--- a/skills/open-prose/examples/44-run-endpoint-ux-test/index.md
+++ b/skills/open-prose/examples/44-run-endpoint-ux-test/index.md
@@ -1,15 +1,20 @@
 ---
 name: run-endpoint-ux-test
 kind: program
-services: [ws-observer, file-observer, synthesizer]
 ---
+
+### Services
+
+- `ws-observer`
+- `file-observer`
+- `synthesizer`
 
 ### Requires
 
-- test-program: the OpenProse program to execute for testing
-- api-url: API base URL (e.g., https://api.openprose.com)
-- auth-token: bearer token for authentication
+- `test-program`: the OpenProse program to execute for testing
+- `api-url`: API base URL (e.g., https://api.openprose.com)
+- `auth-token`: bearer token for authentication
 
 ### Ensures
 
-- action-items: prioritized UX assessment with correlated findings from both observers and concrete recommendations
+- `action-items`: prioritized UX assessment with correlated findings from both observers and concrete recommendations

--- a/skills/open-prose/examples/44-run-endpoint-ux-test/synthesizer.md
+++ b/skills/open-prose/examples/44-run-endpoint-ux-test/synthesizer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- ws-feedback: WebSocket observer findings
-- file-feedback: file observer findings
+- `ws-feedback`: WebSocket observer findings
+- `file-feedback`: file observer findings
 
 ### Ensures
 
-- action-items: unified UX assessment with correlated findings, prioritized action items (high/medium/low), evidence, and concrete recommendations
+- `action-items`: unified UX assessment with correlated findings, prioritized action items (high/medium/low), evidence, and concrete recommendations

--- a/skills/open-prose/examples/44-run-endpoint-ux-test/ws-observer.md
+++ b/skills/open-prose/examples/44-run-endpoint-ux-test/ws-observer.md
@@ -1,13 +1,16 @@
 ---
 name: ws-observer
 kind: service
-persist: true
 ---
+
+### Runtime
+
+- `persist`: true
 
 ### Requires
 
-- execution: WebSocket URL and connection details
+- `execution`: WebSocket URL and connection details
 
 ### Ensures
 
-- ws-feedback: UX assessment covering latency, status clarity, event quality, error messages, and overall flow from a user perspective
+- `ws-feedback`: UX assessment covering latency, status clarity, event quality, error messages, and overall flow from a user perspective

--- a/skills/open-prose/examples/45-plugin-release/analyzer.md
+++ b/skills/open-prose/examples/45-plugin-release/analyzer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- task: what to analyze (commits, impact, version)
+- `task`: what to analyze (commits, impact, version)
 
 ### Ensures
 
-- analysis: categorized changes (breaking, features, fixes) with version recommendation
+- `analysis`: categorized changes (breaking, features, fixes) with version recommendation

--- a/skills/open-prose/examples/45-plugin-release/executor.md
+++ b/skills/open-prose/examples/45-plugin-release/executor.md
@@ -5,15 +5,15 @@ kind: service
 
 ### Requires
 
-- task: what to execute (pre-flight check, version update, commit, tag, push, GitHub release)
+- `task`: what to execute (pre-flight check, version update, commit, tag, push, GitHub release)
 
 ### Ensures
 
-- result: execution status with details
+- `result`: execution status with details
 
 ### Errors
 
-- execution-failed: the operation failed
+- `execution-failed`: the operation failed
 
 ### Strategies
 

--- a/skills/open-prose/examples/45-plugin-release/index.md
+++ b/skills/open-prose/examples/45-plugin-release/index.md
@@ -1,21 +1,27 @@
 ---
 name: plugin-release
 kind: program
-services: [validator, analyzer, writer, executor]
 ---
+
+### Services
+
+- `validator`
+- `analyzer`
+- `writer`
+- `executor`
 
 ### Requires
 
-- release-type: "major", "minor", "patch", or empty for auto-detect (optional)
+- `release-type`: "major", "minor", "patch", or empty for auto-detect (optional)
 
 ### Ensures
 
-- release: completed release with version, tag, changelog, release notes, and verification status
+- `release`: completed release with version, tag, changelog, release notes, and verification status
 
 ### Errors
 
-- preflight-failed: pre-flight checks found issues that must be fixed before release
-- release-failed: release execution failed and was rolled back
+- `preflight-failed`: pre-flight checks found issues that must be fixed before release
+- `release-failed`: release execution failed and was rolled back
 
 ### Strategies
 

--- a/skills/open-prose/examples/45-plugin-release/validator.md
+++ b/skills/open-prose/examples/45-plugin-release/validator.md
@@ -1,15 +1,17 @@
 ---
 name: validator
 kind: service
-shape:
-  self: [validate syntax, check documentation completeness, verify installation]
-  prohibited: [modifying files, running destructive commands]
 ---
+
+### Shape
+
+- `self`: validate syntax, check documentation completeness, verify installation
+- `prohibited`: modifying files, running destructive commands
 
 ### Requires
 
-- task: what to validate
+- `task`: what to validate
 
 ### Ensures
 
-- validation: pass/fail with specific issues listed
+- `validation`: pass/fail with specific issues listed

--- a/skills/open-prose/examples/45-plugin-release/writer.md
+++ b/skills/open-prose/examples/45-plugin-release/writer.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- task: what to write (changelog, release notes, commit message)
-- version: the release version
-- impact: categorized change analysis
+- `task`: what to write (changelog, release notes, commit message)
+- `version`: the release version
+- `impact`: categorized change analysis
 
 ### Ensures
 
-- content: clear, concise release documentation appropriate to the format
+- `content`: clear, concise release documentation appropriate to the format

--- a/skills/open-prose/examples/46-workflow-crystallizer/author.md
+++ b/skills/open-prose/examples/46-workflow-crystallizer/author.md
@@ -5,12 +5,12 @@ kind: service
 
 ### Requires
 
-- scope: the chosen scope and placement
-- existing-programs: patterns to follow
+- `scope`: the chosen scope and placement
+- `existing-programs`: patterns to follow
 
 ### Ensures
 
-- program: a complete, self-reviewed .prose file following spec patterns and avoiding antipatterns
+- `program`: a complete, self-reviewed .prose file following spec patterns and avoiding antipatterns
 
 ### Strategies
 

--- a/skills/open-prose/examples/46-workflow-crystallizer/compiler.md
+++ b/skills/open-prose/examples/46-workflow-crystallizer/compiler.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- program: .prose file content to validate
+- `program`: .prose file content to validate
 
 ### Ensures
 
-- validation: SUCCESS or specific errors with line numbers
+- `validation`: SUCCESS or specific errors with line numbers

--- a/skills/open-prose/examples/46-workflow-crystallizer/index.md
+++ b/skills/open-prose/examples/46-workflow-crystallizer/index.md
@@ -1,17 +1,23 @@
 ---
 name: workflow-crystallizer
 kind: program
-services: [observer, scoper, author, compiler]
 ---
+
+### Services
+
+- `observer`
+- `scoper`
+- `author`
+- `compiler`
 
 ### Requires
 
-- thread: the conversation thread to analyze
-- hint: what aspect to focus on (optional)
+- `thread`: the conversation thread to analyze
+- `hint`: what aspect to focus on (optional)
 
 ### Ensures
 
-- crystallized: a validated .prose program extracted from the observed workflow pattern, written to the appropriate location
+- `crystallized`: a validated .prose program extracted from the observed workflow pattern, written to the appropriate location
 
 ### Strategies
 

--- a/skills/open-prose/examples/46-workflow-crystallizer/observer.md
+++ b/skills/open-prose/examples/46-workflow-crystallizer/observer.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- thread: conversation thread to analyze
-- hint: focus area (optional)
+- `thread`: conversation thread to analyze
+- `hint`: focus area (optional)
 
 ### Ensures
 
-- observation: identified workflow with discrete steps, decisions, parallelization opportunities, and artifacts created, with specific quotes from the thread
+- `observation`: identified workflow with discrete steps, decisions, parallelization opportunities, and artifacts created, with specific quotes from the thread

--- a/skills/open-prose/examples/46-workflow-crystallizer/scoper.md
+++ b/skills/open-prose/examples/46-workflow-crystallizer/scoper.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- observation: extracted workflow pattern
-- existing-programs: inventory of current .prose examples
+- `observation`: extracted workflow pattern
+- `existing-programs`: inventory of current .prose examples
 
 ### Ensures
 
-- scope-options: three scoping options (narrow, medium, broad) with inputs, agents, and phases
-- collision-check: overlap analysis with existing programs
-- placement: recommended file location and whether it is operational
+- `scope-options`: three scoping options (narrow, medium, broad) with inputs, agents, and phases
+- `collision-check`: overlap analysis with existing programs
+- `placement`: recommended file location and whether it is operational

--- a/skills/open-prose/examples/47-language-self-improvement/archaeologist.md
+++ b/skills/open-prose/examples/47-language-self-improvement/archaeologist.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- corpus: files to analyze
-- task: what to excavate
+- `corpus`: files to analyze
+- `task`: what to excavate
 
 ### Ensures
 
-- findings: patterns with frequency counts, representative examples, and classification as intentional idiom or compensating workaround
+- `findings`: patterns with frequency counts, representative examples, and classification as intentional idiom or compensating workaround

--- a/skills/open-prose/examples/47-language-self-improvement/architect.md
+++ b/skills/open-prose/examples/47-language-self-improvement/architect.md
@@ -1,15 +1,20 @@
 ---
 name: architect
 kind: service
-persist: true
 ---
+
+### Description
+
+Designs language features with principles: self-evidence, composability, minimalism, consistency. For each proposal, specifies syntax, semantics, and interaction with existing features.
+
+### Runtime
+
+- `persist`: true
 
 ### Requires
 
-- task: what to synthesize or propose
+- `task`: what to synthesize or propose
 
 ### Ensures
 
-- output: ranked improvement list or detailed proposals with syntax, semantics, and interactions
-
-Designs language features with principles: self-evidence, composability, minimalism, consistency. For each proposal, specifies syntax, semantics, and interaction with existing features.
+- `output`: ranked improvement list or detailed proposals with syntax, semantics, and interactions

--- a/skills/open-prose/examples/47-language-self-improvement/clinician.md
+++ b/skills/open-prose/examples/47-language-self-improvement/clinician.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- corpus: code files to analyze
-- conversations: user conversations (optional)
-- task: what pain points to diagnose
+- `corpus`: code files to analyze
+- `conversations`: user conversations (optional)
+- `task`: what pain points to diagnose
 
 ### Ensures
 
-- pain-points: recurring errors, confusing patterns, and gaps between intent and expression, each with a hypothesized language change that would help
+- `pain-points`: recurring errors, confusing patterns, and gaps between intent and expression, each with a hypothesized language change that would help

--- a/skills/open-prose/examples/47-language-self-improvement/guardian.md
+++ b/skills/open-prose/examples/47-language-self-improvement/guardian.md
@@ -5,13 +5,13 @@ kind: service
 
 ### Requires
 
-- proposals: language change proposals
-- spec-patches: specification additions
-- current-spec: current language spec
-- task: what to assess
+- `proposals`: language change proposals
+- `spec-patches`: specification additions
+- `current-spec`: current language spec
+- `task`: what to assess
 
 ### Ensures
 
-- assessment: breaking level (0-3), complexity cost, interaction risks, implementation effort for each proposal
-- aggregate-assessment: whether changes are coherent or represent feature creep
-- recommendation: PROCEED, REDUCE SCOPE, PHASE INCREMENTALLY, or HALT
+- `assessment`: breaking level (0-3), complexity cost, interaction risks, implementation effort for each proposal
+- `aggregate-assessment`: whether changes are coherent or represent feature creep
+- `recommendation`: PROCEED, REDUCE SCOPE, PHASE INCREMENTALLY, or HALT

--- a/skills/open-prose/examples/47-language-self-improvement/index.md
+++ b/skills/open-prose/examples/47-language-self-improvement/index.md
@@ -1,18 +1,26 @@
 ---
 name: language-self-improvement
 kind: program
-services: [archaeologist, clinician, architect, spec-writer, guardian, test-smith]
 ---
+
+### Services
+
+- `archaeologist`
+- `clinician`
+- `architect`
+- `spec-writer`
+- `guardian`
+- `test-smith`
 
 ### Requires
 
-- corpus-path: path to .prose files to analyze (default: examples/)
-- conversations: conversation threads where people struggled with the language (optional)
-- focus: specific area to focus on, e.g., "error handling", "parallelism" (optional)
+- `corpus-path`: path to .prose files to analyze (default: examples/)
+- `conversations`: conversation threads where people struggled with the language (optional)
+- `focus`: specific area to focus on, e.g., "error handling", "parallelism" (optional)
 
 ### Ensures
 
-- evolution: language improvement proposals with spec patches, test files, risk assessment, and migration guide
+- `evolution`: language improvement proposals with spec patches, test files, risk assessment, and migration guide
 
 ### Execution
 

--- a/skills/open-prose/examples/47-language-self-improvement/spec-writer.md
+++ b/skills/open-prose/examples/47-language-self-improvement/spec-writer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- task: what specification to write
+- `task`: what specification to write
 
 ### Ensures
 
-- output: precise language specifications following the OpenProse reference style with grammar rules, semantic descriptions, examples, and edge cases
+- `output`: precise language specifications following the OpenProse reference style with grammar rules, semantic descriptions, examples, and edge cases

--- a/skills/open-prose/examples/47-language-self-improvement/test-smith.md
+++ b/skills/open-prose/examples/47-language-self-improvement/test-smith.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- proposals: language feature proposals
-- task: what tests to create
+- `proposals`: language feature proposals
+- `task`: what tests to create
 
 ### Ensures
 
-- test-files: complete, runnable test programs covering happy path, edge cases, error conditions, and interaction with existing features
+- `test-files`: complete, runnable test programs covering happy path, edge cases, error conditions, and interaction with existing features

--- a/skills/open-prose/examples/48-habit-miner/author.md
+++ b/skills/open-prose/examples/48-habit-miner/author.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- pattern: a qualified workflow pattern with examples
+- `pattern`: a qualified workflow pattern with examples
 
 ### Ensures
 
-- program: a complete .prose program parameterizing what varies and hardcoding what is constant
+- `program`: a complete .prose program parameterizing what varies and hardcoding what is constant

--- a/skills/open-prose/examples/48-habit-miner/index.md
+++ b/skills/open-prose/examples/48-habit-miner/index.md
@@ -1,18 +1,26 @@
 ---
 name: habit-miner
 kind: program
-services: [scout, parser, miner, qualifier, author, organizer]
 ---
+
+### Services
+
+- `scout`
+- `parser`
+- `miner`
+- `qualifier`
+- `author`
+- `organizer`
 
 ### Requires
 
-- mode: "full" (analyze everything), "incremental" (new logs only), or "check" (inventory only)
-- min-frequency: minimum times a pattern must appear to qualify (default: 3)
-- focus: filter to specific area, e.g., "git", "testing" (optional)
+- `mode`: "full" (analyze everything), "incremental" (new logs only), or "check" (inventory only)
+- `min-frequency`: minimum times a pattern must appear to qualify (default: 3)
+- `focus`: filter to specific area, e.g., "git", "testing" (optional)
 
 ### Ensures
 
-- result: generated .prose programs for mature workflow patterns, organized by domain
+- `result`: generated .prose programs for mature workflow patterns, organized by domain
 - if mode is check: inventory of available log sources
 - if no patterns are ready: status report with maturity update
 

--- a/skills/open-prose/examples/48-habit-miner/miner.md
+++ b/skills/open-prose/examples/48-habit-miner/miner.md
@@ -1,16 +1,21 @@
 ---
 name: miner
 kind: service
-persist: true
 ---
+
+### Description
+
+Remembers patterns across runs. Each pattern has name, maturity (emerging/established/proven), examples, last_seen, and trend (growing/stable/declining).
+
+### Runtime
+
+- `persist`: true
 
 ### Requires
 
-- sessions: parsed and normalized session data
-- focus: area to focus on (optional)
+- `sessions`: parsed and normalized session data
+- `focus`: area to focus on (optional)
 
 ### Ensures
 
-- pattern-update: patterns that matured, new emerging patterns, declining patterns, and current state of all tracked patterns
-
-Remembers patterns across runs. Each pattern has name, maturity (emerging/established/proven), examples, last_seen, and trend (growing/stable/declining).
+- `pattern-update`: patterns that matured, new emerging patterns, declining patterns, and current state of all tracked patterns

--- a/skills/open-prose/examples/48-habit-miner/organizer.md
+++ b/skills/open-prose/examples/48-habit-miner/organizer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- programs: generated .prose programs
+- `programs`: generated .prose programs
 
 ### Ensures
 
-- organization: programs grouped by domain with directory structure, index README, shared pattern notes, and composition suggestions
+- `organization`: programs grouped by domain with directory structure, index README, shared pattern notes, and composition suggestions

--- a/skills/open-prose/examples/48-habit-miner/parser.md
+++ b/skills/open-prose/examples/48-habit-miner/parser.md
@@ -3,12 +3,14 @@ name: parser
 kind: service
 ---
 
+### Description
+
+Handles formats: JSONL (Claude Code), SQLite, JSON arrays, and Markdown conversation exports. Normalizes all to a common schema.
+
 ### Requires
 
-- sources: log file paths to parse
+- `sources`: log file paths to parse
 
 ### Ensures
 
-- sessions: normalized conversation data with session ID, timestamps, user requests, assistant actions, and outcomes
-
-Handles formats: JSONL (Claude Code), SQLite, JSON arrays, and Markdown conversation exports. Normalizes all to a common schema.
+- `sessions`: normalized conversation data with session ID, timestamps, user requests, assistant actions, and outcomes

--- a/skills/open-prose/examples/48-habit-miner/qualifier.md
+++ b/skills/open-prose/examples/48-habit-miner/qualifier.md
@@ -3,13 +3,15 @@ name: qualifier
 kind: service
 ---
 
+### Description
+
+Rejects patterns that are still emerging, too simple, too variable, or declining.
+
 ### Requires
 
-- pattern-update: miner's pattern analysis
-- min-frequency: minimum threshold
+- `pattern-update`: miner's pattern analysis
+- `min-frequency`: minimum threshold
 
 ### Ensures
 
-- qualified: ranked list of patterns ready for automation with reasoning
-
-Rejects patterns that are still emerging, too simple, too variable, or declining.
+- `qualified`: ranked list of patterns ready for automation with reasoning

--- a/skills/open-prose/examples/48-habit-miner/scout.md
+++ b/skills/open-prose/examples/48-habit-miner/scout.md
@@ -5,10 +5,10 @@ kind: service
 
 ### Requires
 
-- mode: scan mode
+- `mode`: scan mode
 
 ### Ensures
 
-- inventory: structured list of AI assistant log locations with path, format, size, session count, and date range
+- `inventory`: structured list of AI assistant log locations with path, format, size, session count, and date range
 
 Checks: ~/.claude/, ~/.opencode/, ~/.cursor/, ~/.continue/, ~/.aider/, ~/.copilot/, ~/.codeium/, ~/.tabnine/

--- a/skills/open-prose/examples/49-prose-run-retrospective/analyst.md
+++ b/skills/open-prose/examples/49-prose-run-retrospective/analyst.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- task: what to analyze, classify, or draft
+- `task`: what to analyze, classify, or draft
 
 ### Ensures
 
-- output: run classification (success/transient-error/architectural-issue/antipattern-instance), improvement opportunities, or pattern/antipattern entries
+- `output`: run classification (success/transient-error/architectural-issue/antipattern-instance), improvement opportunities, or pattern/antipattern entries

--- a/skills/open-prose/examples/49-prose-run-retrospective/extractor.md
+++ b/skills/open-prose/examples/49-prose-run-retrospective/extractor.md
@@ -3,12 +3,14 @@ name: extractor
 kind: service
 ---
 
+### Description
+
+Distinguishes situational factors from generalizable principles. Proposes only broadly applicable patterns supported by evidence.
+
 ### Requires
 
-- task: what patterns to extract or what .prose to improve
+- `task`: what patterns to extract or what .prose to improve
 
 ### Ensures
 
-- output: generalizable patterns (conservative, avoiding over-generalization) or improved .prose file preserving purpose and inputs
-
-Distinguishes situational factors from generalizable principles. Proposes only broadly applicable patterns supported by evidence.
+- `output`: generalizable patterns (conservative, avoiding over-generalization) or improved .prose file preserving purpose and inputs

--- a/skills/open-prose/examples/49-prose-run-retrospective/index.md
+++ b/skills/open-prose/examples/49-prose-run-retrospective/index.md
@@ -1,15 +1,19 @@
 ---
 name: prose-run-retrospective
 kind: program
-services: [analyst, extractor]
 ---
+
+### Services
+
+- `analyst`
+- `extractor`
 
 ### Requires
 
-- run-id: path to the completed run directory
-- prose-path: path to the .prose file that was executed
+- `run-id`: path to the completed run directory
+- `prose-path`: path to the .prose file that was executed
 
 ### Ensures
 
-- result: classification, improvements, improved .prose file, and any new patterns/antipatterns
+- `result`: classification, improvements, improved .prose file, and any new patterns/antipatterns
 - if transient error: recommendation to re-run with no structural changes needed

--- a/skills/open-prose/examples/50-interactive-tutor.md
+++ b/skills/open-prose/examples/50-interactive-tutor.md
@@ -3,17 +3,19 @@ name: interactive-tutor
 kind: service
 ---
 
+### Description
+
 Demonstrates how Contract Markdown handles interactive input. `### Requires` collects inputs at program start. Mid-program prompts should use `gate()` when available.
 
 ### Requires
 
-- name: the learner's name
-- topic: what they want to learn about
-- level: experience level (beginner, intermediate, advanced)
+- `name`: the learner's name
+- `topic`: what they want to learn about
+- `level`: experience level (beginner, intermediate, advanced)
 
 ### Ensures
 
-- explanation: a personalized, engaging explanation of the topic appropriate for the learner's level, addressed by name
+- `explanation`: a personalized, engaging explanation of the topic appropriate for the learner's level, addressed by name
 - if learner wants deeper dive: expanded explanation with advanced details
 - if learner wants practice: 3 practice exercises at the appropriate level
 - if learner is satisfied: summary of what was learned

--- a/skills/open-prose/examples/composites-demo/critic.md
+++ b/skills/open-prose/examples/composites-demo/critic.md
@@ -5,11 +5,11 @@ kind: service
 
 ### Requires
 
-- output: the worker's output to evaluate
-- quality-bar: what constitutes acceptable quality
+- `output`: the worker's output to evaluate
+- `quality-bar`: what constitutes acceptable quality
 
 ### Ensures
 
-- score: numeric quality score 0-100
-- feedback: specific issues to address if score is below threshold
-- accepted: whether the output meets the quality bar
+- `score`: numeric quality score 0-100
+- `feedback`: specific issues to address if score is below threshold
+- `accepted`: whether the output meets the quality bar

--- a/skills/open-prose/examples/composites-demo/index.md
+++ b/skills/open-prose/examples/composites-demo/index.md
@@ -1,25 +1,31 @@
 ---
 name: composites-demo
 kind: program
-services:
-  - name: reviewed-result
-    compose: std/composites/worker-critic
-    with:
-      worker: worker
-      critic: critic
-      max_rounds: 4
 ---
+
+### Services
+
+```yaml
+- name: reviewed-result
+  compose: std/composites/worker-critic
+  with:
+    worker: worker
+    critic: critic
+    max_rounds: 4
+```
+
+### Description
 
 Demonstrates explicit worker-critic composition. The worker produces output, the critic evaluates it, and the composed unit repeats until the quality bar is met or the iteration budget is exhausted.
 
 ### Requires
 
-- task: what to produce
-- quality-bar: what "good enough" means
+- `task`: what to produce
+- `quality-bar`: what "good enough" means
 
 ### Ensures
 
-- result: output that meets the quality bar, refined through worker-critic iteration
+- `result`: output that meets the quality bar, refined through worker-critic iteration
 
 ### Strategies
 

--- a/skills/open-prose/examples/composites-demo/worker.md
+++ b/skills/open-prose/examples/composites-demo/worker.md
@@ -5,9 +5,9 @@ kind: service
 
 ### Requires
 
-- task: what to produce or revise
-- feedback: critic feedback to address (optional, absent on first iteration)
+- `task`: what to produce or revise
+- `feedback`: critic feedback to address (optional, absent on first iteration)
 
 ### Ensures
 
-- output: completed work product addressing the task and any feedback
+- `output`: completed work product addressing the task and any feedback

--- a/skills/open-prose/examples/multi-service-single-file.md
+++ b/skills/open-prose/examples/multi-service-single-file.md
@@ -1,46 +1,53 @@
 ---
 name: content-pipeline-compact
 kind: program
-services: [review, polish, fact-check]
 ---
+
+### Services
+
+- `review`
+- `polish`
+- `fact-check`
+
+### Description
 
 Demonstrates multiple services in a single file using `##` heading delimiters. Each `##` section defines a separate service with its own contract.
 
 ### Requires
 
-- draft: a piece of writing to review and polish
+- `draft`: a piece of writing to review and polish
 
 ### Ensures
 
-- final: polished text incorporating editorial feedback with all facts verified
+- `final`: polished text incorporating editorial feedback with all facts verified
 
 ## review
 
 ### Requires
 
-- draft: a piece of writing to review
+- `draft`: a piece of writing to review
 
 ### Ensures
 
-- feedback: specific, actionable editorial notes
+- `feedback`: specific, actionable editorial notes
 
 ## polish
 
 ### Requires
 
-- draft: the original text
-- feedback: editorial notes to incorporate
+- `draft`: the original text
+- `feedback`: editorial notes to incorporate
 
 ### Ensures
 
-- final: polished text incorporating all feedback
+- `final`: polished text incorporating all feedback
 
 ## fact-check
 
 ### Requires
 
-- text: content containing factual claims
+- `text`: content containing factual claims
 
 ### Ensures
 
-- claims: each factual claim with verification status (verified, unverified, disputed)
+- `claims`: each factual claim with verification status (verified, unverified, disputed)

--- a/skills/open-prose/examples/registry-import/index.md
+++ b/skills/open-prose/examples/registry-import/index.md
@@ -1,15 +1,21 @@
 ---
 name: registry-import-demo
 kind: program
-services: [local-analyzer, openprose/std/evals/inspector]
 ---
+
+### Services
+
+- `local-analyzer`
+- `openprose/std/evals/inspector`
+
+### Description
 
 Demonstrates importing a service from the external standard library. The `openprose/std/evals/inspector` service is installed and pinned by `prose install`. Local and dependency services are wired together by Forme using the same contract-matching algorithm.
 
 ### Requires
 
-- run-path: path to a completed .prose run to analyze
+- `run-path`: path to a completed .prose run to analyze
 
 ### Ensures
 
-- analysis: local analysis combined with registry inspector findings
+- `analysis`: local analysis combined with registry inspector findings

--- a/skills/open-prose/examples/registry-import/local-analyzer.md
+++ b/skills/open-prose/examples/registry-import/local-analyzer.md
@@ -5,8 +5,8 @@ kind: service
 
 ### Requires
 
-- run-path: path to the run to analyze
+- `run-path`: path to the run to analyze
 
 ### Ensures
 
-- local-findings: project-specific analysis of the run using local codebase context
+- `local-findings`: project-specific analysis of the run using local codebase context

--- a/skills/open-prose/examples/test-demo.md
+++ b/skills/open-prose/examples/test-demo.md
@@ -4,20 +4,22 @@ kind: test
 subject: 02-research-and-summarize
 ---
 
+### Description
+
 Demonstrates `kind: test` with fixtures and assertions. Tests run the subject program with fixed inputs and evaluate outputs against expectations.
 
 ### Fixtures
 
-- topic: "recent developments in quantum error correction"
+- `topic`: "recent developments in quantum error correction"
 
 ### Expects
 
-- summary: contains at least 5 bullet points
-- summary: mentions specific papers, companies, or research groups
-- summary: includes practical implications
-- summary: is under 500 words
+- `summary`: contains at least 5 bullet points
+- `summary`: mentions specific papers, companies, or research groups
+- `summary`: includes practical implications
+- `summary`: is under 500 words
 
 ### Expects Not
 
-- __error.md exists
-- summary: contains fabricated citations
+- `__error.md` exists
+- `summary`: contains fabricated citations

--- a/skills/open-prose/examples/wiring-declaration.md
+++ b/skills/open-prose/examples/wiring-declaration.md
@@ -1,18 +1,25 @@
 ---
 name: wiring-declaration-demo
 kind: program
-services: [researcher, critic, synthesizer]
 ---
+
+### Services
+
+- `researcher`
+- `critic`
+- `synthesizer`
+
+### Description
 
 Demonstrates Level 2 explicit wiring. When Forme's auto-wiring would be ambiguous, the author can pin the wiring with a `### Wiring` section.
 
 ### Requires
 
-- question: what the user wants answered
+- `question`: what the user wants answered
 
 ### Ensures
 
-- report: a critically evaluated research report
+- `report`: a critically evaluated research report
 
 ### Wiring
 

--- a/skills/open-prose/forme.md
+++ b/skills/open-prose/forme.md
@@ -72,14 +72,20 @@ When invoked with a program entry point, follow this process exactly.
 
 ### Step 1: Read the Entry Point
 
-The entry point is the file with `kind: program` in its YAML frontmatter:
+The entry point is the file with `kind: program` in its YAML frontmatter.
+The program's service graph is declared with `### Services`:
 
-```yaml
+```markdown
 ---
 name: deep-research
 kind: program
-services: [researcher, critic, synthesizer]
 ---
+
+### Services
+
+- `researcher`
+- `critic`
+- `synthesizer`
 ```
 
 The program contract is written as `###` sections:
@@ -96,13 +102,19 @@ The program contract is written as `###` sections:
 
 Extract:
 - `name` — the program name
-- `services` — the list of component names to scan
+- `### Services` — the list of component names or structured service declarations to scan
 - `### Requires` — the program's inputs (what the caller provides)
 - `### Ensures` — the program's outputs (what gets returned)
 
+Parse `### Services` in two forms:
+
+- Markdown list items name services; strip optional backticks from the item text.
+- Fenced YAML lists declare structured entries with fields such as `name`,
+  `compose`, and `with`.
+
 ### Step 2: Resolve Component Files
 
-For each name in `services`, locate the corresponding `.md` file:
+For each entry in `### Services`, locate the corresponding `.md` file:
 
 **Resolution order:**
 1. Same directory as the entry point: `./researcher.md`
@@ -120,9 +132,9 @@ When a service declaration includes `compose:` (e.g., `compose: std/composites/w
 
 **Recursive resolution for `kind: program` services:**
 
-When a resolved component has `kind: program` (with its own `services` list) rather than `kind: service`, Forme recursively invokes the wiring algorithm on that sub-program. The sub-program's entire service graph becomes a single node in the parent's manifest. The sub-program's `### Ensures` become the node's outputs. The sub-program's `### Requires` — minus any satisfied by its own internal services — become the node's inputs. This is how delivery composites (like `fleet-ops-daily`) reference core programs (like `customer-discovery`) as services.
+When a resolved component has `kind: program` (with its own `### Services` section) rather than `kind: service`, Forme recursively invokes the wiring algorithm on that sub-program. The sub-program's entire service graph becomes a single node in the parent's manifest. The sub-program's `### Ensures` become the node's outputs. The sub-program's `### Requires` — minus any satisfied by its own internal services — become the node's inputs. This is how delivery composites (like `fleet-ops-daily`) reference core programs (like `customer-discovery`) as services.
 
-**Composite slot resolution:** Services named in `with:` blocks of `compose:` declarations are resolved using the same rules as top-level services, even if not listed separately in the `services:` array. This means a program can declare only the composed unit in `services:` — the slot-filling services will be resolved from the `with:` entries automatically.
+**Composite slot resolution:** Services named in `with:` blocks of `compose:` declarations are resolved using the same rules as top-level services, even if not listed separately in `### Services`. This means a program can declare only the composed unit in `### Services` — the slot-filling services will be resolved from the `with:` entries automatically.
 
 If a component cannot be resolved, emit an error:
 
@@ -139,8 +151,8 @@ If a component cannot be resolved, emit an error:
 
 For each resolved component, extract from its `.md` file:
 
-- **Frontmatter:** `name`, `kind`, `shape` (if present)
-- **Contract sections:** `### Requires`, `### Ensures`, `### Errors`, `### Invariants`, `### Strategies`, `### Environment`
+- **Frontmatter:** `name`, `kind`, plus compatibility fields if present
+- **Sections:** `### Services`, `### Requires`, `### Ensures`, `### Errors`, `### Invariants`, `### Strategies`, `### Environment`, `### Runtime`, `### Shape`
 
 Lowercase colon blocks (`requires:`, `ensures:`, etc.) are compatibility syntax
 and must still be accepted. When both the `###` section and lowercase block
@@ -156,10 +168,9 @@ a warning.
 | `###` | Section inside the current component |
 
 Inline components may include a YAML frontmatter block immediately after the
-`##` heading. The heading supplies the component name; if the block also
-declares `name`, it must match the heading. `kind` defaults to `service`, and
-component-local fields such as `shape`, `persist`, `model`, and `delegates`
-apply only to that inline component.
+`##` heading for compatibility. The heading supplies the component name; if the
+block also declares `name`, it must match the heading. `kind` defaults to
+`service`. Canonical components put behavior in `### Runtime` and `### Shape`.
 
 When a resolved file has `kind: composite`, extract instead:
 - `### Slots` — slot definitions (`name`, `primary` flag, contract with Requires/Ensures)
@@ -173,12 +184,14 @@ A component has this structure:
 ---
 name: researcher
 kind: service
-shape:
-  self: [evaluate sources, score confidence]
-  delegates:
-    summarizer: [compression]
-  prohibited: [direct web scraping]
 ---
+
+### Shape
+
+- `self`: evaluate sources, score confidence
+- `delegates`:
+  - `summarizer`: compression
+- `prohibited`: direct web scraping
 
 ### Requires
 
@@ -311,10 +324,10 @@ Before producing the manifest, check:
 | Unused ensures | `[Warning] researcher.ensures.sources not consumed by any downstream component` |
 | Semantic match (not exact) | `[Warning] Wired caller.question → researcher.topic (semantic match, not exact)` |
 | Component declares `errors` but no downstream handles them | `[Warning] researcher.errors.no-results has no recovery path` |
-| Shape declares delegate not in services list | `[Warning] researcher.shape.delegates.summarizer not in program services` |
+| Shape declares delegate not in `### Services` | `[Warning] researcher.shape.delegates.summarizer not declared in program services` |
 | `run`-typed input on a service (not the program) | `[Warning] analyzer.requires.subject uses run type — run inputs are typically program-level, not service-level` |
 | Config parameter type mismatch | `[Warning] Composite worker-critic config 'max_rounds' expects integer, got string` |
-| Declared service never referenced | `[Warning] Service '{name}' is declared in services: but never called in ### Execution and no component requires its outputs` |
+| Declared service never referenced | `[Warning] Service '{name}' is declared in ### Services but never called in ### Execution and no component requires its outputs` |
 
 ### Step 7: Copy Source Files
 
@@ -493,7 +506,9 @@ The manifest you produce depends on what the author has written. Authors choose 
 
 ### Level 1: Contracts Only (Default)
 
-The author writes only `### Requires`, `### Ensures`, and optionally `shape` frontmatter on each component. No wiring declaration, no execution block. You auto-wire everything.
+The author writes only `### Requires`, `### Ensures`, and optionally
+`### Shape` on each component. No wiring declaration, no execution block. You
+auto-wire everything.
 
 **Your job:** Full auto-wiring. Build the complete dependency graph from contract matching. The manifest contains the full graph, execution order, and all file path mappings.
 
@@ -549,18 +564,19 @@ return report
 
 ## Handling Components with Shapes
 
-When a component has a `shape` in its frontmatter, treat it as a **binding constraint** — not a hint, not a suggestion. Shapes MUST be honored during wiring.
+When a component has a `### Shape` section, treat it as a **binding constraint** — not a hint, not a suggestion. Compatibility `shape:` frontmatter has the same meaning.
 
-```yaml
-shape:
-  self: [evaluate progress, select strategy]
-  delegates:
-    researcher: [source discovery, claim extraction]
-    critic: [quality evaluation]
-  prohibited: [direct web search]
+```markdown
+### Shape
+
+- `self`: evaluate progress, select strategy
+- `delegates`:
+  - `researcher`: source discovery, claim extraction
+  - `critic`: quality evaluation
+- `prohibited`: direct web search
 ```
 
-**`delegates`** has both wiring-time and runtime meaning. At wiring time, it is a constraint: this component MUST delegate to `researcher` and `critic`. If these are in the `services` list, wire them as dependencies of this component. If a declared delegate is not in the `services` list, emit a warning — the author likely forgot to include it. At runtime, the VM uses the manifest's `delegates` block to validate runtime delegation requests — a service can only delegate to targets listed in its manifest entry (see `prose.md`, Runtime Delegation).
+**`delegates`** has both wiring-time and runtime meaning. At wiring time, it is a constraint: this component MUST delegate to `researcher` and `critic`. If these are in `### Services`, wire them as dependencies of this component. If a declared delegate is not in `### Services`, emit a warning — the author likely forgot to include it. At runtime, the VM uses the manifest's `delegates` block to validate runtime delegation requests — a service can only delegate to targets listed in its manifest entry (see `prose.md`, Runtime Delegation).
 
 **`prohibited`** is a hard constraint. Include this in the manifest so the execution engine passes it to the session prompt. The subagent must not perform any prohibited action.
 
@@ -576,39 +592,44 @@ A single `.md` file can contain multiple services delimited by `##` headings:
 ---
 name: content-pipeline
 kind: program
-services: [review, polish, fact-check]
 ---
+
+### Services
+
+- `review`
+- `polish`
+- `fact-check`
 
 ## review
 
 ### Requires
 
-- draft: a piece of writing to review
+- `draft`: a piece of writing to review
 
 ### Ensures
 
-- feedback: specific, actionable editorial notes
+- `feedback`: specific, actionable editorial notes
 
 ## polish
 
 ### Requires
 
-- draft: the original text
-- feedback: editorial notes to incorporate
+- `draft`: the original text
+- `feedback`: editorial notes to incorporate
 
 ### Ensures
 
-- final: polished text incorporating all feedback
+- `final`: polished text incorporating all feedback
 
 ## fact-check
 
 ### Requires
 
-- text: content containing factual claims
+- `text`: content containing factual claims
 
 ### Ensures
 
-- claims: each factual claim with verification status
+- `claims`: each factual claim with verification status
 ```
 
 When you encounter a multi-service file:
@@ -630,29 +651,33 @@ Composites are parameterized multi-agent topologies — they define how agents i
 
 **Program entry point:**
 
-```yaml
+````markdown
 ---
 name: radar-report
 kind: program
-services:
-  - name: quality-checked-output
-    compose: std/composites/worker-critic
-    with:
-      worker: radar-compiler
-      critic: quality-reviewer
-      max_rounds: 3
-  - radar-compiler
-  - quality-reviewer
 ---
+
+### Services
+
+```yaml
+- name: quality-checked-output
+  compose: std/composites/worker-critic
+  with:
+    worker: radar-compiler
+    critic: quality-reviewer
+    max_rounds: 3
+- radar-compiler
+- quality-reviewer
+```
 
 ### Requires
 
-- brief: the radar compilation task
+- `brief`: the radar compilation task
 
 ### Ensures
 
-- report: a quality-reviewed radar report
-```
+- `report`: a quality-reviewed radar report
+````
 
 **Expansion steps:**
 
@@ -751,9 +776,10 @@ If the entry point file has no `kind: program` in its frontmatter, treat it as a
 - No wiring needed — just validate the contract and produce a minimal manifest
 - The execution engine spawns one session for this component
 
-### Empty `services` list
+### Empty `### Services`
 
-If `services: []` or `services` is absent:
+If `### Services` is empty or absent, and there is no compatibility
+`services:` frontmatter:
 
 - Same as above — the program file is the sole component
 - Produce a minimal manifest
@@ -806,12 +832,12 @@ The test manifest's additional section:
 
 ### Expects
 
-- summary: mentions authentication or auth handling
-- summary: is under 200 words
+- `summary`: mentions authentication or auth handling
+- `summary`: is under 200 words
 
 ### Expects Not
 
-- __error.md exists
+- `__error.md` exists
 ```
 
 The Prose VM handles execution and assertion evaluation — see `prose.md`, Executing Tests.
@@ -827,7 +853,7 @@ prose run ./research-program.md
 ```
 
 The runtime:
-1. Detects `kind: program` with `services` → triggers Forme (Phase 1)
+1. Detects `kind: program` with `### Services` or compatibility `services:` frontmatter -> triggers Forme (Phase 1)
 2. Loads this document (`forme.md`) into the agent's context
 3. The agent performs the wiring algorithm
 4. The agent writes `manifest.md` and copies source files

--- a/skills/open-prose/guidance/patterns.md
+++ b/skills/open-prose/guidance/patterns.md
@@ -130,7 +130,7 @@ for each article in articles:
 ```markdown
 ### Ensures
 
-- articles: collected articles from the feed
+- `articles`: collected articles from the feed
 - each article has: a summary, a relevance score (0-1), and key claims extracted
 ```
 

--- a/skills/open-prose/guidance/system-prompt.md
+++ b/skills/open-prose/guidance/system-prompt.md
@@ -26,9 +26,9 @@ You are not merely describing a virtual machine. You are the OpenProse VM:
 
 OpenProse has two authoring surfaces:
 
-- **Contract Markdown** (`.md`): YAML frontmatter plus `### Requires`,
-  `### Ensures`, and related contract sections. Load `forme.md` for multi-service
-  wiring, then `prose.md` for execution.
+- **Contract Markdown** (`.md`): small identity frontmatter plus `### Services`,
+  `### Requires`, `### Ensures`, and related sections. Load `forme.md` for
+  multi-service wiring, then `prose.md` for execution.
 - **ProseScript** (`.prose` and `### Execution`): imperative choreography with
   `session`, `call`, `let`, `parallel`, `loop`, `try/catch`, `choice`, `block`,
   and `agent`.
@@ -62,7 +62,7 @@ workspace for these specification files.
 When executing:
 
 - Load `contract-markdown.md` for `.md` programs.
-- Load `forme.md` only when wiring is needed: `kind: program` with `services`,
+- Load `forme.md` only when wiring is needed: `kind: program` with `### Services`,
   multi-service files, composites, or explicit wiring.
 - Load `prose.md` for execution.
 - Load `prosescript.md` for `.prose` files or `### Execution` blocks.

--- a/skills/open-prose/help.md
+++ b/skills/open-prose/help.md
@@ -105,7 +105,7 @@ We started with YAML. The problem: loops, conditionals, and variable declaration
 
 ### How do dependencies work?
 
-OpenProse uses a git-native dependency model -- GitHub is the registry. A program can reference dependencies with `use "owner/repo/path"`, dependency-like entries in `services:`, or `compose:` paths. Run `prose install` to clone dependencies into `.deps/` and pin their versions in `prose.lock`. The lockfile is committed to git; `.deps/` is gitignored (it's a cache, reproducible from the lockfile). `std/` is shorthand for `openprose/std/` -- the standard library. At runtime, dependencies are read from disk only -- no network calls. If deps are missing, `prose run` errors and tells you to run `prose install`.
+OpenProse uses a git-native dependency model -- GitHub is the registry. A program can reference dependencies with `use "owner/repo/path"`, dependency-like entries in `### Services`, or `compose:` paths. Run `prose install` to clone dependencies into `.deps/` and pin their versions in `prose.lock`. The lockfile is committed to git; `.deps/` is gitignored (it's a cache, reproducible from the lockfile). `std/` is shorthand for `openprose/std/` -- the standard library. At runtime, dependencies are read from disk only -- no network calls. If deps are missing, `prose run` errors and tells you to run `prose install`.
 
 ### Why not LangChain/CrewAI/AutoGen?
 
@@ -117,25 +117,31 @@ Those are orchestration libraries -- they coordinate agents from outside. OpenPr
 
 ### Contract Markdown (`.md` files)
 
-Programs are `.md` files with YAML frontmatter and contract sections. The Forme Container reads contracts, auto-wires dependencies, and the Prose VM executes.
+Programs are `.md` files with tiny YAML identity frontmatter and readable `###` sections. The Forme Container reads contracts, auto-wires dependencies, and the Prose VM executes.
 
-**Frontmatter:**
+**Identity frontmatter:**
 
 ```yaml
 ---
 name: my-service
 kind: service          # service | program | test
-shape:                 # optional behavioral constraints
-  self: [evaluate, decide]
-  delegates:
-    helper: [research]
-  prohibited: [direct web scraping]
 ---
 ```
 
-**Contract sections:**
+**Sections:**
 
 ```markdown
+### Runtime
+
+- `persist`: project
+
+### Shape
+
+- `self`: evaluate, decide
+- `delegates`:
+  - `helper`: research
+- `prohibited`: direct web scraping
+
 ### Requires
 
 - `topic`: a research question to investigate
@@ -143,7 +149,7 @@ shape:                 # optional behavioral constraints
 ### Ensures
 
 - `findings`: sourced claims from 3+ distinct sources
-- each finding: includes confidence score 0-1
+- each finding includes: confidence score 0-1
 
 ### Errors
 
@@ -164,8 +170,13 @@ shape:                 # optional behavioral constraints
 ---
 name: deep-research
 kind: program
-services: [researcher, critic, synthesizer]
 ---
+
+### Services
+
+- `researcher`
+- `critic`
+- `synthesizer`
 
 ### Requires
 

--- a/skills/open-prose/primitives/session.md
+++ b/skills/open-prose/primitives/session.md
@@ -34,23 +34,25 @@ Your service definition is a Markdown file with a contract. It tells you:
 ---
 name: researcher
 kind: service
-shape:
-  self: [evaluate sources, score confidence]
-  prohibited: [direct web scraping]
 ---
+
+### Shape
+
+- `self`: evaluate sources, score confidence
+- `prohibited`: direct web scraping
 
 ### Requires
 
-- topic: a research question to investigate
+- `topic`: a research question to investigate
 
 ### Ensures
 
-- findings: sourced claims from 3+ distinct sources, each with confidence 0-1
-- sources: all URLs consulted with relevance ratings
+- `findings`: sourced claims from 3+ distinct sources, each with confidence 0-1
+- `sources`: all URLs consulted with relevance ratings
 
 ### Errors
 
-- no-results: no relevant sources found for this topic
+- `no-results`: no relevant sources found for this topic
 
 ### Strategies
 
@@ -72,7 +74,7 @@ Read these files to get your input data. For large inputs, read selectively—fo
 
 ### 1.3 Shape Constraints
 
-If your service has a `shape` in its frontmatter:
+If your service has a `### Shape` section:
 
 | Field | Meaning |
 |-------|---------|
@@ -84,7 +86,7 @@ Respect these boundaries. If `prohibited` says no direct web scraping, don't scr
 
 ### 1.4 Persistent Agent Memory
 
-If you are a **persistent agent** (your service has `persist:` in frontmatter), you'll receive a memory file path:
+If you are a **persistent agent** (your service has `persist` in `### Runtime`), you'll receive a memory file path:
 
 ```
 Your memory is at:

--- a/skills/open-prose/prose.md
+++ b/skills/open-prose/prose.md
@@ -67,7 +67,7 @@ A Prose program runs in two phases:
 
 You are Phase 2. The manifest tells you what to run and in what order. You execute it.
 
-For **single-component programs** (no `services` list in frontmatter), Phase 1 is skipped. The `.md` file is the entire program—you spawn one session and return its output.
+For **single-component programs** (no `### Services` section), Phase 1 is skipped. The `.md` file is the entire program—you spawn one session and return its output.
 
 ### Component Kinds
 
@@ -432,7 +432,7 @@ Look at the program entry point's `### Ensures` for conditional clauses:
 ```markdown
 ### Ensures
 
-- report: a critically evaluated research report
+- `report`: a critically evaluated research report
 - if research is unavailable: partial report with explanation
 ```
 
@@ -480,7 +480,7 @@ Task({
   description: "OpenProse service: {service-name}",
   prompt: "{the prompt constructed in Step 4b}",
   subagent_type: "general-purpose",
-  model: "{model from service frontmatter, if specified}"
+  model: "{model from service ### Runtime, if specified}"
 })
 ```
 
@@ -637,23 +637,26 @@ This is the "return" in Prose. When a service completes:
 
 ## Persistent Agents
 
-Services can be persistent agents that maintain memory across invocations. This is declared in the service's frontmatter:
+Services can be persistent agents that maintain memory across invocations. This is declared in `### Runtime`:
 
-```yaml
+```markdown
 ---
 name: captain
 kind: service
-persist: true
 ---
+
+### Runtime
+
+- `persist`: true
 ```
 
 ### Persistence Scoping
 
 | Scope               | Declaration        | Path                              | Lifetime                 |
 | ------------------- | ------------------ | --------------------------------- | ------------------------ |
-| Execution (default) | `persist: true`    | `.prose/runs/{id}/agents/{name}/` | Dies with run            |
-| Project             | `persist: project` | `.prose/agents/{name}/`           | Survives runs in project |
-| User                | `persist: user`    | `~/.prose/agents/{name}/`         | Survives across projects |
+| Execution (default) | `### Runtime` with `persist: true`    | `.prose/runs/{id}/agents/{name}/` | Dies with run            |
+| Project             | `### Runtime` with `persist: project` | `.prose/agents/{name}/`           | Survives runs in project |
+| User                | `### Runtime` with `persist: user`    | `~/.prose/agents/{name}/`         | Survives across projects |
 
 ### Invocation
 
@@ -834,7 +837,7 @@ When an `### Ensures` clause begins with `each`, it expresses a collection postc
 ```markdown
 ### Ensures
 
-- articles: collected articles from the feed
+- `articles`: collected articles from the feed
 - each article has: a summary, a relevance score (0-1), and key claims extracted
 ```
 

--- a/skills/open-prose/prosescript.md
+++ b/skills/open-prose/prosescript.md
@@ -262,7 +262,7 @@ let review = resume: captain
   context: plan
 ```
 
-Inside Contract Markdown, prefer `persist:` on services and `call service` in
+Inside Contract Markdown, prefer `### Runtime` on services and `call service` in
 execution blocks. `session:` and `resume:` remain available for standalone
 scripts and compatibility.
 

--- a/skills/open-prose/state/filesystem.md
+++ b/skills/open-prose/state/filesystem.md
@@ -456,9 +456,9 @@ timestamp: 2026-03-17T14:32:15Z
 
 | Scope | Declaration | Path | Lifetime |
 |-------|-------------|------|----------|
-| Execution (default) | `persist: true` | `.prose/runs/{id}/agents/{name}/` | Dies with run |
-| Project | `persist: project` | `.prose/agents/{name}/` | Survives runs |
-| User | `persist: user` | `~/.prose/agents/{name}/` | Survives projects |
+| Execution (default) | `### Runtime` with `persist: true` | `.prose/runs/{id}/agents/{name}/` | Dies with run |
+| Project | `### Runtime` with `persist: project` | `.prose/agents/{name}/` | Survives runs |
+| User | `### Runtime` with `persist: user` | `~/.prose/agents/{name}/` | Survives projects |
 
 ---
 

--- a/skills/open-prose/state/postgres.md
+++ b/skills/open-prose/state/postgres.md
@@ -716,7 +716,7 @@ UPDATE openprose.run SET status = 'failed' WHERE id = '20260116-143052-a7b3c9';
 
 ## Project-Scoped and User-Scoped Agents
 
-Execution-scoped agents (the default) use `run_id = specific value`. **Project-scoped agents** (`persist: project`) and **user-scoped agents** (`persist: user`) use `run_id IS NULL` and survive across runs.
+Execution-scoped agents (the default) use `run_id = specific value`. **Project-scoped agents** (`### Runtime` with `persist: project`) and **user-scoped agents** (`### Runtime` with `persist: user`) use `run_id IS NULL` and survive across runs.
 
 For user-scoped agents, the VM maintains a separate connection or uses a naming convention to distinguish them from project-scoped agents. One approach is to prefix user-scoped agent names with `__user__` in the same database, or use a separate user-level database configured via `OPENPROSE_POSTGRES_USER_URL`.
 

--- a/skills/open-prose/state/sqlite.md
+++ b/skills/open-prose/state/sqlite.md
@@ -62,7 +62,7 @@ Example: `.prose/runs/20260116-143052-a7b3c9/state.db`
 
 ### Project-Scoped and User-Scoped Agents
 
-Execution-scoped agents (the default) live in the per-run `state.db`. However, **project-scoped agents** (`persist: project`) and **user-scoped agents** (`persist: user`) must survive across runs.
+Execution-scoped agents (the default) live in the per-run `state.db`. However, **project-scoped agents** (`### Runtime` with `persist: project`) and **user-scoped agents** (`### Runtime` with `persist: user`) must survive across runs.
 
 For project-scoped agents, use a separate database:
 


### PR DESCRIPTION
## Summary
- make `### Services` the canonical Contract Markdown topology section, with `services:` retained only as compatibility syntax
- move behavior declarations toward `### Runtime`, `### Shape`, and `### Description` across docs and examples
- normalize examples with backticked contract fields and explicit description sections so first-read syntax feels consistent

## Checks
- `git diff --check`
- searched for raw legacy example frontmatter keys: `services:`, `shape:`, `persist:`, `model:`, `permissions:`
- checked Markdown fence balance across non-v0 OpenProse docs
- audited examples for unexpected behavioral frontmatter keys