### PR TITLE
docs(contract-markdown): canonize ### Memory section

### DIFF
--- a/skills/open-prose/contract-markdown.md
+++ b/skills/open-prose/contract-markdown.md
@@ -81,6 +81,7 @@ Forme and the Prose VM recognize these `###` sections case-insensitively:
 | `### Strategies` | program, service, test | Guidance for judgment calls and edge cases |
 | `### Environment` | program, service | Runtime variables supplied by host infrastructure |
 | `### Runtime` | program, service | Execution hints such as `persist` and `model` |
+| `### Memory` | service | Declared reads from and writes to persistent agent memory. Only meaningful when `### Runtime` sets `persist: project` or `persist: user` |
 | `### Shape` | service | Capability boundaries: self, delegates, and prohibited work |
 | `### Wiring` | program | Explicit Level 2 wiring declaration |
 | `### Execution` | program, service | ProseScript choreography that pins execution |
@@ -230,6 +231,47 @@ Runtime hints and behavioral boundaries are also sections:
 
 The old `persist:`, `model:`, and `shape:` frontmatter fields remain accepted
 for compatibility.
+
+## Memory
+
+A service with `persist: project` or `persist: user` in `### Runtime` reaches
+into memory files that outlive the current run. The `### Memory` section
+declares what that service *reads from* and *writes to* memory — the
+persistent equivalent of `### Requires` / `### Ensures`:
+
+````markdown
+### Memory
+
+```yaml
+reads:
+  - high_water_mark: ISO timestamp of the newest item processed in a prior run
+  - cumulative_registry: map of id → { first_seen, last_seen, hit_count }
+writes:
+  - high_water_mark: advanced to the newest item observed this run
+  - cumulative_registry: merged with items observed this run
+  - last_run_at: ISO timestamp of this run's completion
+```
+````
+
+Rules:
+
+- `### Memory` is only meaningful when `### Runtime` sets `persist: project`
+  or `persist: user`. A service with execution-scoped memory (`persist:
+  true`) does not need this section — its memory dies with the run.
+- `reads:` names fields the service expects to exist in memory; missing
+  fields should be handled as "first run" rather than as errors.
+- `writes:` names fields the service commits to update on a successful run.
+  A failed run that does not reach the memory write leaves state untouched
+  — see the `idempotent-scheduled-intake` pattern in
+  `guidance/patterns.md`.
+- Fields that downstream responsibilities also need (high-water marks,
+  cursors, run IDs) should *also* appear at the top level of `### Ensures`
+  — see `top-level-cursor-emission` in `guidance/patterns.md`. Memory is
+  for the next invocation of *this* service; the return value is for the
+  next responsibility.
+
+See `prose.md` (Persistent Agents) and `state/filesystem.md` (Memory
+Scoping) for the on-disk format of memory files.
 
 ## Frontmatter
 


### PR DESCRIPTION
## Summary

Customer programs that accumulate state across runs (stargazer-intake, agents-site-analytics) have been carrying a load-bearing `### Memory` section that enumerates reads/writes to their persistent memory file. Per the existing spec, `### Memory` was an "unknown section" — preserved as documentation but not a contract.

This gap caused real problems:

- Agents editing those programs couldn't tell whether the section was load-bearing or ornamental.
- No single source of truth for fields that appear in three places (memory file, top-level Ensures, memory_update echo).
- The 2026-04-21 eval-blanket on stargazer-intake flagged "authoritative source when 3 copies exist" as a friction item worth resolving.

## What this PR does

- Adds `### Memory` to the Canonical Sections table
- Defines the `reads:` / `writes:` YAML format that customer programs already use
- Names the rule: `### Memory` only applies when `### Runtime` sets `persist: project` or `persist: user`
- Cross-references `top-level-cursor-emission` and `idempotent-scheduled-intake` in `guidance/patterns.md` (see companion PR #34) so authors know cursor fields should *also* appear in `### Ensures`
- Points to `prose.md` Persistent Agents and `state/filesystem.md` Memory Scoping for on-disk format

No behavior change; this canonizes prior art so readers stop having to infer it.

## Relationship to other PRs

- Pairs naturally with #34 (adds the patterns referenced from this section)
- Pairs with #32 (clarifies the `persist: true` vs `persist: project` distinction that drives when `### Memory` applies)

## Test plan

- [ ] Existing programs using `### Memory` (stargazer-intake, agents-site-analytics) lint cleanly under the canonical definition
- [ ] `reads:` fields without a prior run are treated as first-run, not an error
- [ ] Forme's extraction list in forme.md already covers `### Memory` — or should be updated in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)