### PR TITLE
docs: make skills and RFCs self-contained

### DIFF
--- a/rfcs/001-scheduled-execution.md
+++ b/rfcs/001-scheduled-execution.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed
 **Date:** 2026-04-08
-**Author:** Dan (via OpenProse Cloud customer programs)
+**Author:** Dan B. (OpenProse)
 
 ## Problem
 
@@ -35,7 +35,7 @@ name: deal-radar-weekly
 kind: program
 services: [deal-flow-radar, human-gate, slack-notifier]
 schedule:
-  cron: "0 8 * * 5"  # Fridays at 8am
+  cron: "0 8 * * 5" # Fridays at 8am
   timezone: "America/Los_Angeles"
   description: "Weekly deal flow radar, delivered Friday mornings"
 ---
@@ -68,6 +68,7 @@ schedule:
 ## Impact
 
 This would affect:
+
 - `prose.md` — document the schedule field in frontmatter
 - `forme.md` — Forme should include schedule in the manifest so the runtime can read it
 - Press runtime — implement cron-based invocation

--- a/rfcs/002-feedback-loop-syntax.md
+++ b/rfcs/002-feedback-loop-syntax.md
@@ -2,13 +2,14 @@
 
 **Status:** Proposed
 **Date:** 2026-04-08
-**Author:** Dan (via OpenProse Cloud customer programs)
+**Author:** Dan B. (OpenProse)
 
 ## Problem
 
 Every customer program we've built includes a `previous_feedback:` or `previous_reports:` input that allows the program to incorporate human feedback and improve over time. But the mechanism for actually feeding back is entirely manual — someone reads the output, formulates feedback, and passes it as a string to the next run.
 
 The Prose language has no formal construct for:
+
 1. Declaring that a program improves with feedback
 2. Structuring feedback so it's machine-readable
 3. Accumulating feedback across runs (feedback history)
@@ -47,13 +48,16 @@ And a `feedback_history:` file in the run directory that accumulates feedback ac
 # Feedback History
 
 ## Preferences (persist)
+
 - 2026-04-07: "weight consumer AI and creator tools higher" (via Slack reply)
 - 2026-04-08: "show quarterly numbers, not weekly" (via email)
 
 ## Exceptions (persist)
+
 - 2026-04-07: "Site 4 overnight HVAC is intentional — bakery" (via Slack)
 
 ## Corrections (one-time, applied)
+
 - 2026-04-07: "Suno revenue should be $80M" (applied in run radar-20260408-001)
 ```
 

--- a/rfcs/003-environment-declaration.md
+++ b/rfcs/003-environment-declaration.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed
 **Date:** 2026-04-08
-**Author:** Dan (via OpenProse Cloud customer programs)
+**Author:** Dan B. (OpenProse)
 
 ## Problem
 
@@ -37,6 +37,7 @@ environment:
 ```
 
 Key properties:
+
 - `environment:` variables are resolved by the VM from the host environment (`.prose/.env` or system env vars)
 - The model never sees actual values — only the variable names and descriptions
 - `required: true` means `prose preflight` will fail if the variable is not set

--- a/rfcs/004-composite-instantiation.md
+++ b/rfcs/004-composite-instantiation.md
@@ -4,7 +4,6 @@
 **Authors:** Dan B., Claude (OpenProse build session 2026-04-08)
 **Created:** 2026-04-08
 **Related:** RFC-001 (Scheduled Execution), RFC-002 (Feedback Loops), RFC-003 (Environment Declaration)
-**Full design document:** `planning/builds/2026-04-08-composite-instantiation/00-overview.md`
 
 ---
 
@@ -69,7 +68,3 @@ with: {slots}    slots, validates,   delegation steps
 ## Prior art
 
 Haskell typeclasses (slot contracts are trait bounds), Python decorators (Level 3 is this), web middleware (composites are middleware for AI sessions), Aspect-Oriented Programming (Forme is the weaver), Terraform modules (Level 1 is this), monad transformers (composites stack like transformer layers).
-
-## Full specification
-
-See `planning/builds/2026-04-08-composite-instantiation/00-overview.md` for the complete design document including syntax specification, Forme expansion algorithm, invariant encoding, nested composition, prior art analysis, and evaluation blanket implications.

--- a/skills/README.md
+++ b/skills/README.md
@@ -3,7 +3,6 @@ purpose: Bundled Claude Code skills distributed with the prose repo — open-pro
 related:
   - ../README.md
   - ./open-prose/README.md
-  - ../../../../platform/api-v2/README.md
 ---
 
 # skills
@@ -12,4 +11,4 @@ Claude Code skills bundled with the OpenProse language specification repo. Each 
 
 ## Contents
 
-- `open-prose/` — the OpenProse VM skill; defines the language spec, compiler, state backends, primitives, standard library, examples, and VM guidance. This skill is the canonical definition of what the OpenProse VM is; `platform/api-v2` implements it as a hosted execution service.
+- `open-prose/` — the OpenProse VM skill; defines the language spec, compiler, state backends, primitives, standard library, examples, and VM guidance. This skill is the canonical definition of what the OpenProse VM is; OpenProse Cloud is the hosted execution service that implements this spec.

--- a/skills/open-prose/state/README.md
+++ b/skills/open-prose/state/README.md
@@ -4,7 +4,6 @@ related:
   - ../README.md
   - ../primitives/README.md
   - ../guidance/README.md
-  - ../../../../../platform/api-v2/README.md
 glossary:
   State Backend: A persistence layer the VM uses to store variables, results, and execution context between sessions
 ---


### PR DESCRIPTION
Several docs referenced paths and deployment internals that only exist in our workspace, not in this repo. Clean them up so external readers get a self-contained view.

- skills/README.md, skills/open-prose/state/README.md: drop `related:` frontmatter entries that pointed outside the repo tree; refer to "OpenProse Cloud" by name instead of an internal path.

- skills/open-prose/agent-onboarding.md: replace a 25-line maintainer comment (infra paths, deploy mechanic) with a single link to the canonical rendering at https://openprose.ai/llms-full.txt. This file is served verbatim as llms-full.txt, so the comment was publicly visible but only meaningful to hosting maintainers.

- rfcs/004-composite-instantiation.md: drop two pointers to an external design doc — the RFC is already self-contained (Summary, Problem, Proposal, Architecture, Changes, Prior Art).

- rfcs/001/002/003: normalize author line to match rfcs/004's format (`Dan B. (OpenProse)`).

Docs only, no behavior changes.