### PR TITLE
RFC 005: package-bounded component resolution

### DIFF
--- a/rfcs/005-flexible-component-resolution.md
+++ b/rfcs/005-flexible-component-resolution.md
@@ -1,0 +1,231 @@
+# RFC 005: Package-Bounded Component Resolution
+
+**Status:** Proposed
+**Date:** 2026-04-21
+**Author:** Dan B. (OpenProse)
+
+## Problem
+
+Forme's component resolution (`forme.md` §Step 2) accepts four locations:
+
+1. `./<name>.md` — same directory as the entry point
+2. `./<name>/index.md` — a subdirectory with an `index.md`
+3. `.deps/<owner>/<repo>/<path>.md` — git-native dependencies
+4. Registry shorthand (compatibility)
+
+This works for **flat** layouts (all services in one directory), **single-subdir** layouts (`./name/index.md`), and **externalized-as-dep** (`use "my-org/shared-bits"`). It does not accommodate the **layered / categorized** shape that appears as soon as a customer project grows past a handful of files:
+
+```
+customers/acme/
+  responsibilities/     # orchestration programs that coordinate services
+  services/             # leaf services shared across programs
+    firehose/           # categorized subdirectories
+    enrichment/
+  delivery/             # cadence + channel wrappers around responsibilities
+  evals/
+```
+
+A delivery composite in `delivery/` that references a responsibility in `responsibilities/` (which delegates to services under `services/firehose/` and `services/`) has no resolution path today. The spec's four rules only look inside the entry point's own directory, one level deeper, or in `.deps/`.
+
+Today's workarounds:
+
+1. **Flatten the tree.** Collapse every service into one directory alongside the program that uses it. Destroys the architectural separation; shared services get duplicated or ambiguously assigned.
+2. **`./name/index.md` subdirs.** Force every service into its own named subdirectory with an `index.md`. Fights natural Markdown conventions and produces deep, sparse trees.
+3. **`use` everything.** Turn every internal module into a `.deps/`-installed git dep. Massive overhead for an internal refactor.
+4. **Rely on runtime fuzzy matching.** Fail Phase 1 wiring and let the VM agent grep/glob for the file. Silently undermines tenet T16 ("Components don't discover each other — Forme discovers them"); no deterministic linter can reproduce it.
+
+## Scenarios
+
+1. **Niural GTM pipeline (`customers/prose-niural/`).** Delivery composite in `delivery/`, responsibility in `responsibilities/`, 7 services spread across `services/` and `services/firehose/`. No cross-directory references resolve today.
+
+2. **Rippling GTM (`customers/prose-rippling/`).** Delivery composites in `programs/delivery/` reference core programs in `programs/startup-gtm/`. Under current rules these never resolve. The actual run traces in `.prose/runs/` all target core programs standalone — the delivery composites appear to have never been successfully wire-tested.
+
+3. **Internal stdlib.** A customer building reusable workers/critics/renderers under `customers/acme/lib/{roles,renderers,evals}/` today cannot reference `markdown-renderer` from a program outside `lib/renderers/` without externalizing `lib/` as a git dep.
+
+## Proposal
+
+Forme resolves components by walking the **package**, bounded by a package root marker. No per-program configuration required.
+
+### Expanded resolution order
+
+For each entry in `### Services`, locate the corresponding `.md` file:
+
+1. `./<name>.md` — entry point's own directory
+2. `./<name>/index.md` — subdirectory with an `index.md`
+3. **Package-bounded walk.** From the entry point, walk up the filesystem to the nearest ancestor that contains any package root marker (see below). From that ancestor, recursively scan every `.md` file under the subtree, skipping excluded directories. A component matches when its frontmatter `name:` equals the wanted name, or — if the file declares no `name:` frontmatter — when its filename stem matches.
+4. `.deps/` — git-native dependencies (unchanged).
+5. Registry shorthand (compatibility, unchanged).
+
+A structured service entry may carry an explicit `path:` field. `path:` is an absolute override — Forme resolves the entry directly against that path (relative to the program file) and skips all other rules. Use `path:` for one-off cross-package references or forced disambiguation; the primary pattern remains plain name references resolved through the package walk.
+
+### Package root
+
+The package root is the nearest ancestor directory (walking up from the entry point file, inclusive) containing any of:
+
+- `.prose/` — the runtime's workspace directory
+- `prose.lock` — the dependency lockfile
+
+If no ancestor carries a marker, the entry point's own directory is the package root (single-file programs keep working with no setup).
+
+A package root marker is load-bearing: it declares "this directory and its subtree are one coherent OpenProse project." Authors who want to split one filesystem tree into multiple independent packages do so by placing markers at the desired boundaries.
+
+### Walk exclusions
+
+The walk never traverses:
+
+- `.deps/` — dependencies are resolved through rule (4), not the walk
+- `.prose/` — runtime artifacts, not source
+- `.git/`, `node_modules/`, `.venv/`, `dist/`, `build/`, `target/` — conventional non-source directories
+- Any directory whose name begins with `_` — author convention for "ignore me" (mirrors many language toolchains)
+
+### Name uniqueness as convention
+
+Within a package, a component name is a unique identifier. Authors name components by purpose; Forme finds them. Multiple `.md` files in the walk matching the same name is a **hard error**:
+
+```
+[Error] Ambiguous component 'entity-resolver'
+  Found in package root ./customers/acme/:
+    - ./services/entity-resolver.md
+    - ./lib/enrichment/entity-resolver.md
+  Forme will not silently prefer one over the other.
+  Fix: rename one of them, or pin the intended file with an explicit 'path:' in the service entry.
+```
+
+This preserves tenet T2 ("do not add deterministic fallbacks or type systems to replace model judgment") — there is no "first wins" or "closer wins" rule that authors must remember.
+
+### Error messages
+
+"Component not found" lists every location checked. For the walk, it summarizes rather than enumerating every `.md` file scanned:
+
+```
+[Error] Component not found: 'pre-fundraise-radar'
+  Searched:
+    - ./pre-fundraise-radar.md
+    - ./pre-fundraise-radar/index.md
+    - package walk rooted at ./customers/prose-niural/ (47 .md files scanned, 0 matches)
+    - .deps/ (no matching path)
+  Entry point: customers/prose-niural/delivery/niural-pre-fundraise-daily.md
+
+  Hint: Forme expects 'pre-fundraise-radar' to be the frontmatter `name:` of
+  some .md file in the package. Verify the name or add a `path:` override.
+```
+
+### Manifest transparency
+
+The manifest already records each service's resolved source path. Authors debug resolution by reading the manifest (or running `prose lint`, which produces the same walk resolution). No silent behavior: the walk is reproducible and its output is inspectable.
+
+## Tenet Check
+
+| Tenet | Impact |
+|-------|--------|
+| **T2** (trust the model; no deterministic fallbacks) | **Strengthened.** The walk leans into the intelligent-container framing rather than requiring explicit configuration. Ambiguity is still a hard error, not a silent pick. |
+| **T7** (two things — component and container) | Preserved. No new component kind. Package root is a filesystem convention, not a new kind of thing. |
+| **T11** (interpreter-spec pattern) | Preserved. The walk algorithm lives in `forme.md`, expressed as prose. |
+| **T12** (Forme owns opinions about program structure) | **Strengthened.** Forme now has an opinion about package boundaries and name uniqueness, which is where the opinion belongs. |
+| **T16** (components don't discover each other; Forme discovers them) | **Strengthened.** Components never know anything about the filesystem layout. The package root marker is read only by Forme. |
+
+## Compatibility
+
+Fully backward compatible. Existing programs resolve identically because:
+
+- The current rules (1), (2), (4), (5) remain as-is.
+- The new walk rule (3) only fires when the current rules don't match. A flat program where every service is a sibling of the entry point still resolves in rule (1).
+- A program at the filesystem root (no marker above it) treats its own directory as the package root, so the walk searches only the flat directory — same as today.
+- No file layout becomes invalid.
+
+A program that today relies on a service being unresolvable (why would it?) could theoretically break if the walk now finds it. This is unlikely in practice; it would indicate the name had been chosen for something else in the tree and the program author did not realize.
+
+## Non-Goals
+
+- **Cross-package resolution via walks.** The walk stops at the package root. To reference a component in another package, install it as a dep or use `path:`. This keeps packages self-contained and predictable.
+- **Recursive package roots.** If two nested directories both carry package markers, the walk stops at the nearest (closest to the entry point). Authors who nest packages are explicitly declaring they want resolution bounded tighter.
+- **Glob patterns in `### Services`.** Services should still be named. The walk resolves names; it does not enumerate them.
+- **Name-mangling / auto-namespacing.** A collision within a package means the author needs to pick better names or use `path:`. Auto-prefixing with the directory name would make refactors silently change names.
+
+## Trade-offs
+
+**In favor:**
+
+- Zero per-program configuration. Conventional layouts just work.
+- Name uniqueness is a natural hygiene signal. Authors hit collisions early and fix them by clarifying intent.
+- Aligns tighter with the "trust the model" bet: more intelligence in the container, less configuration ritual.
+- Package boundary is explicit (the marker file) but lightweight (one file per project).
+
+**Against:**
+
+- Phase 1 cost is O(files-in-package). For a customer project with a few hundred `.md` files, the walk scans all of them on every `prose run` / `prose lint`. Still one-time-per-run and typically well under a second; can be cached if it ever becomes a hot path.
+- Collisions at scale — a project with 500+ components risks accidental name overlap. Mitigated by name-by-purpose discipline and the hard-error behavior (you find out immediately).
+- Requires a package root marker. Any author using `.prose/` (i.e., everyone who has ever run `prose run`) already has one; greenfield projects need to `mkdir .prose` or add `prose.lock` via `prose install`. This is a one-time setup cost.
+
+## Worked Example
+
+### Before (current spec — cannot wire)
+
+```
+customers/prose-niural/
+  .prose/                                      # package root marker
+  delivery/
+    niural-pre-fundraise-daily.md              # kind: program
+  responsibilities/
+    pre-fundraise-radar.md                     # kind: program
+  services/
+    entity-resolver.md                         # kind: service
+    fusion-scorer.md
+    outbound-drafter.md
+    same-day-news-backstop.md
+    firehose/
+      form-d-daily.md
+      first-cfo-hire-daily.md
+      ch-sh01-cluster-daily.md
+```
+
+Running `prose lint` on `delivery/niural-pre-fundraise-daily.md` today:
+
+```
+[Error] Component not found: 'pre-fundraise-radar'
+  Searched:
+    - ./pre-fundraise-radar.md
+    - ./pre-fundraise-radar/index.md
+    - .deps/ (no matching path)
+```
+
+### After (with package walk)
+
+No changes to the files. Same layout. Same `### Services` lists.
+
+```markdown
+---
+name: niural-pre-fundraise-daily
+kind: program
+---
+
+### Services
+
+- `pre-fundraise-radar`
+```
+
+Forme walks the package rooted at `customers/prose-niural/` (marked by `.prose/`), scans `.md` files, finds `responsibilities/pre-fundraise-radar.md` with frontmatter `name: pre-fundraise-radar`, resolves. The sub-program's `### Services` then resolves `entity-resolver`, `fusion-scorer`, etc. via the same walk.
+
+Authors organize files however they want; names are the contract.
+
+## Spec Changes
+
+This RFC corresponds to a single edit in `skills/open-prose/forme.md` §Step 2:
+
+1. Rewrite the **Resolution order** from 4 items to 5, inserting the package-bounded walk as item (3).
+2. Add a new subsection **Package root and walk scope** documenting the marker files, walk exclusions, and name-matching rules.
+3. Add a new subsection **Explicit paths** documenting the `path:` field on structured service entries.
+4. Extend the "Component not found" error example to show the walk summary.
+5. Add an **Ambiguity across the package walk** error to the Errors table in §Step 6.
+
+The accompanying patch to `forme.md` is in the same pull request that opens this RFC.
+
+## Open Questions
+
+1. **Should any existing directory name in `std/` be added to the exclusion list?** Today `composites/`, `controls/`, `roles/`, etc. under `std/` are already reachable via `.deps/openprose/std/`. An author's own `customers/acme/composites/` should be walked. I don't think we need to exclude anything else, but worth flagging.
+
+2. **What about `kind: test` files?** They live alongside programs and have frontmatter `name:`. The walk currently finds them. They're never resolved as components (they're entry points), so this is fine. But if an author names a test the same as a service by accident, the hard-error surfaces it. Acceptable behavior or worth calling out?
+
+3. **Do we want a `.proseignore` file** analogous to `.gitignore`, for authors who want to exclude additional directories from the walk beyond the default exclusions? Probably not for V1 — the default exclusion list is already reasonable. Can be added later if real demand emerges.
+
+4. **Runtime fuzzy resolution.** Today's runtime agent sometimes finds components through grep/glob when Forme's Phase 1 fails. With this RFC, Phase 1 should succeed for all reasonable layouts — should we explicitly forbid the runtime fallback, making Phase 1 the single source of truth for resolution? I lean toward "yes" — one resolution algorithm, expressed in `forme.md`, full stop. But this is a runtime behavior change worth calling out.

--- a/skills/open-prose/forme.md
+++ b/skills/open-prose/forme.md
@@ -119,12 +119,35 @@ For each entry in `### Services`, locate the corresponding `.md` file:
 **Resolution order:**
 1. Same directory as the entry point: `./researcher.md`
 2. A subdirectory matching the name: `./researcher/index.md`
-3. `.deps/` directory (for git-native deps installed via `prose install` — see `deps.md`):
+3. **Package-bounded walk.** From the entry point, walk up the filesystem to the nearest ancestor directory carrying a package root marker. From that ancestor, recursively scan every `.md` file in the subtree (skipping excluded directories — see below). A file matches when its frontmatter `name:` equals the wanted name, or — if the file declares no `name:` frontmatter — when its filename stem matches.
+4. `.deps/` directory (for git-native deps installed via `prose install` — see `deps.md`):
    - Expand `std/` shorthand to `openprose/std/`
    - Map the service name to `.deps/{owner}/{repo}/{path}.md`
    - Example: `openprose/std/evals/inspector` → `.deps/openprose/std/evals/inspector.md`
    - Example: `alice/tools/formatter` → `.deps/alice/tools/formatter.md`
-4. Registry shorthand (if contains `/`): fetch from `https://p.prose.md/{path}` (compatibility path)
+5. Registry shorthand (if contains `/`): fetch from `https://p.prose.md/{path}` (compatibility path)
+
+A structured service entry may carry an explicit `path:` field. When present, `path:` is an absolute override — Forme resolves the entry directly against that path (relative to the program file) and skips all other rules above. Use `path:` for cross-package references or to force disambiguation when the package walk finds more than one match; the primary pattern remains plain name references resolved through the package walk.
+
+**Package root and walk scope:**
+
+The package root is the nearest ancestor directory (walking up from the entry point, inclusive) that contains any of:
+
+- `.prose/` — the runtime's workspace directory (created by the first `prose run`)
+- `prose.lock` — the dependency lockfile (created by `prose install`)
+
+If no ancestor carries a marker, the entry point's own directory is the package root. Single-file programs continue to work with no setup.
+
+The walk skips these directories wherever they appear in the subtree:
+
+- `.deps/` — dependencies are resolved through rule (4), not the walk
+- `.prose/` — runtime artifacts, not source
+- `.git/`, `node_modules/`, `.venv/`, `dist/`, `build/`, `target/` — conventional non-source directories
+- Any directory whose name begins with `_` — author convention for "ignore me"
+
+Within a package, a component name is a unique identifier. If two `.md` files in the walk resolve to the same name, Forme emits an **Ambiguity across the package walk** error (see §Step 6). Authors resolve the ambiguity by renaming one of the files or by pinning the intended file with an explicit `path:` in the service entry.
+
+The walk is bounded by the package — it never crosses into another package (a sibling tree with its own marker). Cross-package references use rule (4) (`.deps/`) or `path:`.
 
 **Composite resolution:**
 
@@ -136,15 +159,19 @@ When a resolved component has `kind: program` (with its own `### Services` secti
 
 **Composite slot resolution:** Services named in `with:` blocks of `compose:` declarations are resolved using the same rules as top-level services, even if not listed separately in `### Services`. This means a program can declare only the composed unit in `### Services` — the slot-filling services will be resolved from the `with:` entries automatically.
 
-If a component cannot be resolved, emit an error:
+If a component cannot be resolved, emit an error that lists every location Forme checked. The package walk is summarized rather than enumerated:
 
 ```
 [Error] Component not found: 'researcher'
   Searched:
     - ./researcher.md
     - ./researcher/index.md
+    - package walk rooted at ./my-project/ (47 .md files scanned, 0 matches)
     - .deps/ (no matching path)
-  Entry point: ./program.md
+  Entry point: ./my-project/programs/report.md
+
+  Hint: Forme expects 'researcher' to be the frontmatter `name:` of some .md
+  file in the package. Verify the name or add a `path:` override.
 ```
 
 ### Step 3: Read Each Component's Contract
@@ -322,6 +349,7 @@ Before producing the manifest, check:
 |-------|-------|
 | Circular dependency | `[Error] Circular dependency: A → B → C → A` |
 | Missing component file | `[Error] Component not found: 'missing-service'` |
+| Ambiguity across the package walk | `[Error] Ambiguous component 'entity-resolver' — found at ./services/entity-resolver.md and ./lib/enrichment/entity-resolver.md in package rooted at ./customers/acme/. Rename one, or pin the intended file with an explicit 'path:' in the service entry.` |
 | Program has no `ensures` | `[Error] Program declares no ensures — nothing to produce` |
 | Component `requires` completely unresolvable | `[Error] No source for critic.requires.raw_data` |
 | Composite slot missing binding | `[Error] Composite worker-critic slot 'critic' has no binding and no default` |


### PR DESCRIPTION
## Summary

Adds a **package-bounded recursive walk** as Forme's resolution rule (3), between the entry point's own directory and `.deps/`. Authors organize files however they want; Forme finds components by name within the package.

- Full proposal and rationale: `rfcs/005-flexible-component-resolution.md`
- Spec patch: `skills/open-prose/forme.md` §Step 2

> **Note:** This PR was previously an `### Paths` explicit-declaration proposal (v1). Revised to a convention-based walk after review — the walk version is lighter on authors, aligns tighter with T2 ("trust the model") and T16 ("Forme does the discovery"), and requires no per-program boilerplate. The escape-hatch `path:` field on service entries stays.

## Why

Forme's current resolution is `./name.md` → `./name/index.md` → `.deps/` → registry. Works for flat trees and externalized-as-dep modules; does not accommodate the common layered shape that appears once a customer project grows past a handful of files:

```
customers/acme/
  responsibilities/     # orchestration programs
  services/             # leaf services
    firehose/           # categorized subdirectories
  delivery/             # cadence+channel wrappers
```

A delivery composite in `delivery/` that references a responsibility in `responsibilities/` (which delegates to services in `services/firehose/`) has no resolution path today. Authors work around this by flattening the tree, forcing `./name/index.md` subdirs, externalizing every module as a git dep, or relying on runtime fuzzy matching — all unsatisfying.

## What changes

**1. New resolution rule (3): package-bounded walk.** From the entry point, walk up to the nearest ancestor containing `.prose/` or `prose.lock` (the package root). Recursively scan every `.md` file in the subtree, matching by frontmatter `name:` (or filename stem if no `name:` frontmatter). Excludes `.deps/`, `.prose/`, `.git/`, `node_modules/`, `.venv/`, `dist/`, `build/`, `target/`, and any `_`-prefixed directory.

**2. Structured `path:` field on service entries.** Escape hatch for cross-package references or forced disambiguation. `path:` is an absolute override — skips all other resolution rules.

**3. Ambiguity across the walk is a hard error.** Two `.md` files with the same name in one package fails loudly, listing both paths. No silent "first wins." Authors resolve by renaming or pinning with `path:`.

## Convention

Within a package, a component name is a unique identifier. Pick a name that reflects purpose; Forme finds the file. Zero per-program configuration.

## Tenet check

- **T2** (trust the model; no deterministic fallbacks) — **strengthened.** The walk leans into the intelligent-container framing. Ambiguity is still a hard error.
- **T7** (two things — component and container) — preserved. No new component kind.
- **T11** (interpreter-spec pattern) — preserved. Walk algorithm lives in `forme.md`.
- **T12** (Forme owns opinions about program structure) — **strengthened.** Package boundary and name uniqueness are Forme's opinions, expressed where they belong.
- **T16** (components don't discover each other) — **strengthened.** Only Forme reads the package marker. Components never know anything about the filesystem.

## Compatibility

Fully backward compatible. Existing rules (1), (2), (4), (5) are unchanged. The walk rule (3) only fires when (1) and (2) don't match. Flat programs continue to resolve identically.

## Trade-offs

**In favor:** zero per-program boilerplate, convention-over-configuration aligns with the "intelligent container" bet, name collisions surface as healthy early signals.

**Against:** Phase 1 cost is O(files-in-package) — typically hundreds of `.md` files, well under a second; collisions at scale (500+ components) require naming discipline; greenfield projects need a package marker (`.prose/` or `prose.lock`), a one-time setup cost.

## Open questions (also listed in the RFC)

1. Any `std/`-relative names we should exclude from the walk explicitly? (Today they're reachable via `.deps/openprose/std/`.)
2. `kind: test` files — the walk finds them by name. Acceptable or worth calling out?
3. `.proseignore` file for author-level additions to the exclusion list? My lean: not in V1.
4. Should this RFC explicitly forbid runtime fuzzy fallback, making Phase 1 the single source of truth for resolution? My lean: yes.

## Test plan

- [ ] Review the walk semantics against the tenets — are there workflow shapes this breaks?
- [ ] Sanity-check the exclusion list — anything missing, or too aggressive?
- [ ] Walk through the Niural example (in the RFC) — does resolution land where expected?
- [ ] Consider performance at 1000+ `.md` package size (probably fine for Phase 1; worth flagging if ever a hot path)
- [ ] Confirm no conflict with `contract-markdown.md` or `deps.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)