### PR TITLE
docs: unify prose-run and use resolution (explicit git hosts)

### DIFF
--- a/skills/open-prose/SKILL.md
+++ b/skills/open-prose/SKILL.md
@@ -233,18 +233,36 @@ User-level persistent agents live under `~/.prose/agents/`.
 
 ## Remote Programs
 
-`prose run` accepts URLs and registry shorthands:
+`prose run` and `use` share one resolution algorithm: prefer the locally
+installed copy in `.deps/`, fetch from the source host as fallback. The
+canonical identifier is `host/owner/repo` — any git host works, written
+explicitly.
 
 | Input | Resolution |
 |-------|------------|
-| Starts with `http://` or `https://` | Fetch directly |
-| Starts with `@` | Strip `@`, resolve to `https://p.prose.md/{path}` |
-| Contains `/` but no protocol | Resolve to `https://p.prose.md/{path}` |
+| Starts with `http://` or `https://` | Fetch directly (no caching) |
+| First path segment contains a dot | Explicit git host; cache-first under `.deps/{host}/{owner}/{repo}/`, clone from that host if not cached |
+| Ends with `@{version}` | Resolve that version (SHA or tag); fetch if that version is not cached |
+| Other `/`-containing identifier | Reserved for the OpenProse registry (future home at `p.prose.md`); inert today |
 | Otherwise | Treat as local path |
 
-`use` statements inside programs use the git-native dependency model from
-`deps.md`: dependencies are installed into `.deps/` by `prose install` and read
-from disk at runtime.
+```bash
+prose run github.com/alice/research              # canonical; cached copy wins
+prose run github.com/alice/research@0.3.1        # pin to tag; fetch iff not cached
+prose run gitlab.com/alice/research              # any git host
+prose run git.company.com/team/repo              # self-hosted
+prose run github.com/alice/research --offline    # never fetch; error if not in .deps/
+```
+
+**On the bare `owner/repo` form.** Bare identifiers (no host prefix) are
+reserved for the OpenProse registry. Publication there isn't open yet, so the
+bare form doesn't resolve today — write `github.com/owner/repo` (or the
+appropriate host) explicitly. When the registry opens, the bare form gains a
+defined resolution without breaking programs that wrote explicit hosts.
+
+`use` statements inside programs follow the same rule via the git-native
+dependency model in `deps.md`: dependencies get pinned in `prose.lock` and
+installed into `.deps/` by `prose install`.
 
 ## State Modes
 

--- a/skills/open-prose/deps.md
+++ b/skills/open-prose/deps.md
@@ -22,42 +22,59 @@ is no registry server — GitHub IS the registry. Dependencies are cloned into
 
 ## `use` Statement Parsing
 
-A `use` statement resolves to a GitHub repository and a path within it.
+A `use` statement names an explicit git host, owner, repo, and path. The
+canonical form is `host/owner/repo/path`:
 
 ```prose
-use "openprose/std/evals/inspector"
+use "github.com/openprose/std/evals/inspector"
 ```
 
 Parsed as:
 
 | Component | Value |
 |-----------|-------|
+| Host | `github.com` |
 | Owner | `openprose` |
 | Repo | `std` |
 | Path | `evals/inspector` |
-| GitHub URL | `github.com/openprose/std` |
-| Local clone | `.deps/openprose/std/` |
-| Resolved file | `.deps/openprose/std/evals/inspector.md` |
+| Clone URL | `github.com/openprose/std` |
+| Local clone | `.deps/github.com/openprose/std/` |
+| Resolved file | `.deps/github.com/openprose/std/evals/inspector.md` |
 
-The first two segments of the `use` path are always `owner/repo`. Everything after is a path within the cloned repository.
+The first path segment is the host (must contain a dot — `github.com`,
+`gitlab.com`, `codeberg.org`, `git.company.com`). The next two segments are
+always `owner/repo`. Everything after is a path within the cloned
+repository.
+
+Any git host works. Nothing in the resolver privileges GitHub — it's the
+common case, not a default.
 
 ### `std/` Shorthand
 
-`std/` expands to `openprose/std/`:
+`std/` expands to `github.com/openprose/std/`:
 
 ```prose
 use "std/evals/inspector"
 # equivalent to:
-use "openprose/std/evals/inspector"
+use "github.com/openprose/std/evals/inspector"
 ```
+
+### Bare `owner/repo` Form
+
+Identifiers without a host prefix (e.g. `use "alice/research"`) are reserved
+for the OpenProse registry — eventually hosted at `p.prose.md`. That
+registry isn't open for publication yet, so the bare form doesn't resolve
+today. Write the host explicitly (`github.com/alice/research`) or use the
+`std/` shorthand. When the registry opens, the bare form gains a defined
+resolution without breaking programs that wrote explicit hosts.
 
 ### File Extension Resolution
 
 If the `use` path includes an explicit extension (`.md` or `.prose`), use it. If no extension, prefer `.md`:
 
 ```prose
-use "alice/tools/formatter"
-# resolves to: .deps/alice/tools/formatter.md
+use "github.com/alice/tools/formatter"
+# resolves to: .deps/github.com/alice/tools/formatter.md
 ```
 
 ### Aliasing
@@ -65,7 +82,7 @@ use "alice/tools/formatter"
 `use` statements support `as` aliases in execution blocks:
 
 ```prose
-use "alice/research-pipeline" as research
+use "github.com/alice/research-pipeline" as research
 
 let result = research(topic: "quantum computing")
 ```
@@ -78,9 +95,9 @@ In `### Services`, use the full path — aliases are for execution blocks only.
 
 When the VM or Forme encounters a `use` path at runtime:
 
-1. Expand `std/` shorthand to `openprose/std/` if applicable
-2. Parse `owner/repo` from the first two segments
-3. Check `.deps/{owner}/{repo}/` exists on disk
+1. Expand `std/` shorthand to `github.com/openprose/std/` if applicable
+2. Parse `{host}/{owner}/{repo}` from the first three segments
+3. Check `.deps/{host}/{owner}/{repo}/` exists on disk
 4. If not found, error immediately (see Error Handling below)
 5. Resolve the remaining path segments within the cloned repo
 6. Return the absolute file path
@@ -96,19 +113,19 @@ Scans the project for dependency references and clones missing dependencies.
 ### Algorithm
 
 1. **Scan** all `.md` and `.prose` files in the project for:
-   - `use "owner/repo/path"` statements
-   - service names in `### Services` that start with `std/` or `owner/repo/`
-   - `compose:` paths that start with `std/` or `owner/repo/`
-2. **Parse** each dependency path to extract `owner/repo` pairs
-3. **Expand** `std/` shorthand to `openprose/std/`
-4. For each unique `owner/repo`:
-   a. If `.deps/{owner}/{repo}/` does not exist, full clone: `git clone github.com/{owner}/{repo} .deps/{owner}/{repo}/`
+   - `use "host/owner/repo/path"` statements
+   - service names in `### Services` that start with `std/` or `host/owner/repo/`
+   - `compose:` paths that start with `std/` or `host/owner/repo/`
+2. **Parse** each dependency path to extract `{host, owner, repo}` triples (the first segment is the host if it contains a dot)
+3. **Expand** `std/` shorthand to `github.com/openprose/std/`
+4. For each unique `{host, owner, repo}`:
+   a. If `.deps/{host}/{owner}/{repo}/` does not exist, full clone: `git clone {host}/{owner}/{repo} .deps/{host}/{owner}/{repo}/`
    b. If `prose.lock` has a pinned SHA for this repo, checkout: `git checkout {sha}`
    c. If no pinned SHA exists (new dependency), use HEAD and record the SHA
 5. **Scan transitive dependencies** — scan all `.md` and `.prose` files within newly cloned repos in `.deps/` for their own `use` statements
 6. **Cycle detection** — if a newly discovered dependency is already in the resolved set, skip it. If scanning reveals a cycle (A requires B requires A), error: `[Error] Circular dependency detected: A → B → A`
 7. **Repeat** from step 2 with any newly discovered dependencies until no new deps are found
-8. **Write** `prose.lock` with all resolved SHAs (direct and transitive, flat list)
+8. **Write** `prose.lock` with all resolved `{host, owner, repo, sha}` entries (direct and transitive, flat list)
 
 ### Transitive Resolution (Multi-Pass)
 
@@ -277,15 +294,26 @@ Existing `.prose` programs without `.deps/` continue to work via the p.prose.md 
 
 ## Interaction with p.prose.md
 
-The registry at `p.prose.md` shifts to a **discovery-only** role:
+`p.prose.md` is reserved as the future home of the OpenProse registry.
+Publication there isn't open yet — no identifier actually resolves via
+`p.prose.md` today. When it opens, the bare `owner/repo` form gains a
+defined resolution and `p.prose.md` takes on a discovery role (search,
+docs, install counts, eval scores, callable runtimes).
 
 | Use case | Resolution |
 |----------|------------|
-| `use "owner/repo/path"` in a program | Git-native via `.deps/` (requires `prose install`) |
-| `prose run handle/slug` at the CLI | Still resolves via `https://p.prose.md/{path}` |
-| Browsing/searching for programs | `p.prose.md` website |
+| `use "github.com/owner/repo/path"` in a program | `.deps/github.com/owner/repo/` if cached, clone from GitHub if not |
+| `use "std/..."` in a program | Expands to `github.com/openprose/std/...` then resolves as above |
+| `prose run github.com/owner/repo/path` at the CLI | Same algorithm as `use` |
+| `prose run github.com/owner/repo/path@{version}` | That specific version — cached copy wins, fetch otherwise |
+| `prose run ... --offline` | `.deps/` only; error on miss |
+| `use "alice/research"` / `prose run alice/research` | Reserved for the OpenProse registry; inert today |
+| Browsing/searching for programs | Not yet available; `p.prose.md` will host this |
 
-`use` statements resolve via git. The CLI `prose run handle/slug` shorthand can still use p.prose.md as a convenience for ad-hoc execution.
+`use` and `prose run` share one resolution algorithm. `prose install` is the
+explicit "get me every declared dependency at its pinned SHA" command; both
+`use` and `prose run` can auto-fetch a missing identifier as a convenience
+when the declared `prose.lock` SHA is not yet on disk.
 
 ---
 
@@ -293,12 +321,12 @@ The registry at `p.prose.md` shifts to a **discovery-only** role:
 
 | Concept | Detail |
 |---------|--------|
-| Registry | GitHub (no custom registry server) |
+| Registry | Any git host, named explicitly (`github.com/...`, `gitlab.com/...`); bare `owner/repo` reserved for future `p.prose.md` |
 | Install command | `prose install` (explicit, not auto) |
 | Update command | `prose install --update` |
 | Lockfile | `prose.lock` (plaintext, committed) |
-| Cache directory | `.deps/` (gitignored) |
-| Shorthand | `std/` → `openprose/std/` |
+| Cache directory | `.deps/{host}/{owner}/{repo}/` (gitignored) |
+| Shorthand | `std/` → `github.com/openprose/std/` |
 | Clone strategy | Full clone (supports SHA checkout without refetch) |
 | Transitive deps | Multi-pass scan until stable (errors on cycles) |
 | Version conflicts | Auto-resolve to newer SHA with warning |

--- a/skills/open-prose/prose.md
+++ b/skills/open-prose/prose.md
@@ -24,9 +24,12 @@ OpenProse is invoked via `prose` commands:
 
 | Command                     | Action                                                          |
 | --------------------------- | --------------------------------------------------------------- |
-| `prose run <file.md>`       | Execute a local `.md` program                                   |
-| `prose run <file.prose>`    | Execute a ProseScript program                                   |
-| `prose run handle/slug`     | Fetch from registry and execute                                 |
+| `prose run <file.md>`            | Execute a local `.md` program                                             |
+| `prose run <file.prose>`         | Execute a ProseScript program                                             |
+| `prose run <host>/<owner>/<repo>` | Explicit git host (e.g. `github.com/alice/research`); cache in `.deps/`   |
+| `prose run <owner>/<repo>`       | Reserved for the OpenProse registry (future home at `p.prose.md`)         |
+| `prose run ...@<version>`        | Pin to a SHA or tag; fetch if that version isn't cached                   |
+| `prose run ... --offline`        | Never fetch; error if not in `.deps/`                                     |
 | `prose lint <file.md>`      | Validate structure, schema, shapes, and contracts               |
 | `prose preflight <file.md>` | Check dependencies and environment variables                    |
 | `prose test <path>`         | Run test(s) and report results                                  |
@@ -39,21 +42,61 @@ OpenProse is invoked via `prose` commands:
 
 ### Remote Programs
 
+`prose run` and `use` statements share one resolution algorithm: prefer the
+locally installed copy in `.deps/`, fetch from the source host as fallback.
+This is the cache-first behavior Deno and Go modules converged on after
+trying other shapes.
+
+The canonical identifier is `host/owner/repo`. Any git host works —
+write the host explicitly. GitHub is the 90% case but nothing in the
+resolver privileges it.
+
 ```bash
-# Direct URL
+# Raw URL — fetched every time, no caching
 prose run https://example.com/program.md
 
-# Registry shorthand — resolves to p.prose.md
-prose run alice/research
-prose run @alice/research
+# Canonical: explicit git host
+prose run github.com/alice/research              # cached copy wins; clones if missing
+prose run github.com/alice/research@0.3.1        # pin to tag; fetch iff that version isn't cached
+prose run github.com/alice/research@abc1234      # pin to SHA
+prose run gitlab.com/alice/research              # any git host
+prose run git.company.com/team/repo              # self-hosted
+
+# Flags
+prose run github.com/alice/research --offline    # never hit the network; error if not cached
 ```
 
 **Resolution rules:**
 
-- Starts with `http://` or `https://` → fetch directly
-- Starts with `@` → strip the `@`, resolve to `https://p.prose.md/{path}`
-- Contains `/` but no protocol → resolve to `https://p.prose.md/{path}`
+- Starts with `http://` or `https://` → fetch directly (no caching)
+- First path segment contains a dot (looks like a hostname) → explicit git host; cache-first under `.deps/{host}/{owner}/{repo}/`, clone from that host if not cached
+- Ends with `@{version}` → resolve that version (SHA or tag); fetch if that version is not cached
+- Otherwise contains `/` → reserved for the OpenProse registry (future home at `p.prose.md`); nothing publishes there today, so this path is spec'd but inert
 - Otherwise → treat as local file path
+
+`--offline` disables the network fallback. `prose run
+github.com/alice/research --offline` errors out rather than fetching.
+
+**When resolution fails:**
+
+When an identifier is not in `.deps/` *and* the fetch from its host returns
+no match, report:
+
+```
+Not found in `.deps/` or at github.com/alice/research.
+Did you mean to run `prose install`, or try `prose run github.com/alice/research@latest`?
+```
+
+The error must name both the identifier and the exact host URL that was
+tried, so the user can distinguish a typo from a missing install from a
+host-side outage.
+
+**On the bare `owner/repo` form.** Bare identifiers (no host prefix) are
+reserved for the OpenProse registry. That registry isn't accepting
+publications yet, so the bare form doesn't resolve today — use
+`github.com/owner/repo` (or the appropriate host) explicitly. When the
+registry opens, the bare form gains a defined resolution without breaking
+anyone who wrote explicit hosts.
 
 ---
 


### PR DESCRIPTION
## What changed

Collapse the resolution asymmetry between `prose run` and `use`. Canonical identifier is `host/owner/repo` — any git host, written explicitly. Cache-first under `.deps/{host}/{owner}/{repo}/`, clone from that host as fallback.

| Input | Resolution |
|-------|------------|
| `http(s)://...` | Fetch directly (no caching) |
| First segment has a dot (e.g. `github.com/alice/research`) | Explicit git host; cache-first, clone from host if missing |
| `...@{version}` | Pin to SHA or tag; fetch if that version isn't cached |
| Other `/`-containing identifier | Reserved for the OpenProse registry (future home at `p.prose.md`); inert today |
| Otherwise | Local path |

```bash
prose run github.com/alice/research              # canonical
prose run github.com/alice/research@0.3.1        # pin to tag
prose run gitlab.com/alice/research              # any git host
prose run git.company.com/team/repo              # self-hosted
prose run github.com/alice/research --offline    # never fetch
```

## Why

Previously, `prose run alice/research` hit `p.prose.md` and `use "alice/research"` hit GitHub. Same identifier, two sources. An agent who `prose install`s a dep and re-runs it watches a different copy execute.

## Shape

Modeled on Deno and Go modules — both started with URL-based imports, added a central layer (jsr.io, proxy.golang.org) much later as a value-add rather than a load-bearing dependency. Deno's evolution is the closest match to what you want: explicit URLs from day one, central registry added without breaking anyone.

GitHub is the 90% case but nothing in the resolver privileges it. Write the host explicitly. Enterprise self-hosted git (`git.company.com/...`) works without special config.

## No "force registry" flag

npm / npx taught us this: `npx foo` uses what's installed, `npx foo@1.2.3` pins a version and re-fetches if needed. One concept (`@{version}`), two jobs — version pinning *and* cache bypass. `prose` gets the same shape. `--offline` is the only added flag, for air-gapped CI and explicit reproducibility checks.

## Bare `owner/repo` is reserved, not deprecated

Bare identifiers (no host) are reserved for the OpenProse registry — eventually hosted at `p.prose.md`. Publication isn't open yet, so the bare form doesn't resolve today. When the registry opens, the bare form gains a defined resolution without breaking programs that wrote explicit hosts.

## Error when resolution fails

```
Not found in `.deps/` or at github.com/alice/research.
Did you mean to run `prose install`, or try `prose run github.com/alice/research@latest`?
```

The error names both the identifier and the exact host URL tried, so users can distinguish a typo from a missing install from a host-side outage.

## Files

- `SKILL.md` Remote Programs table
- `prose.md` CLI Commands table + Remote Programs section (algorithm, `--offline`, error shape, reserved-form note)
- `deps.md` `use` Statement Parsing (canonical shape, new "Bare owner/repo Form" subsection), Resolution Algorithm + `prose install` Algorithm (key on `{host}/{owner}/{repo}`), Interaction with p.prose.md table, Summary table

No tooling changes. Migrating `.deps/` to include the `{host}/` segment is a follow-up.

## Test plan

- [ ] `prose install && prose run github.com/alice/research` uses the cached copy
- [ ] `prose run github.com/alice/research@0.4.0` fetches 0.4.0 even if 0.3.1 is in `.deps/`
- [ ] `prose run gitlab.com/alice/research` clones from GitLab
- [ ] `prose run git.company.com/team/repo` clones from a self-hosted host
- [ ] `prose run alice/research` (bare) errors today with a pointer to the explicit form
- [ ] `prose run github.com/alice/research --offline` with no `.deps/` errors with the documented message
- [ ] `std/evals/inspector` resolves to `github.com/openprose/std/evals/inspector.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)