### PR TITLE
docs(contract-markdown): document run / run[] typed caller inputs

### DIFF
--- a/skills/open-prose/contract-markdown.md
+++ b/skills/open-prose/contract-markdown.md
@@ -268,6 +268,28 @@ accepted for compatibility:
 - each article has: a summary, relevance score, and key claims
 ```
 
+## Typed Caller Inputs
+
+Most `### Requires` entries are free-form values the caller provides at run
+time. Two keywords are reserved for passing *completed runs* as inputs — the
+typical shape for inspectors, regression checkers, and meta-programs:
+
+```markdown
+### Requires
+
+- `subject`: run — a completed run to inspect
+- `cohort`: run[] — a set of completed runs to compare
+```
+
+When an entry's type is `run` or `run[]`, the caller supplies a run ID (or a
+list of them). The Prose VM resolves each ID to its run directory and writes a
+structured binding at `bindings/caller/{name}.md` containing the run ID, path,
+program name, and status. The service reads that binding and then reaches into
+the run's own `bindings/`, `state.md`, and `manifest.md` directly.
+
+See `prose.md` (Run-Typed Inputs) for binding format, resolution order (bare
+ID, `~/{id}` for user scope, absolute path), and staleness validation.
+
 ## Execution Sections
 
 `### Execution` contains ProseScript. Use a fenced block:


### PR DESCRIPTION
## Summary

- `run` and `run[]` are reserved keyword types for `### Requires` entries that accept completed run IDs
- The binding format, resolution order, and staleness rules are specified in `prose.md` and `forme.md`
- `contract-markdown.md` — the primary authoring surface — never mentioned them, so authors had to cross-reference three files to discover the feature

## What this PR does

Adds a "Typed Caller Inputs" subsection after "Contract Item Style" showing the canonical `subject: run` and `cohort: run[]` shapes, a one-paragraph semantics summary, and a pointer to `prose.md` for the full binding/validation rules.

Purely additive, no existing content changed.

## Agent experience

Writing a new inspector/regression program against `contract-markdown.md` alone, I reached the `### Requires` section without knowing the `run` keyword existed. Three file hops later I had the answer. The authoring-surface doc should be self-sufficient for common shapes.

## Test plan

- [ ] Existing inspectors and regression-trackers that already use `subject: run` remain valid
- [ ] Binding behavior described lines up with `prose.md` Run-Typed Inputs section
- [ ] No section renumbering that would break external references

🤖 Generated with [Claude Code](https://claude.com/claude-code)