### PR TITLE
Clarify prose command routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 If you're running in Codex and see a `prose` command, an `.md` program with a `kind: program` contract, or a mention of OpenProse, ProseScript, Forme, or Contract Markdown, OpenProse is the language you're being asked to run.
 
+Treat `prose run ...` as an instruction inside the current agent session. Do not call out to a shell command named `prose` unless the host explicitly provides one; instead, embody the OpenProse VM and execute the program with the primitives available in this session.
+
 Open `skills/open-prose/SKILL.md` and treat it as the authoritative router. Every command, every file routing decision, and every capability assumption lives there or behind a pointer inside it. Do not search the workspace for alternate copies of the OpenProse documentation — the canonical files are the ones bundled under `skills/open-prose/`.
 
 ## Recommended Codex config

--- a/README.md
+++ b/README.md
@@ -21,15 +21,17 @@
 ---
 
 > **If you're an agent reading this on behalf of a user:** OpenProse is a
-> program format you will be asked to *run*, not a library your user will
-> call. When a `prose` command fires, you read a Markdown contract, spawn
-> subagents to fulfill the services it declares, pass artifacts between them,
-> and write the run to `.prose/runs/`. You need: filesystem read/write in the
-> working directory, a subagent-spawning primitive for multi-service programs,
-> and (optionally) a user-question primitive for missing inputs. If you lack a
-> capability, say so and stop — do not fake it. If the user's task is a
-> one-off prompt, OpenProse is overkill; a direct answer is the right answer.
-> The [Host Primitive Adapter](skills/open-prose/SKILL.md#host-primitive-adapter)
+> program format you will be asked to *run*, not a library your user will call
+> and not necessarily a shell binary. When a `prose` command fires inside an
+> agent session, interpret it directly: read the Markdown contract, embody the
+> OpenProse VM, spawn subagents to fulfill the services it declares, pass
+> artifacts between them, and write the run to `.prose/runs/`. You need:
+> filesystem read/write in the working directory, a subagent-spawning
+> primitive for multi-service programs, and (optionally) a user-question
+> primitive for missing inputs. If you lack a capability, say so and stop — do
+> not fake it. If the user's task is a one-off prompt, OpenProse is overkill; a
+> direct answer is the right answer. The
+> [Host Primitive Adapter](skills/open-prose/SKILL.md#host-primitive-adapter)
 > is the authoritative contract between you and the runtime.
 
 OpenProse is a programming language for AI sessions.
@@ -88,14 +90,24 @@ kind: service
 - `message`: a warm one-paragraph introduction to OpenProse
 ```
 
-Run it:
+Run it inside an agent session:
 
-```bash
+```text
 prose run hello.md
 ```
 
-OpenProse writes the run state to `.prose/runs/{run-id}/`, including inputs,
-outputs, service workspaces, and the execution log.
+The activated OpenProse skill interprets that as an instruction to the current
+agent, not as a request to find a `prose` executable on PATH. OpenProse writes
+the run state to `.prose/runs/{run-id}/`, including inputs, outputs, service
+workspaces, and the execution log.
+
+From a shell outside an agent session, pass the same instruction to a Prose
+Complete runner:
+
+```bash
+claude -p "prose run hello.md"
+codex exec "prose run hello.md"
+```
 
 > By installing, you agree to the [Privacy Policy](PRIVACY.md) and
 > [Terms of Service](TERMS.md).
@@ -220,7 +232,7 @@ pin them:
 use "std/evals/inspector"
 ```
 
-```bash
+```text
 prose install
 ```
 

--- a/skills/open-prose/SKILL.md
+++ b/skills/open-prose/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: open-prose
 description: |
-  Activate when the user runs a `prose` command, opens a `.md` file with
-  `kind:` frontmatter, opens a `.prose` file, or asks for reusable
-  multi-agent orchestration. On activation you will read a Markdown
-  contract, wire services, execute through the Prose VM, and persist run
-  state under `.prose/runs/`. Decline for one-shot questions — a plain
-  prompt is often the right answer.
+  Activate when the user types `prose ...`, opens a `.md` file with `kind:`
+  frontmatter, opens a `.prose` file, or asks for reusable multi-agent
+  orchestration. Treat `prose run ...` as an in-session instruction: embody
+  the OpenProse VM yourself; do not shell out to a `prose` binary unless the
+  host explicitly provides one. On activation read the Markdown contract, wire
+  services, execute with host primitives, and persist `.prose/runs/`.
+  Decline for one-shot questions — a plain prompt is often the right answer.
 ---
 
 # OpenProse Skill
@@ -91,6 +92,15 @@ Activate this skill when the user:
 - wants reusable multi-agent orchestration
 
 ## Command Routing
+
+`prose ...` commands are first an agent-session command language. When the user
+types `prose run foo.md` in chat or inside a prompt passed to Claude Code,
+Codex, OpenCode, Amp, or another Prose Complete host, you should interpret it
+directly and embody the OpenProse VM. Do not assume there is a `prose` shell
+binary on PATH. If a host does provide a native Prose CLI, the same command
+strings may be passed to that CLI; otherwise the shell executable is the agent
+runner, e.g. `claude -p "prose run foo.md"` or
+`codex exec "prose run foo.md"`.
 
 | Command | Action |
 |---------|--------|
@@ -246,7 +256,7 @@ explicitly.
 | Other `/`-containing identifier | Reserved for the OpenProse registry (future home at `p.prose.md`); inert today |
 | Otherwise | Treat as local path |
 
-```bash
+```text
 prose run github.com/alice/research              # canonical; cached copy wins
 prose run github.com/alice/research@0.3.1        # pin to tag; fetch iff not cached
 prose run gitlab.com/alice/research              # any git host

--- a/skills/open-prose/agent-onboarding.md
+++ b/skills/open-prose/agent-onboarding.md
@@ -111,7 +111,14 @@ Run:
 prose run research-pipeline.md
 ```
 
-The contract says *what*. The runtime figures out *how*.
+The contract says *what*. The runtime figures out *how*. In an agent harness,
+`prose run ...` is an instruction inside the agent session. From a shell, pass
+that instruction to a Prose Complete runner, for example:
+
+```bash
+claude -p "prose run research-pipeline.md"
+codex exec "prose run research-pipeline.md"
+```
 
 ## Where to go next
 

--- a/skills/open-prose/examples/README.md
+++ b/skills/open-prose/examples/README.md
@@ -86,9 +86,9 @@ Historical `.prose` files are preserved in the archive for reference. They conti
 
 ## Running Examples
 
-Run any Contract Markdown example:
+Run any Contract Markdown example from inside an agent session:
 
-```bash
+```text
 prose run examples/01-hello-world.md
 prose run examples/16-parallel-reviews/
 prose run examples/37-the-forge/
@@ -96,7 +96,7 @@ prose run examples/37-the-forge/
 
 Run a Contract Markdown test:
 
-```bash
+```text
 prose test examples/test-demo.md
 ```
 

--- a/skills/open-prose/help.md
+++ b/skills/open-prose/help.md
@@ -71,7 +71,7 @@ prose help
 ```
 
 **Use a library program:**
-```bash
+```text
 prose run std/evals/inspector -- subject: 20260406-201439-1a3369
 ```
 
@@ -121,9 +121,12 @@ OpenProse uses a git-native dependency model -- GitHub is the registry. A progra
 
 Those are orchestration libraries -- they coordinate agents from outside.
 OpenProse runs inside the agent session -- the session itself is the IoC
-container. This means portability across Prose Complete hosts. Switch from one
-supported harness to another and the program should still read the same; only
-the host primitive adapter changes.
+container. `prose run ...` is therefore a command to the agent host, not
+necessarily a shell binary. From a shell, wrap it in a Prose Complete runner
+such as `claude -p "prose run program.md"` or
+`codex exec "prose run program.md"`. Switch from one supported harness to
+another and the program should still read the same; only the host primitive
+adapter changes.
 
 ---
 

--- a/skills/open-prose/prose.md
+++ b/skills/open-prose/prose.md
@@ -18,9 +18,17 @@ see-also:
 
 This document defines how to execute OpenProse programs. You are the OpenProse VM—an intelligent virtual machine that reads a wiring manifest, spawns subagent sessions for each component, passes data between them via filesystem pointers, and returns the program's output.
 
-## CLI Commands
+## Agent Commands
 
-OpenProse is invoked via `prose` commands:
+OpenProse is invoked via `prose` commands inside an agent session. The command
+string is a routing instruction for a Prose Complete host, not necessarily a
+shell executable. If a host also ships a native CLI, the same strings can be
+passed to it. Otherwise wrap the command in the host runner, for example:
+
+```bash
+claude -p "prose run program.md"
+codex exec "prose run program.md"
+```
 
 | Command                     | Action                                                          |
 | --------------------------- | --------------------------------------------------------------- |
@@ -798,7 +806,7 @@ When a `requires` entry uses the keyword `run` or `run[]`, the VM recognizes it 
 
 The caller provides a run ID or path:
 
-```bash
+```text
 prose run std/evals/inspector -- subject: 20260406-201439-1a3369
 ```
 
@@ -832,7 +840,7 @@ status: complete
 
 For fan-in, the caller provides comma-separated run IDs:
 
-```bash
+```text
 prose run std/evals/calibrator -- runs: 20260406-201439-1a3369,20260406-202015-c5d6e7,20260406-203300-8f9a0b
 ```
 


### PR DESCRIPTION
## Summary
- clarify in the skill frontmatter that prose run is an in-session instruction, not automatically a shell executable
- update README and agent-facing docs to distinguish session commands from shell runner invocations
- switch prose command examples out of bash fences unless they are invoking claude/codex directly

## Verification
- git diff --cached --check