### PR TITLE
Migrate std and co into packages/ monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
   <a href="skills/open-prose/SKILL.md">Docs</a> |
   <a href="skills/open-prose/examples/">Examples</a> |
   <a href="skills/open-prose/contract-markdown.md">Spec</a> |
-  <a href="https://github.com/openprose/std">Stdlib</a>
+  <a href="packages/std/">Stdlib</a> |
+  <a href="packages/co/">Company-as-Prose</a>
 </p>
 
 <p align="center">
@@ -220,17 +221,25 @@ Start with:
 | [39-architect-by-simulation](skills/open-prose/examples/39-architect-by-simulation/) | Pinned ProseScript choreography |
 | [47-language-self-improvement](skills/open-prose/examples/47-language-self-improvement/) | OpenProse improving OpenProse |
 
-## Standard Library
+## Libraries
 
-The standard library lives in
-[`openprose/std`](https://github.com/openprose/std), not this repository.
+Two first-party libraries ship in this repository under [`packages/`](packages/):
 
-Reference std programs with `std/...` or `openprose/std/...`, then install and
-pin them:
+- **[`packages/std/`](packages/std/)** — use-case-agnostic primitives: evals,
+  roles, controls, composites, delivery adapters, memory, ops.
+- **[`packages/co/`](packages/co/)** — company-as-prose: opinionated starter
+  patterns for running an operating company as Prose programs.
+
+Reference them with the `std/` and `co/` shorthands, then install and pin:
 
 ```markdown
 use "std/evals/inspector"
+use "co/programs/company-repo-checker"
 ```
+
+Both shorthands expand to paths inside this repo (`packages/std/...` and
+`packages/co/...`). `prose install` clones this repository into
+`.deps/github.com/openprose/prose/` and pins the SHA in `prose.lock`.
 
 ```text
 prose install

--- a/packages/co/README.md
+++ b/packages/co/README.md
@@ -1,0 +1,79 @@
+# co — Company as Prose
+
+Reusable starter contracts for organizing an operating company as an
+OpenProse-native repository.
+
+`co` sits next to `std` under `packages/`, not inside it. `std` is the
+low-level standard library: roles, controls, delivery adapters, memory, evals,
+and ops primitives. `co` is an opinionated starter kit for a specific domain:
+a company whose operating system is made of Prose programs.
+
+Reference programs in `co` with the `co/` shorthand (analogous to `std/`):
+
+```markdown
+use "co/programs/company-repo-checker"
+```
+
+Which expands to `github.com/openprose/prose/packages/co/programs/company-repo-checker`.
+
+## Package Shape
+
+```text
+packages/co/
+  README.md
+  programs/
+    company-repo-checker.md
+  evals/
+    company-repo-checker.eval.md
+```
+
+Future additions should help a new company get started without copying
+OpenProse, Inc.'s private business logic:
+
+- starter repository architecture
+- company system map
+- native repo checker
+- customer package checker
+- eval ladder
+- fixture and run-replay conventions
+- onboarding workflow for the first operating responsibilities
+
+## std vs co — the split
+
+- **std** — use-case-agnostic primitives. Inspector, contract-grader, retry,
+  fan-out, worker-critic, human-gate. Things that make *prose programs work*.
+- **co** — company-operations-shaped patterns. Starter repo checkers,
+  scheduled intake, windowed analytics, GTM pipelines, fleet monitors.
+  Things that make *prose programs produce business value*.
+
+## Running Programs
+
+`prose run` is an agent-session command. It is not assumed to be a shell binary.
+If a host provides a native Prose CLI, use it. Otherwise wrap the command in an
+agent runner that has the OpenProse skill loaded.
+
+Claude Code:
+
+```bash
+claude -p "prose run co/programs/company-repo-checker --repo_path customers/prose-openprose"
+```
+
+Codex:
+
+```bash
+codex exec -C <workspace-root> "prose run co/programs/company-repo-checker --repo_path customers/prose-openprose"
+```
+
+The shell executable is `claude` or `codex`. The `prose run ...` string is the
+instruction the agent session interprets as the OpenProse VM.
+
+## Design Notes
+
+- Keep this package generic. Do not include OpenProse, Inc. leads, accounts,
+  GTM logic, release logic, or private operating assumptions.
+- Prefer composable programs with inline starter components until a component
+  earns a stable public API.
+- Put universal primitives in `std/`; put company-operating-system patterns
+  here.
+- Keep generated runtime state out of this package. Useful lessons can become
+  docs, fixtures, or evals.

--- a/packages/co/evals/company-repo-checker.eval.md
+++ b/packages/co/evals/company-repo-checker.eval.md
@@ -1,0 +1,74 @@
+---
+name: company-repo-checker.eval
+kind: test
+subject: company-repo-checker
+tier: responsibility
+contract_version: v1
+---
+
+
+# Company Repo Checker — Responsibility Eval
+
+Protects the reusable company-as-prose repository gate.
+
+### Fixtures
+
+- fixture: current_openprose_company_repo
+  repo_path: customers/prose-openprose
+  expected_result: pass
+- fixture: stale_workflow_tier
+  mutation: change any workflow eval frontmatter from `tier: workflow` to
+    `tier: delivery`
+  expected_result: fail
+- fixture: unresolved_service_reference
+  mutation: add `missing-capability` to any `### Services` list
+  expected_result: fail
+- fixture: shared_depends_on_system_private
+  mutation: make a `shared/` capability depend on a `systems/*/services/*`
+    component that is not promoted to shared
+  expected_result: fail
+
+### Expects
+
+- path: report.source_layout
+  predicate: checks_legacy_roots(legacy_roots)
+- path: report.contract_surface
+  predicate: every_program_or_service_has(["Requires","Ensures"])
+- path: report.eval_pairing
+  predicate: every_program_or_service_has_eval_subject
+- path: report.eval_metadata
+  predicate: every_eval_has(["subject","tier","contract_version","Expects","Expects Not","Performance Tracked Over Time"])
+- path: report.dependency_graph
+  predicate: all_services_entries_resolve_to_component_or_explicit_external_reference
+- path: report.counts
+  predicate: includes(["executable_components","evals","dependency_edges"])
+
+### Expects Not
+
+- path: failures[*]
+  predicate: no_false_positive_from_h1_or_description_text_after("### Services")
+- path: failures[*]
+  predicate: no_requirement_to_migrate(".prose/runs") during default scope
+- path: failures[*]
+  predicate: no_requirement_to_migrate("customers/*") during default scope
+- path: execution
+  predicate: no_repo_local_python_or_bash_script_required
+- path: report.dependency_graph
+  predicate: no_shared_component_depends_on_system_private_source
+- path: report.eval_metadata
+  predicate: no_tier("delivery")
+
+### Performance Tracked Over Time
+
+- metric: static_gate_runtime_seconds
+  source: OpenProse run telemetry
+  direction: down
+  alert_when: p95 > 5s
+- metric: false_positive_rate
+  source: human triage of failed repo-checker runs
+  direction: down
+  alert_when: more than 1 false positive in a rolling 10 runs
+- metric: architecture_regression_count
+  source: failed checks grouped by failure kind
+  direction: down
+  alert_when: any regression reaches main

--- a/packages/co/programs/company-repo-checker.md
+++ b/packages/co/programs/company-repo-checker.md
@@ -1,0 +1,216 @@
+---
+name: company-repo-checker
+kind: program
+---
+
+
+### Services
+
+- `repo-structure-inspector`
+- `contract-eval-drift-inspector`
+- `dependency-graph-inspector`
+- `repo-readiness-reporter`
+
+
+# Company Repo Checker
+
+Ensures a company-as-prose repository is still organized as an OpenProse-native
+package before runtime evals or fleet monitors do more expensive work.
+
+This is a reusable public contract. It describes what a company-native repo
+should preserve; the agent host executing `prose run` supplies the concrete
+read/search operations.
+
+### Requires
+
+- `repo_path`: local path to the company-as-prose repository root
+- `source_roots`: optional list of source roots; default `["systems","shared"]`
+- `legacy_roots`: optional list of deprecated flat roots; default
+  `["responsibilities","services","delivery","evals","planning"]`
+- `ignored_roots`: optional list of roots ignored by the default check; default
+  `[".prose","customers"]`
+- `external_prefixes`: optional service-reference prefixes that are resolved
+  outside this package; default `["std/","github.com/","gitlab.com/"]`
+
+### Ensures
+
+- `report`: structured readiness report containing:
+    - `source_layout`: legacy source roots empty, source under declared roots
+    - `contract_surface`: executable components declare Requires and Ensures
+    - `eval_pairing`: every program or service has a paired eval subject
+    - `eval_metadata`: evals declare subject, tier, contract_version, Expects,
+      Expects Not, and Performance Tracked Over Time
+    - `dependency_graph`: Services references resolve and do not cross
+      system-private boundaries
+    - `counts`: executable component count, eval count, dependency edge count
+- `passed`: boolean true only when all hard failures are empty
+- `failures`: array of specific file-grounded failures, empty when passed
+
+### Strategies
+
+- inspect the repo as a bounded package walk rooted at `repo_path`
+- ignore `.prose/runs/` and nested customer packages unless explicitly asked;
+  runtime traces and customer packages have their own migration tracks
+- fail on stale architecture vocabulary when it affects executable metadata,
+  such as `kind: delivery` or `tier: delivery`
+- treat cross-system private dependencies as source ownership bugs; promote the
+  shared primitive or keep the helper local
+- produce file-grounded failures that a maintainer can act on directly
+- avoid quality scoring here; runtime fleet evals own probabilistic and
+  semantic judgments
+
+### Errors
+
+- `parse_failed`: a Contract Markdown file cannot be read or parsed
+- `unresolved_service`: a Services entry does not resolve in the package walk
+- `eval_drift`: a component lacks a paired eval or an eval subject does not
+  resolve
+- `source_layout_violation`: source appears under a deprecated flat root
+- `ownership_violation`: shared code depends on system-private code, or one
+  system depends directly on another system's private source
+
+### Execution
+
+```prose
+parallel:
+  let source_layout = call repo-structure-inspector
+    repo_path: repo_path
+    source_roots: source_roots
+    legacy_roots: legacy_roots
+    ignored_roots: ignored_roots
+
+  let contract_surface = call contract-eval-drift-inspector
+    repo_path: repo_path
+    source_roots: source_roots
+    ignored_roots: ignored_roots
+
+  let dependency_graph = call dependency-graph-inspector
+    repo_path: repo_path
+    source_roots: source_roots
+    ignored_roots: ignored_roots
+    external_prefixes: external_prefixes
+
+let report = call repo-readiness-reporter
+  source_layout: source_layout
+  contract_surface: contract_surface
+  dependency_graph: dependency_graph
+
+return report
+```
+
+
+## repo-structure-inspector
+
+### Requires
+
+- `repo_path`: local path to inspect
+- `source_roots`: source roots to treat as package-owned source
+- `legacy_roots`: deprecated roots that should not accumulate source files
+- `ignored_roots`: roots to skip in default scope
+
+### Ensures
+
+- `source_layout`: report with:
+    - `legacy_roots`: status for each deprecated root
+    - `source_roots`: status for each declared source root
+    - `stale_vocabulary`: file-grounded findings for source metadata that uses
+      obsolete executable vocabulary
+- `failures`: array of source layout violations
+
+### Strategies
+
+- use the package root as the boundary
+- allow historical migration maps in docs to mention old roots; fail only when
+  executable source or eval metadata reintroduces old roots or kinds
+- flag any committed source file under a deprecated flat root
+
+
+## contract-eval-drift-inspector
+
+### Requires
+
+- `repo_path`: local path to inspect
+- `source_roots`: source roots to treat as package-owned source
+- `ignored_roots`: roots to skip in default scope
+
+### Ensures
+
+- `contract_surface`: report with:
+    - `executable_components`: every top-level `kind: program` and
+      `kind: service` found under source roots
+    - `missing_contract_sections`: components missing `### Requires` or
+      `### Ensures`
+    - `eval_pairing`: paired eval subject status for each executable component
+    - `eval_metadata`: subject, tier, contract_version, Expects, Expects Not,
+      and Performance Tracked Over Time status for each eval
+    - `counts`: executable component count and eval count
+- `failures`: array of contract or eval drift violations
+
+### Strategies
+
+- parse Contract Markdown according to the OpenProse spec: frontmatter for
+  identity, `###` sections for contracts, `#` headings as human titles
+- treat `kind: service` plus `### Services` as a kind mismatch; the component
+  should be a program or inline components should be used
+- require workflow evals to use `tier: workflow`, not `tier: delivery`
+- require eval subjects to resolve to a component in the same system or shared
+  package
+- allow shared capabilities to use `tier: service`, `tier: responsibility`, or
+  `tier: capability` depending on the component's role
+
+
+## dependency-graph-inspector
+
+### Requires
+
+- `repo_path`: local path to inspect
+- `source_roots`: source roots to treat as package-owned source
+- `ignored_roots`: roots to skip in default scope
+- `external_prefixes`: service-reference prefixes resolved outside this package
+
+### Ensures
+
+- `dependency_graph`: report with:
+    - `component_names`: globally unique component names under source roots
+    - `edges`: resolved `### Services` dependency edges
+    - `unresolved`: service references that do not resolve by component name or
+      explicit external path
+    - `ownership_violations`: shared-to-system-private or
+      system-to-system-private dependencies
+    - `counts`: dependency edge count
+- `failures`: array of dependency graph violations
+
+### Strategies
+
+- resolve plain service names by component `name:` across the bounded package
+  walk
+- treat `std/...`, host-qualified dependency paths, explicit relative paths,
+  and explicit `.md` paths as external references rather than unresolved local
+  names
+- fail when a shared component depends on a system-private component
+- fail when one system depends directly on another system's private source
+- if a cross-system dependency is intentional, require promotion into shared or
+  an explicit path plus TODO naming the promotion condition
+
+
+## repo-readiness-reporter
+
+### Requires
+
+- `source_layout`: output from repo-structure-inspector
+- `contract_surface`: output from contract-eval-drift-inspector
+- `dependency_graph`: output from dependency-graph-inspector
+
+### Ensures
+
+- `report`: merged readiness report with sections for source_layout,
+  contract_surface, eval_pairing, eval_metadata, dependency_graph, and counts
+- `passed`: boolean true only when all failure arrays are empty
+- `failures`: concatenated file-grounded failures from all inspectors
+
+### Strategies
+
+- keep the summary short enough for CI or PR review
+- list failures before counts
+- preserve exact file paths and component names from inspector outputs
+- do not downgrade hard failures to warnings

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -1,0 +1,120 @@
+# OpenProse Standard Library
+
+Reusable Contract Markdown programs, services, composites, controls, roles, and memory agents for OpenProse.
+
+## Usage
+
+```prose
+use "std/evals/inspector"
+use "std/composites/worker-critic"
+use "std/controls/pipeline"
+use "std/roles/critic"
+use "std/delivery/email-notifier"
+use "std/memory/project-memory"
+```
+
+Install with `prose install`. `std/...` is the shorthand for `github.com/openprose/prose/packages/std/...`; see [deps.md](https://github.com/openprose/prose/blob/main/skills/open-prose/deps.md) for dependency resolution details.
+
+## Library
+
+All Markdown entries use the current Contract Markdown section form (`### Services`, `### Requires`, `### Ensures`, and related sections). The `.prose` memory entries are legacy ProseScript variants retained for compatibility.
+
+### evals/
+
+Programs for evaluating and improving OpenProse runs, contracts, and platform behavior.
+
+| Program | Purpose |
+|---------|---------|
+| `inspector` | Post-run analysis — runtime fidelity and task effectiveness |
+| `contract-grader` | Scores a program against its declared contract |
+| `regression-tracker` | Tracks quality regressions across runs |
+| `cross-run-differ` | Compares runs and recommends follow-up investigation |
+| `eval-calibrator` | Validates light evals against deep evals for reliability |
+| `program-improver` | Analyzes inspections and proposes program improvements |
+| `platform-improver` | Analyzes inspections and proposes platform/runtime improvements |
+
+### ops/
+
+Operational programs for profiling, debugging, validation, and wiring.
+
+| Program | Purpose |
+|---------|---------|
+| `lint` | Validate structure, schema, shapes, and contract consistency for a program and its service tree |
+| `preflight` | Check that all runtime dependencies are satisfied before executing a program |
+| `status` | Summarize recent runs from .prose/runs/ |
+| `wire` | Run Forme wiring to produce an execution manifest |
+| `diagnose` | Investigate failed or suspicious runs and propose fixes |
+| `profiler` | Cost, token usage, and time profiling for completed runs |
+
+### delivery/
+
+Services for delivering program outputs to humans and external systems.
+
+| Service | Purpose |
+|---------|---------|
+| `human-gate` | Present output for human review, block until approved or rejected |
+| `slack-notifier` | Format and deliver content to Slack via webhook or API |
+| `email-notifier` | Send an HTML email via a configured email provider (Resend, SendGrid, Postmark, SES, SMTP) |
+| `email-renderer` | Render structured report data into a branded, email-safe HTML string |
+| `html-renderer` | Render an HTML document from a template and structured data |
+| `webhook-notifier` | Deliver content to an HTTP endpoint via webhook |
+| `file-writer` | Write content to a local, S3, or GCS destination |
+
+### composites/
+
+Named multi-agent topology patterns (`kind: composite`) for reusable coordination shapes.
+
+| Pattern | Purpose |
+|---------|---------|
+| `worker-critic` | Two-agent loop: worker produces, critic evaluates, repeat until accepted |
+| `ensemble-synthesizer` | N-agent ensemble that independently solves then synthesizes into a consensus answer |
+| `ratchet` | Iterative improvement loop with regression prevention |
+| `dialectic` | Two-agent debate structure producing a synthesized conclusion |
+| `proposer-adversary` | Adversarial proposal testing: proposer generates, adversary stress-tests |
+| `oversight` | Actor-observer-arbiter structure for independent observation and decision |
+| `assumption-miner` | Surfaces implicit assumptions in a solution for explicit evaluation |
+| `blind-review` | Independent evaluation without exposure to other agents' assessments |
+| `contrastive-probe` | Generates contrasting solutions to expose decision boundaries |
+| `stochastic-probe` | Introduces controlled randomness to test solution robustness |
+| `coherence-probe` | Tests whether two corpora that should agree are actually in sync |
+
+### controls/
+
+Reusable flow-control composites for sequencing, distribution, guarding, retrying, and fallback.
+
+| Pattern | Purpose |
+|---------|---------|
+| `pipeline` | Sequential stage pipeline: output of each stage feeds the next |
+| `map-reduce` | Parallel fan-out across inputs followed by aggregation |
+| `fan-out` | Parallel delegation without reduction; parent consumes raw results |
+| `race` | Parallel speculative execution; first acceptable result wins |
+| `guard` | Conditional delegation: run target only when guard passes |
+| `refine` | Iterative improvement guided by an evaluator |
+| `fallback-chain` | Sequential failover through candidate delegates |
+| `retry-with-learning` | Retry loop that accumulates failure context to guide subsequent attempts |
+
+### roles/
+
+Single-agent role guides for programs and composites.
+
+| Role | Purpose |
+|---------|---------|
+| `classifier` | Classifies inputs into a fixed set of categories; returns structured label |
+| `critic` | Evaluates a proposed solution against criteria; returns scored feedback |
+| `extractor` | Extracts structured data from unstructured text; returns JSON |
+| `summarizer` | Condenses long content into a concise representation |
+| `verifier` | Checks a solution for correctness against known constraints or test cases |
+| `researcher` | Investigates a topic and produces sourced findings |
+| `writer` | Produces prose for a specified audience and purpose |
+| `planner` | Breaks an objective into ordered work with dependencies |
+| `router` | Routes an input to the right tool, role, or next step |
+| `formatter` | Transforms structured data into a target presentation format |
+
+### memory/
+
+Programs for persistent agent memory management.
+
+| Program | Purpose |
+|---------|---------|
+| `project-memory` | Project-scoped memory |
+| `user-memory` | Cross-project memory (user-scoped) |

--- a/packages/std/composites/README.md
+++ b/packages/std/composites/README.md
@@ -1,0 +1,119 @@
+---
+purpose: Named multi-agent topology patterns — the structural building blocks for Prose programs
+related:
+  - ../README.md
+  - ../controls/README.md
+  - ../roles/README.md
+  - ../../programs/README.md
+---
+
+# std/composites
+
+Composites are named multi-agent patterns (`kind: composite`). Each one defines a topology: which slots exist, how information flows between them, and what structural guarantee the pattern provides.
+
+## Two Categories
+
+### Structural Patterns
+
+These are the six core composites from the language spec (Section 2.4). They define how agents collaborate to produce a result.
+
+| Composite | Slots | What it does |
+|---|---|---|
+| `worker-critic` | worker, critic | Work, evaluate, retry until accepted |
+| `ensemble-synthesizer` | ensemble_member, synthesizer | K agents work independently, synthesizer merges by reasoning about disagreements |
+| `proposer-adversary` | proposer, adversary | One proposes, another attacks; the parent decides |
+| `dialectic` | thesis, antithesis | Argue positions across rounds; disagreement is the output |
+| `ratchet` | advancer, certifier | Advance and certify; certified progress is never rolled back |
+| `oversight` | actor, observer, arbiter | Actor acts, observer watches independently, arbiter decides next step |
+
+### Measurement Instruments
+
+These composites measure properties of artifacts — clarity, determinism, hidden assumptions, coherence. They produce diagnostic profiles, not final outputs.
+
+| Composite | Slots | What it measures |
+|---|---|---|
+| `blind-review` | reviewer, comparator | Cross-tier comprehension divergence (clarity vs. ambiguity vs. complexity) |
+| `stochastic-probe` | probe, analyst | Within-tier response variance (determinism of interpretation) |
+| `assumption-miner` | miner, comparator | Unstated dependencies, classified by visibility across capability tiers |
+| `coherence-probe` | reader, sync_analyst | Whether two corpora that should describe the same system actually agree |
+| `contrastive-probe` | measurement, ranker | Meta-composite: runs any measurement on two candidates, ranks which scores better |
+
+## Decision Matrix
+
+| You need to... | Use |
+|---|---|
+| Iteratively improve output with feedback | `worker-critic` |
+| Stress-test a proposal for flaws | `proposer-adversary` |
+| Explore a question from opposing sides | `dialectic` |
+| Reduce variance through independent attempts | `ensemble-synthesizer` |
+| Make incremental progress that never regresses | `ratchet` |
+| Separate execution from evaluation with independent observation | `oversight` |
+| Measure whether your writing is clear, complex, or ambiguous | `blind-review` |
+| Test whether material constrains interpretation or leaves it open | `stochastic-probe` |
+| Surface implicit assumptions in a document or design | `assumption-miner` |
+| Check if code and docs (or any two corpora) are in sync | `coherence-probe` |
+| Compare two candidates on any measured dimension | `contrastive-probe` |
+
+## The `&compositeState` Convention
+
+Every composite reads and writes `&compositeState`, a YAML anchor resolved at runtime to the object stored at `__compositeState`. This is how the parent program configures a composite: it writes slot assignments, task briefs, and options into `__compositeState`, then delegates to the composite, which reads its configuration from the same location and writes its results back.
+
+```yaml
+state:
+  reads: [&compositeState]
+  writes: [&compositeState]
+```
+
+The parent provides `__compositeState` with at minimum:
+- Slot assignments (which component fills each slot)
+- A `task_brief` (what to work on)
+- Composite-specific options (rounds, max_retries, tiers, etc.)
+
+The composite writes back:
+- `__compositeState.result` — the primary output
+- Any composite-specific secondary outputs (reviews, predictions, exchange history, etc.)
+
+## Using Composites
+
+### Level 1: `compose:` syntax
+
+Reference a composite by path and bind its slots with `with:`.
+
+```yaml
+services:
+  - name: reviewed-output
+    compose: std/composites/worker-critic
+    with:
+      worker: my-writer
+      critic: my-reviewer
+```
+
+### Level 2: Decorator syntax (primary-slot composites only)
+
+Composites that declare a **primary slot** support a shorthand where the decorated service fills the primary slot automatically. The remaining slots and config are passed inline.
+
+```yaml
+services:
+  - my-writer:
+      review: worker-critic(critic: my-reviewer, max_rounds: 3)
+```
+
+This is equivalent to the Level 1 form above — `my-writer` fills the primary `worker` slot.
+
+### Which syntax can I use?
+
+| Composite | Primary slot | Decorator eligible? |
+|---|---|---|
+| `worker-critic` | `worker` | Yes |
+| `ensemble-synthesizer` | `ensemble_member` | Yes |
+| `proposer-adversary` | `proposer` | Yes |
+| `ratchet` | `advancer` | Yes |
+| `oversight` | `actor` | Yes |
+| `dialectic` | *(none)* | No — use `compose:` |
+| `blind-review` | `reviewer` | Yes |
+| `stochastic-probe` | `probe` | Yes |
+| `assumption-miner` | `miner` | Yes |
+| `coherence-probe` | `reader` | Yes |
+| `contrastive-probe` | `measurement` | Yes |
+
+Composites without a primary slot (currently only `dialectic`) require the Level 1 `compose:` form because there is no single "main" service to decorate.

--- a/packages/std/composites/assumption-miner.md
+++ b/packages/std/composites/assumption-miner.md
@@ -1,0 +1,125 @@
+---
+name: assumption-miner
+kind: composite
+---
+
+# Assumption Miner
+
+Heterogeneous agents independently list what the material assumes but does not state. Cross-tier disagreement on assumptions reveals hidden dependencies.
+
+### Description
+
+Heterogeneous agents independently surface unstated assumptions; cross-tier disagreement reveals hidden dependencies.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `miner` (primary)
+  - requires: material, context
+  - ensures: assumptions
+- `comparator`
+  - requires: assumption_lists_by_tier
+  - ensures: classified_assumption_map
+
+### Config
+
+- `tiers` (object[], default: {'model': 'opus', 'count': 3}, {'model': 'sonnet', 'count': 2}): Miner configurations specifying model tier and count per tier
+- `material` (string, default: none): The corpus or artifact to examine for unstated assumptions
+- `context` (string, default: none): Optional domain context to help miners distinguish assumptions from common knowledge
+
+### Invariants
+
+- Each miner receives the same material and identical instructions
+- Miners work independently — no miner sees another's output
+
+### Shape
+
+- `self`: fan out to miners across tiers, collect assumption lists, delegate comparison
+- `delegates`:
+  - `miner`: list unstated assumptions in the material — run across tiers
+  - `comparator`: classify assumptions by agreement pattern across tiers
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    miner: string           -- component name for each miner
+    comparator: string      -- component name for the comparator
+    material: string        -- the corpus or artifact to examine
+    tiers: object[]         -- miner configurations, e.g. [{ model: "opus", count: 3 }, { model: "sonnet", count: 2 }]
+    context: string         -- (optional) domain context to help miners distinguish assumptions from common knowledge
+
+### Ensures
+
+- Each miner receives the same material and is asked: "What does this assume is true but not explicitly state?"
+- Miners work independently — no miner sees another's output
+- Comparator receives all assumption lists and classifies each assumption:
+  - Universal: surfaced by all tiers — a KNOWN implicit dependency (widely recognizable)
+  - Deep: surfaced only by higher tiers — a HIDDEN dependency (requires expertise to notice)
+  - Contested: agents disagree on whether it IS an assumption — may be a FALSE assumption or a point of genuine ambiguity about what the material presupposes
+  - Phantom: surfaced by lower tiers but not higher — likely a MISREADING, not an actual assumption
+- &compositeState.result contains the comparator's classified assumption map
+- &compositeState.raw_assumptions contains per-miner assumption lists
+
+### Delegation Loop
+
+```javascript
+const { miner, comparator, material, tiers, context } = __compositeState;
+
+// Build miner roster
+const roster = [];
+for (const tier of tiers) {
+  for (let i = 0; i < (tier.count || 1); i++) {
+    roster.push({ id: `${tier.model}-${i + 1}`, model: tier.model });
+  }
+}
+
+// Each miner independently extracts assumptions
+const rawAssumptions = {};
+for (const agent of roster) {
+  const brief = `Examine the following material carefully. List every assumption it makes but does not explicitly state — things that must be true for the material to be correct or coherent, but which are not written down.
+
+For each assumption, explain:
+- What is assumed
+- Where in the material this assumption is required
+- What would break if the assumption were false
+
+${context ? `Domain context: ${context}\n\n` : ""}Material:
+${material}`;
+
+  const assumptions = await rlm(brief, null, { use: miner, model: agent.model });
+  rawAssumptions[agent.id] = { model: agent.model, assumptions };
+}
+
+// Comparator classifies
+const comparatorBrief = `${roster.length} independent agents across ${tiers.length} capability tiers examined the same material and listed its unstated assumptions.
+
+Classify each unique assumption that was surfaced:
+- UNIVERSAL: surfaced by agents across all tiers — a widely recognizable implicit dependency
+- DEEP: surfaced only by higher-tier agents — a hidden dependency requiring expertise to notice
+- CONTESTED: agents disagree on whether this is actually an assumption — indicates ambiguity about what the material presupposes
+- PHANTOM: surfaced by lower tiers but not higher — likely a misreading rather than a real assumption
+
+For each assumption, note which agents surfaced it and at which tier.
+
+Assumption lists by tier:
+${tiers.map(tier => {
+  const tierAgents = roster.filter(a => a.model === tier.model);
+  return `\n=== ${tier.model.toUpperCase()} TIER ===\n${tierAgents.map(a =>
+    `--- ${a.id} ---\n${rawAssumptions[a.id].assumptions}`
+  ).join("\n\n")}`;
+}).join("\n")}`;
+
+const analysis = await rlm(comparatorBrief, null, { use: comparator });
+
+__compositeState.result = analysis;
+__compositeState.raw_assumptions = rawAssumptions;
+return(analysis);
+```
+
+### Notes
+
+This is a seed pattern. Miners do not know other miners exist. The comparator does not know it is part of an assumption miner composite. The key distinction from blind-review: blind-review asks "what does this say?" and measures comprehension. Assumption miner asks "what does this NOT say?" and measures implicit dependencies. A document can score perfectly clear on blind-review while harboring deep unstated assumptions that only the assumption miner surfaces. The most dangerous assumptions are the DEEP ones — dependencies that are real, load-bearing, and invisible to most readers.

--- a/packages/std/composites/blind-review.md
+++ b/packages/std/composites/blind-review.md
@@ -1,0 +1,142 @@
+---
+name: blind-review
+kind: composite
+---
+
+# Blind Review
+
+Heterogeneous reviewers build understanding progressively. Disagreement across capability tiers reveals ambiguity; agreement reveals clarity.
+
+### Description
+
+Heterogeneous reviewers build understanding progressively; cross-tier divergence diagnoses clarity, complexity, and ambiguity.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `reviewer` (primary)
+  - requires: task_brief, material
+  - ensures: report
+- `comparator`
+  - requires: staged_reports_by_tier
+  - ensures: analysis
+
+### Config
+
+- `tiers` (object[], default: {'model': 'opus', 'count': 3}, {'model': 'sonnet', 'count': 3}, {'model': 'haiku', 'count': 3}): Reviewer configurations specifying model tier and count per tier
+- `materials` (string[], default: none): Ordered list of materials to disclose progressively
+- `task_brief` (string, default: none): What reviewers should focus on when examining materials
+- `output_dir` (string, default: none): Optional directory for reviewer reports
+
+### Invariants
+
+- Reviewers are independent — no reviewer sees another's output
+- Materials are disclosed one at a time, in order, to each reviewer
+- Reviewers across different tiers receive identical materials and briefs
+
+### Shape
+
+- `self`: fan out to reviewers across tiers, feed material progressively, collect staged reports, delegate comparison
+- `delegates`:
+  - `reviewer`: examine material and report understanding — run once per tier per reviewer
+  - `comparator`: compare reports across tiers and stages, identify divergence
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    reviewer: string          -- component name for each reviewer
+    comparator: string        -- component name for the comparator
+    tiers: object[]           -- reviewer configurations, e.g. [{ model: "opus", count: 3 }, { model: "sonnet", count: 3 }, { model: "haiku", count: 3 }]
+    materials: string[]       -- ordered list of materials to disclose progressively (file paths, briefs, etc.)
+    task_brief: string        -- what reviewers should focus on (e.g. "describe what this system is and intends to do")
+    output_dir: string        -- (optional) directory for reviewer reports
+
+### Ensures
+
+- Reviewers are independent — no reviewer sees another's output
+- Materials are disclosed one at a time, in order — each reviewer reports understanding after each disclosure
+- Reviewers across different tiers receive identical materials and briefs
+- Comparator receives all staged reports grouped by material and by tier
+- Comparator identifies: agreement (clarity), disagreement (ambiguity), and tier-correlated divergence (complexity)
+- &compositeState.result contains the comparator's analysis
+- &compositeState.reviews contains the structured per-reviewer, per-stage reports
+- &compositeState.divergences contains points of disagreement with tier and stage metadata
+
+### Delegation Loop
+
+```javascript
+const { reviewer, comparator, tiers, materials, task_brief, output_dir } = __compositeState;
+
+// Build reviewer roster from tier specs
+const roster = [];
+for (const tier of tiers) {
+  for (let i = 0; i < (tier.count || 1); i++) {
+    roster.push({ id: `${tier.model}-${i + 1}`, model: tier.model });
+  }
+}
+
+// Progressive disclosure: each reviewer sees materials one at a time
+const reviews = {}; // reviews[reviewerId][stageIndex] = report
+
+for (const agent of roster) {
+  reviews[agent.id] = [];
+  let priorUnderstanding = "";
+
+  for (let stage = 0; stage < materials.length; stage++) {
+    const material = materials[stage];
+    const brief = stage === 0
+      ? `${task_brief}\n\nExamine ONLY the following material. Report your understanding as specifically as possible.\n\n${material}`
+      : `${task_brief}\n\nYour understanding so far:\n${priorUnderstanding}\n\nNow also examine this additional material. Report how your understanding has changed or deepened.\n\n${material}`;
+
+    const report = await rlm(brief, null, { use: reviewer, model: agent.model });
+    reviews[agent.id].push({ stage, material_ref: material, report });
+    priorUnderstanding = report;
+  }
+}
+
+// Comparator analyzes across tiers and stages
+const comparatorBrief = `${roster.length} independent reviewers across ${tiers.length} capability tiers examined the same materials progressively. Compare their reports.
+
+Identify:
+1. Points of AGREEMENT across all tiers (high clarity — the material communicates unambiguously)
+2. Points of DISAGREEMENT within a tier (noise — individual variation)
+3. Points of DISAGREEMENT across tiers (ambiguity or complexity — the material may be unclear)
+4. Understanding that only emerges at higher tiers (complexity that rewards capability)
+
+Task context: ${task_brief}
+
+Reviews by tier:
+${tiers.map(tier => {
+  const tierAgents = roster.filter(a => a.model === tier.model);
+  return `\n=== ${tier.model.toUpperCase()} TIER ===\n${tierAgents.map(a =>
+    `--- ${a.id} ---\n${reviews[a.id].map((r, i) =>
+      `[After material ${i + 1}]: ${r.report}`
+    ).join("\n")}`
+  ).join("\n\n")}`;
+}).join("\n")}`;
+
+const analysis = await rlm(comparatorBrief, null, { use: comparator });
+
+// Extract divergences
+__compositeState.result = analysis;
+__compositeState.reviews = reviews;
+return(analysis);
+```
+
+### Notes
+
+This is a seed pattern. Reviewers do not know other reviewers exist. The comparator does not know it is part of a blind review composite. The two structural innovations over a standard ensemble are:
+
+**Heterogeneous tiers.** The tier variation is not a cost-saving measure — it is the diagnostic instrument. Cross-tier response patterns produce three distinct diagnoses:
+
+- **Clear:** All tiers agree (including haiku). The material communicates unambiguously regardless of capability.
+- **Complex but unambiguous:** Higher tiers agree, lower tiers struggle or diverge. The material rewards capability but is not unclear — it is genuinely difficult.
+- **Ambiguous:** Agents within the same tier disagree with each other (especially at higher tiers). The material itself is unclear — more capability does not resolve the disagreement because the source of divergence is in the material, not the reader.
+
+**Progressive disclosure.** By feeding material incrementally and collecting reports at each stage, the orchestrator can identify exactly *which piece of material* introduces divergence. This turns a binary "agree/disagree" into a localized ambiguity map.
+
+The combination produces a diagnostic tool: run a blind review on your documentation, specification, or design, and the divergence pattern tells you where your communication is unclear, where it is merely complex, and where it is genuinely ambiguous.

--- a/packages/std/composites/coherence-probe.md
+++ b/packages/std/composites/coherence-probe.md
@@ -1,0 +1,143 @@
+---
+name: coherence-probe
+kind: composite
+---
+
+# Coherence Probe
+
+Two corpora that should describe the same system are read independently. Agents that read corpus A predict what corpus B should say, and vice versa. Where predictions fail, the corpora have drifted.
+
+### Description
+
+Detects drift between two corpora by having independent readers predict what the counterpart should say, then classifying where predictions fail.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `reader` (primary)
+  - requires: corpus, counterpart_label
+  - ensures: prediction
+- `sync_analyst`
+  - requires: predictions, actuals, labels
+  - ensures: bidirectional_drift_report
+
+### Config
+
+- `readers_per_direction` (number, default: 3): How many independent readers per direction (A→B and B→A)
+- `corpus_a` (string, default: none): First corpus to compare
+- `corpus_b` (string, default: none): Second corpus to compare
+- `label_a` (string, default: Corpus A): Human label for the first corpus
+- `label_b` (string, default: Corpus B): Human label for the second corpus
+
+### Invariants
+
+- Readers of corpus A never see corpus B, and vice versa
+- Analysis is bidirectional — A→B drift is a separate finding from B→A drift
+
+### Shape
+
+- `self`: assign readers to each corpus, collect predictions, compare predictions to actuals
+- `delegates`:
+  - `reader`: build understanding from one corpus, predict what the other should say
+  - `sync_analyst`: compare predictions to actuals in both directions, classify drift
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    reader: string            -- component name for reader agents
+    sync_analyst: string      -- component name for the sync analyst
+    corpus_a: string          -- first corpus (e.g. the code)
+    corpus_b: string          -- second corpus (e.g. the documentation)
+    label_a: string           -- (optional, default "Corpus A") human label for corpus A
+    label_b: string           -- (optional, default "Corpus B") human label for corpus B
+    readers_per_direction: number -- (optional, default 3) agents per direction
+
+### Ensures
+
+- Readers of corpus A never see corpus B, and vice versa
+- Each reader builds understanding from its assigned corpus, then predicts what the counterpart corpus should contain
+- Sync analyst receives predictions alongside actuals and classifies each discrepancy:
+  - Stale: corpus B once matched corpus A but has not been updated (common with docs)
+  - Undocumented: corpus A describes behavior that corpus B does not mention at all
+  - Contradictory: both corpora address the same topic but make incompatible claims
+  - Redundant divergence: both say the same thing differently — not a real drift, just style
+- Analysis is BIDIRECTIONAL — drift from A→B is a different finding than drift from B→A
+- &compositeState.result contains the sync analyst's bidirectional drift report
+- &compositeState.predictions contains raw predictions from both directions
+
+### Delegation Loop
+
+```javascript
+const {
+  reader, sync_analyst, corpus_a, corpus_b,
+  label_a = "Corpus A", label_b = "Corpus B",
+  readers_per_direction = 3
+} = __compositeState;
+
+const predictions = { a_predicts_b: [], b_predicts_a: [] };
+
+// Direction 1: readers of A predict B
+for (let i = 0; i < readers_per_direction; i++) {
+  const brief = `You are reading ${label_a}. Study it carefully, then predict what ${label_b} should contain if the two are in sync.
+
+${label_a}:
+${corpus_a}
+
+Based on your reading, describe what you expect ${label_b} to say. Be specific — list the claims, behaviors, interfaces, or rules you expect to find documented there.`;
+
+  const prediction = await rlm(brief, null, { use: reader });
+  predictions.a_predicts_b.push(prediction);
+}
+
+// Direction 2: readers of B predict A
+for (let i = 0; i < readers_per_direction; i++) {
+  const brief = `You are reading ${label_b}. Study it carefully, then predict what ${label_a} should contain if the two are in sync.
+
+${label_b}:
+${corpus_b}
+
+Based on your reading, describe what you expect ${label_a} to say. Be specific — list the claims, behaviors, interfaces, or rules you expect to find there.`;
+
+  const prediction = await rlm(brief, null, { use: reader });
+  predictions.b_predicts_a.push(prediction);
+}
+
+// Sync analyst compares predictions to actuals in both directions
+const analystBrief = `Two corpora — "${label_a}" and "${label_b}" — should describe the same system. Agents read one corpus and predicted what the other should contain. Compare their predictions to the actual content.
+
+=== DIRECTION 1: ${label_a} readers predict ${label_b} ===
+Predictions (what ${label_a} readers expect ${label_b} to say):
+${predictions.a_predicts_b.map((p, i) => `--- Reader ${i + 1} ---\n${p}`).join("\n\n")}
+
+Actual ${label_b}:
+${corpus_b}
+
+=== DIRECTION 2: ${label_b} readers predict ${label_a} ===
+Predictions (what ${label_b} readers expect ${label_a} to say):
+${predictions.b_predicts_a.map((p, i) => `--- Reader ${i + 1} ---\n${p}`).join("\n\n")}
+
+Actual ${label_a}:
+${corpus_a}
+
+For each discrepancy between prediction and actual, classify:
+- STALE: the prediction matches an older version of the actual — drift from a formerly-synced state
+- UNDOCUMENTED: one corpus describes something the other omits entirely
+- CONTRADICTORY: both address the same topic with incompatible claims
+- REDUNDANT DIVERGENCE: both say the same thing differently — style, not substance
+
+Report findings bidirectionally. "${label_a} says X but ${label_b} says Y" is a different finding from "${label_b} says Y but ${label_a} says X."`;
+
+const analysis = await rlm(analystBrief, null, { use: sync_analyst });
+
+__compositeState.result = analysis;
+__compositeState.predictions = predictions;
+return(analysis);
+```
+
+### Notes
+
+This is a seed pattern. Readers of one corpus never see the other — their predictions are based entirely on what they read. The sync analyst does not know it is part of a coherence probe. The structural insight is that *prediction failure is more informative than direct comparison*. A diff between two documents tells you they differ. A prediction failure tells you they differ *in ways that a reader of one would not expect given the other* — which is the meaningful kind of drift. Two documents can differ extensively in wording while remaining synchronized, and they can appear similar while harboring subtle contradictions. The prediction layer catches the latter.

--- a/packages/std/composites/contrastive-probe.md
+++ b/packages/std/composites/contrastive-probe.md
@@ -1,0 +1,130 @@
+---
+name: contrastive-probe
+kind: composite
+---
+
+# Contrastive Probe
+
+A meta-composite. Run any read-only measurement on two candidate artifacts, then rank which scores better on the measured dimension.
+
+### Description
+
+Runs any measurement composite on two candidates independently, then ranks which scores better on the measured dimension.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `measurement` (primary)
+  - requires: candidate_config
+  - ensures: diagnostic_profile
+- `ranker`
+  - requires: profile_a, profile_b, dimension
+  - ensures: verdict, magnitude, evidence
+
+### Config
+
+- `dimension` (string, default: none): The quality being compared (e.g. "clarity", "determinism", "assumption count")
+- `candidate_a` (string, default: none): First candidate configuration
+- `candidate_b` (string, default: none): Second candidate configuration
+- `label_a` (string, default: Candidate A): Human label for the first candidate
+- `label_b` (string, default: Candidate B): Human label for the second candidate
+
+### Invariants
+
+- The same measurement composite runs on both candidates
+- Candidates are measured in isolation — measurement of A does not influence B
+
+### Shape
+
+- `self`: run the same measurement composite on candidate A and candidate B, delegate ranking
+- `delegates`:
+  - `measurement`: any read-only measurement composite — blind-review, stochastic-probe, assumption-miner, etc.
+  - `ranker`: given two diagnostic profiles, determine which candidate is superior on the measured dimension
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    measurement: string       -- component name for the measurement composite to use
+    ranker: string            -- component name for the ranker
+    candidate_a: object       -- compositeState config for measuring candidate A (passed to measurement composite)
+    candidate_b: object       -- compositeState config for measuring candidate B (passed to measurement composite)
+    label_a: string           -- (optional, default "Candidate A")
+    label_b: string           -- (optional, default "Candidate B")
+    dimension: string         -- what is being compared (e.g. "clarity", "determinism", "assumption count")
+
+### Ensures
+
+- The same measurement composite runs independently on both candidates
+- Candidates are measured in isolation — the measurement of A does not influence B
+- Ranker receives both diagnostic profiles and the dimension to judge
+- Ranker determines:
+  - Which candidate scores better on the specified dimension
+  - By how much (qualitative magnitude: marginal, clear, decisive)
+  - What specifically makes one better than the other
+- &compositeState.result contains the ranker's verdict
+- &compositeState.profile_a contains candidate A's measurement result
+- &compositeState.profile_b contains candidate B's measurement result
+
+### Delegation Loop
+
+```javascript
+const {
+  measurement, ranker,
+  candidate_a, candidate_b,
+  label_a = "Candidate A", label_b = "Candidate B",
+  dimension
+} = __compositeState;
+
+// Run measurement on candidate A
+const profileA = await rlm(null, null, {
+  use: measurement,
+  compositeState: candidate_a
+});
+
+// Run measurement on candidate B
+const profileB = await rlm(null, null, {
+  use: measurement,
+  compositeState: candidate_b
+});
+
+// Ranker compares
+const rankerBrief = `Two candidates were measured on the same dimension using the same diagnostic instrument.
+
+Dimension: ${dimension}
+
+=== ${label_a.toUpperCase()} — Diagnostic Profile ===
+${JSON.stringify(profileA, null, 2)}
+
+=== ${label_b.toUpperCase()} — Diagnostic Profile ===
+${JSON.stringify(profileB, null, 2)}
+
+Determine:
+1. Which candidate scores BETTER on "${dimension}"?
+2. By how much? (marginal / clear / decisive)
+3. What specifically makes one better? (cite evidence from the profiles)
+4. Are there sub-dimensions where the losing candidate is actually superior?`;
+
+const verdict = await rlm(rankerBrief, null, { use: ranker });
+
+__compositeState.result = verdict;
+__compositeState.profile_a = profileA;
+__compositeState.profile_b = profileB;
+return(verdict);
+```
+
+### Notes
+
+This is a seed pattern and a meta-composite — it composes over other measurement composites rather than implementing its own measurement logic. The ranker does not know it is part of a contrastive probe. The measurement composite does not know it is being used comparatively.
+
+The value is in making qualitative comparisons empirical. "Which of these two prompts is clearer?" is a subjective question. "Which of these two prompts produces a higher cross-tier agreement score on blind-review?" is a measurable one. Contrastive probe turns any measurement composite into a comparator, enabling:
+
+- **Prompt A/B testing**: which prompt is more deterministic (via stochastic-probe)?
+- **Documentation quality comparison**: which version is clearer (via blind-review)?
+- **API surface ranking**: which interface has fewer hidden assumptions (via assumption-miner)?
+- **Vendor evaluation**: which provider's documentation drifts less from their actual API behavior (via coherence-probe)?
+
+The meta-composite pattern also means new measurement composites automatically become available as contrastive dimensions without any additional work.

--- a/packages/std/composites/dialectic.md
+++ b/packages/std/composites/dialectic.md
@@ -1,0 +1,93 @@
+---
+name: dialectic
+kind: composite
+---
+
+# Dialectic
+
+Thesis and antithesis argue positions. Disagreement IS the output.
+
+### Description
+
+Thesis and antithesis argue opposing positions; the unresolved tension is the output.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `thesis`
+  - requires: task_brief, prior antithesis argument (if not first round)
+  - ensures: argument for the position
+- `antithesis`
+  - requires: task_brief, prior thesis argument
+  - ensures: argument against the position
+
+### Config
+
+- `task_brief` (string, default: none): The question or topic for debate
+- `rounds` (integer, default: 2): Number of exchange rounds
+
+### Invariants
+
+- Neither agent knows it is part of a dialectic
+- The full exchange is the output — the composite never resolves the tension
+- Each agent sees only the other's prior argument, not its reasoning
+
+### Shape
+
+- `self`: manage argument rounds, pass each agent the other's prior argument
+- `delegates`:
+  - `thesis`: argue for a position
+  - `antithesis`: argue against it
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    thesis: string        -- component name for thesis agent
+    antithesis: string    -- component name for antithesis agent
+    task_brief: string    -- the question or proposition to argue
+    rounds: number        -- (optional, default 2)
+
+### Ensures
+
+- Round 1: thesis argues first, antithesis responds
+- Subsequent rounds: each agent sees the other's prior argument
+- This composite does NOT resolve the tension — the full exchange is the output
+- The parent extracts insight from the tension
+- &compositeState.result contains the full exchange
+- &compositeState.exchange contains the structured round-by-round arguments
+
+### Delegation Loop
+
+```javascript
+const { thesis, antithesis, task_brief, rounds = 2 } = __compositeState;
+const exchange = [];
+
+let lastThesis = null;
+let lastAntithesis = null;
+
+for (let round = 0; round < rounds; round++) {
+  // Thesis argues
+  let thesisBrief = round === 0
+    ? `Argue FOR the following position.\n\n${task_brief}`
+    : `Argue FOR the following position, responding to the counterargument.\n\n${task_brief}\n\nCounterargument from prior round:\n${lastAntithesis}`;
+  lastThesis = await rlm(thesisBrief, null, { use: thesis });
+
+  // Antithesis argues
+  const antithesisBrief = `Argue AGAINST the following position.\n\n${task_brief}\n\nArgument to counter:\n${lastThesis}`;
+  lastAntithesis = await rlm(antithesisBrief, null, { use: antithesis });
+
+  exchange.push({ round: round + 1, thesis: lastThesis, antithesis: lastAntithesis });
+}
+
+__compositeState.result = exchange;
+__compositeState.exchange = exchange;
+return(exchange);
+```
+
+### Notes
+
+This is a seed pattern. Neither agent knows it is part of a dialectic. Each receives a brief asking it to argue a position. The structural value is in the tension between positions — premature consensus is more dangerous than unresolved disagreement.

--- a/packages/std/composites/ensemble-synthesizer.md
+++ b/packages/std/composites/ensemble-synthesizer.md
@@ -1,0 +1,87 @@
+---
+name: ensemble-synthesizer
+kind: composite
+---
+
+# Ensemble-Synthesizer
+
+K agents work independently on the same task. A synthesizer merges by reasoning about disagreements.
+
+### Description
+
+Fans out the same task to K independent agents and synthesizes their results by reasoning about disagreements.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `ensemble_member` (primary)
+  - requires: task_brief
+  - ensures: result text
+- `synthesizer`
+  - requires: K member results, original task_brief
+  - ensures: synthesized result with confidence assessment
+
+### Config
+
+- `task_brief` (string, default: none): The task sent identically to every ensemble member
+- `ensemble_size` (integer, default: 3): Number of independent ensemble members to run
+
+### Invariants
+
+- All ensemble members receive the identical brief
+- Synthesizer reasons about disagreements — it does not majority-vote
+- Ensemble members are unaware of each other
+
+### Shape
+
+- `self`: fan out to K ensemble members, collect results, delegate to synthesizer
+- `delegates`:
+  - `ensemble_member`: produce a result given the brief — run K times
+  - `synthesizer`: merge K results by reasoning about disagreements
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    ensemble_member: string   -- component name for each ensemble member
+    synthesizer: string       -- component name for the synthesizer
+    task_brief: string        -- the task (same brief goes to all members)
+    ensemble_size: number     -- (optional, default 3)
+
+### Ensures
+
+- All K members receive the SAME brief independently
+- Synthesizer receives all K results — its job is NOT majority voting
+- Synthesizer reasons about WHY results differ — disagreements are signal
+  about ambiguity or difficulty
+- Returns the synthesized result plus a confidence assessment
+- &compositeState.result contains the synthesis
+- &compositeState.member_results contains the K individual results
+
+### Delegation
+
+```javascript
+const { ensemble_member, synthesizer, task_brief, ensemble_size = 3 } = __compositeState;
+
+// Fan out to K members — each works independently
+const memberResults = [];
+for (let i = 0; i < ensemble_size; i++) {
+  const result = await rlm(task_brief, null, { use: ensemble_member });
+  memberResults.push(result);
+}
+
+// Synthesizer merges
+const synthBrief = `${ensemble_size} independent agents worked on the same task. Reason about their results — where they agree, where they disagree, and why.\n\nOriginal task: ${task_brief}\n\nResults:\n${memberResults.map((r, i) => `--- Agent ${i + 1} ---\n${r}`).join("\n\n")}`;
+const synthesis = await rlm(synthBrief, null, { use: synthesizer });
+
+__compositeState.result = synthesis;
+__compositeState.member_results = memberResults;
+return(synthesis);
+```
+
+### Notes
+
+This is a seed pattern. Ensemble members do not know other agents are working on the same task. The synthesizer does not know it is part of an ensemble composite. Disagreement between members is the primary signal — it reveals ambiguity in the task, not errors in individual agents.

--- a/packages/std/composites/oversight.md
+++ b/packages/std/composites/oversight.md
@@ -1,0 +1,111 @@
+---
+name: oversight
+kind: composite
+---
+
+# Oversight
+
+Actor acts, observer watches outcomes independently, arbiter decides next step based on the observer's report — not the actor's self-assessment.
+
+### Description
+
+Actor executes, observer independently analyzes outcomes, arbiter decides whether to continue, adjust, or abort.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `actor` (primary)
+  - requires: task_brief, adjustment (if prior cycle was adjusted)
+  - ensures: execution outcome
+- `observer`
+  - requires: task_brief, actor outcome
+  - ensures: independent analysis of the outcome
+- `arbiter`
+  - requires: task_brief, observer report
+  - ensures: {'decision': 'continue'}, adjust, or abort
+
+### Config
+
+- `task_brief` (string, default: none): The task for the actor to perform
+- `max_cycles` (integer, default: 3): Maximum oversight cycles
+
+### Invariants
+
+- The observer sees only the outcome, never the actor's reasoning or self-assessment
+- The actor does not know an observer is watching
+- The observer does not know an arbiter will act on its report
+- The arbiter decides solely from the observer's report, not from the actor
+
+### Shape
+
+- `self`: manage the cycle, route information between roles, enforce separation
+- `delegates`:
+  - `actor`: execute the current plan
+  - `observer`: independently analyze the outcome
+  - `arbiter`: decide: continue, adjust, or abort
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    actor: string         -- component name for the actor
+    observer: string      -- component name for the observer
+    arbiter: string       -- component name for the arbiter
+    task_brief: string    -- the task to execute
+    max_cycles: number    -- (optional, default 3)
+
+### Ensures
+
+- Actor receives the task brief (first cycle) or adjusted brief (subsequent cycles)
+- Observer receives ONLY the outcome — not the actor's reasoning or self-assessment
+- Arbiter receives the observer's report and decides: continue, adjust, or abort
+- If arbiter says adjust: the adjustment is passed to the actor's next cycle
+- If arbiter says abort: return immediately with the reason
+- If arbiter says continue: actor runs another cycle with the same brief
+- &compositeState.result contains the final outcome
+- &compositeState.cycles contains the number of cycles run
+
+### Delegation Loop
+
+```javascript
+const { actor, observer, arbiter, task_brief, max_cycles = 3 } = __compositeState;
+let currentBrief = task_brief;
+let lastOutcome = null;
+
+for (let cycle = 0; cycle < max_cycles; cycle++) {
+  // Actor executes
+  lastOutcome = await rlm(currentBrief, null, { use: actor });
+
+  // Observer analyzes the outcome — no access to actor's reasoning
+  const observerBrief = `Analyze this outcome independently.\n\nTask: ${task_brief}\nOutcome:\n${lastOutcome}`;
+  const observation = await rlm(observerBrief, null, { use: observer });
+
+  // Arbiter decides based on observer's report
+  const arbiterBrief = `Based on this independent observation, decide: continue, adjust, or abort.\n\nTask: ${task_brief}\nObserver report:\n${observation}`;
+  const decision = await rlm(arbiterBrief, null, { use: arbiter });
+
+  const decisionStr = String(decision).toLowerCase();
+  if (/abort/.test(decisionStr)) {
+    __compositeState.result = lastOutcome;
+    __compositeState.cycles = cycle + 1;
+    __compositeState.abort_reason = decision;
+    return(lastOutcome);
+  }
+
+  if (/adjust/.test(decisionStr)) {
+    currentBrief = `${task_brief}\n\nAdjustment from oversight: ${decision}`;
+  }
+  // "continue" → loop with same or adjusted brief
+}
+
+__compositeState.result = lastOutcome;
+__compositeState.cycles = max_cycles;
+return(lastOutcome);
+```
+
+### Notes
+
+The actor does not know an observer is watching. The observer does not know an arbiter will act on its report. The information firewall between actor and observer is the structural guarantee — the observer's assessment cannot be contaminated by the actor's rationalization.

--- a/packages/std/composites/proposer-adversary.md
+++ b/packages/std/composites/proposer-adversary.md
@@ -1,0 +1,78 @@
+---
+name: proposer-adversary
+kind: composite
+---
+
+# Proposer-Adversary
+
+One proposes, another attacks. The composite returns both — the parent decides.
+
+### Description
+
+One agent proposes, another attacks the proposal, and the unresolved tension is returned for the parent to judge.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `proposer` (primary)
+  - requires: task_brief
+  - ensures: proposal text
+- `adversary`
+  - requires: proposal, original task_brief
+  - ensures: attack identifying flaws, edge cases, and counterexamples
+
+### Config
+
+- `task_brief` (string, default: none): What the proposer should propose on
+
+### Invariants
+
+- The composite does not resolve the tension — it returns both proposal and attack
+- Proposer is unaware it will be attacked
+- Adversary is unaware its output will be weighed against the proposal
+
+### Shape
+
+- `self`: delegate to proposer, delegate to adversary, return both outputs
+- `delegates`:
+  - `proposer`: produce a proposal given the brief
+  - `adversary`: find flaws in the proposal
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    proposer: string      -- component name for the proposer
+    adversary: string     -- component name for the adversary
+    task_brief: string    -- what to propose
+
+### Ensures
+
+- Proposer receives only the task brief
+- Adversary receives the proposal and the task brief — its job is to find flaws,
+  edge cases, and counterexamples
+- This composite does NOT resolve the tension
+- Returns { proposal, attack } — the parent reasons about the disagreement
+- &compositeState.result contains { proposal, attack }
+
+### Delegation
+
+```javascript
+const { proposer, adversary, task_brief } = __compositeState;
+
+const proposal = await rlm(task_brief, null, { use: proposer });
+
+const adversaryBrief = `Find flaws, edge cases, or counterexamples in this proposal.\n\nOriginal task: ${task_brief}\n\nProposal:\n${proposal}`;
+const attack = await rlm(adversaryBrief, null, { use: adversary });
+
+const result = { proposal, attack };
+__compositeState.result = result;
+return(result);
+```
+
+### Notes
+
+This is a seed pattern. The proposer does not know it will be attacked. The adversary does not know its output will be weighed against the proposal. The parent composes both perspectives and makes the final judgment.

--- a/packages/std/composites/ratchet.md
+++ b/packages/std/composites/ratchet.md
@@ -1,0 +1,102 @@
+---
+name: ratchet
+kind: composite
+---
+
+# Ratchet
+
+Advancer proposes steps, certifier validates. Certified progress is never rolled back.
+
+### Description
+
+Advancer proposes incremental steps; certifier validates each one; certified progress is never rolled back.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `advancer` (primary)
+  - requires: task_brief, certified_progress, rejection feedback (if prior rejection)
+  - ensures: proposed next step
+- `certifier`
+  - requires: task_brief, certified_progress, proposed step
+  - ensures: certify or reject verdict
+
+### Config
+
+- `task_brief` (string, default: none): The goal to advance toward
+- `max_steps` (integer, default: 5): Maximum advancement attempts
+- `certified_progress` (array, default: none): Prior certified steps to resume from
+
+### Invariants
+
+- Progress is monotonic — the certified_progress array only grows, never shrinks
+- The advancer does not know a certifier will evaluate its proposals
+- The certifier does not know its verdicts drive a retry loop
+- Rejected steps are discarded, never appended to certified progress
+
+### Shape
+
+- `self`: manage the advance-certify loop, maintain certified progress log
+- `delegates`:
+  - `advancer`: propose the next incremental step
+  - `certifier`: certify or reject the proposed step
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    advancer: string             -- component name for the advancer
+    certifier: string            -- component name for the certifier
+    task_brief: string           -- the overall goal
+    max_steps: number            -- (optional, default 5)
+    certified_progress: any[]    -- (optional, default []) — prior certified steps
+
+### Ensures
+
+- Advancer receives the task brief plus all certified progress so far
+- Certifier receives the proposed step and decides: certify or reject
+- Certified steps are appended to &compositeState.certified_progress — never removed
+- Rejected steps are discarded — advancer receives the rejection reason and proposes differently
+- Progress is monotonic: the certified_progress array only grows
+- &compositeState.result contains the final certified progress
+
+### Delegation Loop
+
+```javascript
+const { advancer, certifier, task_brief, max_steps = 5 } = __compositeState;
+let certified = __compositeState.certified_progress || [];
+let consecutiveRejects = 0;
+
+for (let step = 0; step < max_steps; step++) {
+  // Advancer proposes
+  let advancerBrief = `Propose the next incremental step toward the goal.\n\nGoal: ${task_brief}\n\nCertified progress so far:\n${certified.length ? certified.map((s, i) => `${i + 1}. ${s}`).join("\n") : "(none yet)"}`;
+  if (consecutiveRejects > 0) {
+    advancerBrief += `\n\nYour last ${consecutiveRejects} proposal(s) were rejected. Try a different approach.`;
+  }
+
+  const proposal = await rlm(advancerBrief, null, { use: advancer });
+
+  // Certifier validates
+  const certifierBrief = `Evaluate this proposed step. Does it maintain all invariants? Does it advance toward the goal? Is it consistent with prior certified progress?\n\nGoal: ${task_brief}\nCertified progress: ${JSON.stringify(certified)}\n\nProposed step:\n${proposal}`;
+  const verdict = await rlm(certifierBrief, null, { use: certifier });
+
+  const verdictStr = String(verdict).toLowerCase();
+  if (/certif|accept|approve/.test(verdictStr)) {
+    certified.push(proposal);
+    __compositeState.certified_progress = certified;
+    consecutiveRejects = 0;
+  } else {
+    consecutiveRejects++;
+  }
+}
+
+__compositeState.result = certified;
+return(certified);
+```
+
+### Notes
+
+The advancer does not know a certifier will evaluate its proposals. The certifier does not know its verdicts drive a retry loop. The structural guarantee is monotonic progress — once a step is certified, it is committed. This is valuable when rollback is expensive or when partial progress must be preserved across failures.

--- a/packages/std/composites/stochastic-probe.md
+++ b/packages/std/composites/stochastic-probe.md
@@ -1,0 +1,113 @@
+---
+name: stochastic-probe
+kind: composite
+---
+
+# Stochastic Probe
+
+Run the same agent on the same material N times. Variance in responses measures how much the material underdetermines its interpretation.
+
+### Description
+
+Run the same agent on identical inputs N times; variance in responses measures how much the material underdetermines interpretation.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `probe` (primary)
+  - requires: task_brief, material
+  - ensures: response
+- `analyst`
+  - requires: responses
+  - ensures: analysis
+
+### Config
+
+- `sample_size` (number, default: 7): Number of identical probe runs
+- `model` (string, default: none): Model tier to probe at — fixing the tier isolates material variance from capability variance
+- `task_brief` (string, default: none): The question to pose against the material
+- `material` (string, default: none): The corpus or artifact to examine
+
+### Invariants
+
+- All N runs receive identical inputs — same brief, same material, same model
+- Temperature and sampling inherent to the model are the only source of variation
+
+### Shape
+
+- `self`: run probe N times with identical inputs, collect responses, delegate variance analysis
+- `delegates`:
+  - `probe`: respond to the brief — run N times with identical configuration
+  - `analyst`: quantify variance across N responses, classify determinism
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    probe: string             -- component name for the probe agent
+    analyst: string           -- component name for the variance analyst
+    task_brief: string        -- the question to pose against the material
+    material: string          -- the corpus or artifact to examine
+    sample_size: number       -- (optional, default 7) number of runs
+    model: string             -- (optional) model tier to probe at — fixing the tier isolates material variance from capability variance
+
+### Ensures
+
+- All N runs receive IDENTICAL inputs — same brief, same material, same model
+- Temperature and sampling inherent to the model are the ONLY source of variation
+- Analyst receives all N responses and classifies the material as:
+  - Deterministic: responses are substantively identical — the material constrains interpretation tightly
+  - Underdetermined: responses vary in specific areas — those areas permit multiple valid readings
+  - Chaotic: responses vary widely — the material fails to constrain interpretation at all
+- Analyst identifies WHICH aspects of the responses vary and which are stable
+- &compositeState.result contains the analyst's classification and variance map
+- &compositeState.responses contains the N raw responses
+
+### Delegation Loop
+
+```javascript
+const { probe, analyst, task_brief, material, sample_size = 7, model } = __compositeState;
+
+// Run the same probe N times — identical inputs
+const responses = [];
+for (let i = 0; i < sample_size; i++) {
+  const opts = model ? { use: probe, model } : { use: probe };
+  const response = await rlm(
+    `${task_brief}\n\nMaterial:\n${material}`,
+    null,
+    opts
+  );
+  responses.push(response);
+}
+
+// Analyst measures variance
+const analystBrief = `${sample_size} identical runs of the same agent on the same material produced the following responses. The agent, prompt, and material were identical across all runs — any variation comes from the material's ambiguity, not the agent's inconsistency.
+
+Analyze:
+1. Which aspects of the responses are STABLE across all runs? (The material determines these.)
+2. Which aspects VARY? (The material underdetermines these — multiple valid readings exist.)
+3. Classify the material overall:
+   - DETERMINISTIC: responses substantively identical
+   - UNDERDETERMINED: specific aspects vary, others stable
+   - CHAOTIC: responses vary widely with no stable core
+
+For underdetermined material, identify the specific passages or aspects that permit multiple readings.
+
+Original task: ${task_brief}
+
+Responses:
+${responses.map((r, i) => `--- Run ${i + 1} ---\n${r}`).join("\n\n")}`;
+
+const analysis = await rlm(analystBrief, null, { use: analyst });
+
+__compositeState.result = analysis;
+__compositeState.responses = responses;
+return(analysis);
+```
+
+### Notes
+
+This is a seed pattern. The probe does not know it is being run multiple times. The analyst does not know it is part of a stochastic probe composite. The measurement is orthogonal to blind-review: blind-review measures cross-tier divergence (is the material clear to different capability levels?), while stochastic probe measures within-tier stability (does the material produce the same reading every time?). Material can be clear but underdetermined (everyone understands it, but they understand it differently each time) or deterministic but complex (it always produces the same reading, but only at high tiers).

--- a/packages/std/composites/worker-critic.md
+++ b/packages/std/composites/worker-critic.md
@@ -1,0 +1,109 @@
+---
+name: worker-critic
+kind: composite
+---
+
+# Worker-Critic
+
+One agent works, another evaluates. Retry until the critic accepts or budget exhausts.
+
+### Description
+
+Iteratively refines a worker's output by looping through critic evaluation until acceptance or budget exhaustion.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Slots
+
+- `worker` (primary)
+  - requires: task_brief, optional critique from previous attempt
+  - ensures: result text
+- `critic`
+  - requires: worker result, original task_brief, criteria
+  - ensures: structured verdict with accept/reject, reasoning, issues, suggestions
+
+### Config
+
+- `task_brief` (string, default: none): The task to pass to the worker
+- `criteria` (string, default: none): Acceptance criteria the critic evaluates against
+- `max_rounds` (integer, default: 3): Maximum number of worker-critic cycles before returning best attempt
+
+### Invariants
+
+- Worker never sees the raw criteria — only the critique derived from them
+- Critic always receives the original task brief alongside the result
+- On accept the loop exits immediately and returns the worker's result
+- After max_rounds exhausted the final attempt is returned with its critique
+
+### Shape
+
+- `self`: manage retry loop, pass critique to worker, return accepted result
+- `delegates`:
+  - `worker`: produce result from brief
+  - `critic`: evaluate result against criteria
+- `prohibited`: none
+
+### Requires
+
+- &compositeState exists at __compositeState with:
+    worker: string        -- component name to use as worker
+    critic: string        -- component name to use as critic
+    task_brief: string    -- the task to pass to the worker
+    criteria: string      -- acceptance criteria for the critic
+    max_rounds: number    -- (optional, default 3)
+
+### Ensures
+
+- Worker receives only the task brief (first attempt) or task brief + critique (retries)
+- Critic receives the worker's result AND the original task brief AND the criteria
+- Critic returns { verdict: "accept" | "reject", reasoning, issues, suggestions }
+- On reject: worker receives the critique as learning signal — not the raw task repeated
+- On accept: return the worker's result immediately
+- After max_rounds exhausted: return the best attempt with the final critique
+- &compositeState.result contains the final output
+- &compositeState.attempts contains the count
+
+### Delegation Loop
+
+```javascript
+const { worker, critic, task_brief, criteria, max_rounds = 3 } = __compositeState;
+let lastResult = null;
+let lastCritique = null;
+
+for (let attempt = 0; attempt < max_rounds; attempt++) {
+  // Build worker brief
+  let workerBrief = task_brief;
+  if (lastCritique) {
+    workerBrief += `\n\nPrevious attempt was rejected.\nCritique: ${lastCritique.reasoning}`;
+    if (lastCritique.suggestions?.length) {
+      workerBrief += `\nSuggestions: ${lastCritique.suggestions.join("; ")}`;
+    }
+  }
+
+  lastResult = await rlm(workerBrief, null, { use: worker });
+
+  // Build critic brief
+  const criticBrief = `Evaluate this result against the criteria.\n\nOriginal task: ${task_brief}\nCriteria: ${criteria}\n\nResult to evaluate:\n${lastResult}`;
+  const verdict = await rlm(criticBrief, null, { use: critic });
+
+  // Parse verdict — critic should return structured assessment
+  if (verdict?.verdict === "accept" || /accept/i.test(String(verdict))) {
+    __compositeState.result = lastResult;
+    __compositeState.attempts = attempt + 1;
+    return(lastResult);
+  }
+
+  lastCritique = verdict;
+}
+
+__compositeState.result = lastResult;
+__compositeState.attempts = max_rounds;
+__compositeState.final_critique = lastCritique;
+return(lastResult);
+```
+
+### Notes
+
+This is a seed pattern in the standard library. The worker does not know it will be critiqued. The critic does not know its verdict triggers a retry. Multi-polarity is managed here, not in the children.

--- a/packages/std/controls/README.md
+++ b/packages/std/controls/README.md
@@ -1,0 +1,74 @@
+---
+purpose: Flow control patterns for Prose programs — 8 patterns describing how work is sequenced, distributed, guarded, retried, or raced across single or multiple agents; complements composites (topology) with execution flow
+related:
+  - ../README.md
+  - ../composites/README.md
+  - ../roles/README.md
+  - ../../programs/README.md
+---
+
+# lib/controls
+
+Flow control patterns used to structure Prose program execution.
+
+Controls are delegation coordinators. Each one takes a `__controlState` object that specifies which components to delegate to and how. The control manages the delegation loop — dispatching briefs, collecting results, tracking state — so the parent program doesn't have to.
+
+## When to Use a Control vs. an Explicit Execution Block
+
+Use a **control** when the delegation pattern is structural — you want pipeline sequencing, parallel fan-out, or retry logic, and the pattern is reusable across different component compositions. Controls encode the *shape* of delegation without knowing the *content*.
+
+Write an **explicit execution block** (`let` + `call`) when the logic is specific to your program — conditional branching based on intermediate results, custom error recovery, or orchestration that doesn't fit a standard pattern. If you find yourself fighting a control to get custom behavior, drop to an execution block.
+
+Rule of thumb: if the delegation logic is about *flow* (sequence, parallel, retry, gate), use a control. If it's about *decisions* (inspect this result, choose that path), use an execution block.
+
+## The `__controlState` Convention
+
+Every control reads and writes a `__controlState` object. This is the control's interface to its parent:
+
+- **Input:** The parent populates `__controlState` with the control's `requires` fields — component names, briefs, configuration.
+- **Output:** The control writes results back to `__controlState` — the final result, metadata (scores, attempt counts, failure history), and any intermediate data.
+- **During execution:** The control uses `__controlState` for internal bookkeeping (e.g., `_lastSuggestions` in refine). Fields prefixed with `_` are private to the control.
+
+The `__controlState` object is the control's entire world. It does not read from or write to any other shared state.
+
+## Controls
+
+| Control | Slots | Pattern |
+|---|---|---|
+| **pipeline** | stages[] | Sequential transformation chain — each stage's output feeds the next |
+| **map-reduce** | mapper, reducer | Split input, delegate chunks in parallel, merge with a reducer |
+| **guard** | guard, target | Check precondition, fail-fast if unmet — binary pass/block |
+| **refine** | refiner, evaluator | Iteratively improve to a quality threshold (0..1 scoring) |
+| **retry-with-learning** | target | Retry with accumulated failure analysis between attempts |
+| **fan-out** | delegates[] | Parallel delegation without reduction — parent uses raw results |
+| **race** | candidates[] | Parallel speculative execution — first acceptable result wins |
+| **fallback-chain** | chain[] | Sequential failover — try A, if it fails try B, then C |
+
+## Decision Matrix
+
+| You need to... | Use |
+|---|---|
+| Transform data through ordered stages | **pipeline** |
+| Process chunks independently then merge | **map-reduce** |
+| Check a precondition before expensive work | **guard** |
+| Improve a mediocre result iteratively | **refine** |
+| Recover from failure with enriched retries | **retry-with-learning** |
+| Get results from N delegates without merging | **fan-out** |
+| Try multiple approaches, take the first win | **race** |
+| Try preferred delegate, fall back on failure | **fallback-chain** |
+
+### Distinguishing Similar Controls
+
+**fan-out vs. map-reduce:** Both run delegates in parallel. Map-reduce includes a reducer that produces a single merged artifact. Fan-out returns the raw collection for the parent to interpret.
+
+**race vs. fan-out:** Both run delegates in parallel. Fan-out waits for all and returns everything. Race returns the first acceptable result.
+
+**race vs. fallback-chain:** Both try multiple candidates. Race tries all simultaneously. Fallback-chain tries sequentially, only advancing on failure. Use race when parallelism is cheap. Use fallback-chain when later candidates are expensive.
+
+**retry-with-learning vs. fallback-chain:** Both handle failure. Retry retries the SAME component with enriched context. Fallback-chain tries DIFFERENT components with the original brief.
+
+**retry-with-learning vs. refine:** Both iterate. Retry recovers from failure (broken results). Refine improves mediocrity (working but insufficient results).
+
+## Future Work
+
+- **accumulator** — Streaming aggregation: process items one at a time, maintaining a running aggregate that grows with each item. Different from map-reduce (no final merge step — the aggregate *is* the result) and pipeline (items don't transform through stages — they contribute to a single evolving state).

--- a/packages/std/controls/fallback-chain.md
+++ b/packages/std/controls/fallback-chain.md
@@ -1,0 +1,102 @@
+---
+name: fallback-chain
+kind: composite
+---
+
+# Fallback Chain
+
+Try delegate A. If it fails, try B. If B fails, try C. Ordered list of fallbacks with decreasing preference.
+
+### Metadata
+
+- `version`: 0.1.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `chain`
+
+### Shape
+
+- `self`: try each delegate in order, return first success, stop on success
+- `delegates`:
+  - `fallback_1..fallback_N`: attempt the task
+- `prohibited`: trying the next fallback when the current one succeeded
+
+### Requires
+
+- &controlState exists at __controlState with:
+    chain: string[]         -- ordered list of component names (first = most preferred)
+    task_brief: string      -- the task (same brief goes to each attempt)
+    failure_criteria: string -- (optional) declarative description of what constitutes failure.
+                                Default: only thrown errors count as failure.
+
+### Ensures
+
+- Delegates are tried sequentially in chain order
+- First successful result is returned immediately — no further delegates are tried
+- Each delegate receives the ORIGINAL brief — no failure context from prior attempts
+- If all delegates fail: return null with full failure history
+- &controlState.result contains the winning result (or null)
+- &controlState.winner contains the winning delegate's name (or null)
+- &controlState.attempts contains the number of delegates tried
+- &controlState.failure_history contains reasons for each failed attempt
+
+### Delegation
+
+```javascript
+const { chain, task_brief, failure_criteria } = __controlState;
+const failures = [];
+
+for (let i = 0; i < chain.length; i++) {
+  try {
+    const result = await rlm(task_brief, null, { use: chain[i] });
+
+    // Evaluate failure_criteria if provided
+    if (failure_criteria) {
+      const evalBrief = `Does this result satisfy the failure criteria?\n\nCriteria: "${failure_criteria}"\n\nResult:\n${String(result).slice(0, 2000)}\n\nRespond with JSON: { "is_failure": true/false, "reason": "..." }`;
+      const evalResult = await rlm(evalBrief, null, {});
+      try {
+        const jsonMatch = String(evalResult).match(/\{[\s\S]*"is_failure"[\s\S]*\}/);
+        const evaluation = JSON.parse(jsonMatch[0]);
+        if (evaluation.is_failure) {
+          failures.push({ delegate: chain[i], reason: evaluation.reason });
+          continue;
+        }
+      } catch {
+        // Unparseable evaluation — treat as success (fail open)
+      }
+    }
+
+    __controlState.result = result;
+    __controlState.winner = chain[i];
+    __controlState.attempts = i + 1;
+    __controlState.failure_history = failures;
+    return(result);
+  } catch (e) {
+    failures.push({ delegate: chain[i], reason: e.message });
+  }
+}
+
+// All delegates failed
+__controlState.result = null;
+__controlState.winner = null;
+__controlState.attempts = chain.length;
+__controlState.failure_history = failures;
+return(null);
+```
+
+### Notes
+
+Each delegate receives the original brief with no modification. Unlike `retry-with-learning`, fallback-chain does not pass failure context between attempts — each delegate gets a clean start. The assumption is that different delegates have different capabilities, not that the same delegate needs better instructions.
+
+The chain order expresses preference. Put the best, most capable, or cheapest delegate first. Later delegates are fallbacks for when preferred options fail.
+
+Different from `retry-with-learning`: retry retries the SAME component with enriched failure context. Fallback-chain tries DIFFERENT components with the original brief. A search service that returned no results should be retried with broader terms (retry-with-learning). A search service that is down should be replaced with an alternative (fallback-chain).
+
+Different from `race`: race tries all candidates simultaneously. Fallback-chain tries them sequentially, only advancing on failure. Use fallback-chain when later candidates are expensive and should only run if cheaper ones fail. Use race when all candidates are worth trying in parallel.

--- a/packages/std/controls/fan-out.md
+++ b/packages/std/controls/fan-out.md
@@ -1,0 +1,76 @@
+---
+name: fan-out
+kind: composite
+---
+
+# Fan-Out
+
+Parallel delegation without reduction. Send briefs to N delegates, collect all results. The parent decides how to use them.
+
+### Metadata
+
+- `version`: 0.1.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `delegates`
+
+### Shape
+
+- `self`: dispatch briefs to delegates in parallel, collect all results, return collection
+- `delegates`:
+  - `delegate_1..delegate_N`: execute assigned brief
+- `prohibited`: merging or synthesizing results — that is the parent's job
+
+### Requires
+
+- &controlState exists at __controlState with:
+    delegates: string[]     -- component names for each delegate
+    briefs: string[]        -- one brief per delegate (same length as delegates)
+                               OR a single string applied to all delegates
+
+### Ensures
+
+- Each delegate receives exactly one brief
+- All delegates execute in parallel
+- No delegate knows other delegates exist
+- Results are returned as an ordered array matching the input delegates
+- No merging or synthesis — the raw results are the output
+- &controlState.result contains the array of all delegate outputs
+- &controlState.results contains the same array (keyed alias)
+
+### Delegation
+
+```javascript
+const { delegates, briefs, task_brief } = __controlState;
+
+// Normalize briefs: single string broadcasts to all, array maps 1:1
+const briefList = Array.isArray(briefs)
+  ? briefs
+  : delegates.map(() => briefs || task_brief);
+
+// All delegates run in parallel
+const results = await Promise.all(
+  delegates.map((delegate, i) => {
+    return rlm(briefList[i], null, { use: delegate });
+  })
+);
+
+__controlState.result = results;
+__controlState.results = results;
+return(results);
+```
+
+### Notes
+
+No delegate knows other delegates exist. Each receives a brief and returns a result. The fan-out control collects results but does not interpret them — interpretation is the parent's responsibility.
+
+Different from `map-reduce`: map-reduce includes a reducer that merges results into a single output. Fan-out returns the raw collection. Use fan-out when the parent needs to see all results individually (e.g., to compare, to select, to present side-by-side). Use map-reduce when the goal is a single merged artifact.
+
+Different from `race`: fan-out waits for ALL delegates. Race returns the FIRST acceptable result and cancels the rest.

--- a/packages/std/controls/guard.md
+++ b/packages/std/controls/guard.md
@@ -1,0 +1,87 @@
+---
+name: guard
+kind: composite
+---
+
+# Guard
+
+Check before delegating. Fail-fast pattern.
+
+### Metadata
+
+- `version`: 0.2.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `guard`
+- `target`
+
+### Shape
+
+- `self`: delegate to guard, if cleared delegate to target, otherwise return guard's reason
+- `delegates`:
+  - `guard`: evaluate whether the task should proceed
+  - `target`: execute the task if guard approves
+- `prohibited`: none
+
+### Requires
+
+- &controlState exists at __controlState with:
+    guard: string          -- component name for the guard
+    target: string         -- component name for the target
+    task_brief: string     -- the task (goes to both guard and target)
+
+### Ensures
+
+- Guard receives the brief and returns structured JSON: { proceed: boolean, reason: string }
+- If proceed: target receives the ORIGINAL brief unchanged
+- If blocked: return immediately with the guard's reason — no delegation to target
+- The guard does NOT modify the brief based on output — binary pass/block
+- &controlState.result contains the target's output (if proceeded) or guard's reason (if blocked)
+- &controlState.proceeded is true/false
+
+### Delegation
+
+```javascript
+const { guard, target, task_brief } = __controlState;
+
+// Guard decides — expects structured JSON output { proceed, reason }
+const guardBrief = `Evaluate whether this task should proceed.\n\nReturn your decision as JSON: { "proceed": true/false, "reason": "..." }\n\n${task_brief}`;
+const guardResult = await rlm(guardBrief, null, { use: guard });
+
+// Parse the guard's structured output
+let decision;
+try {
+  const jsonMatch = String(guardResult).match(/\{[\s\S]*"proceed"[\s\S]*\}/);
+  decision = JSON.parse(jsonMatch[0]);
+} catch {
+  // If the guard fails to return structured output, treat as blocked — fail safe
+  decision = { proceed: false, reason: `Guard returned unparseable output: ${String(guardResult).slice(0, 200)}` };
+}
+
+if (!decision.proceed) {
+  __controlState.result = decision.reason;
+  __controlState.proceeded = false;
+  return(decision.reason);
+}
+
+// Target executes
+const result = await rlm(task_brief, null, { use: target });
+__controlState.result = result;
+__controlState.proceeded = true;
+return(result);
+```
+
+### Notes
+
+The guard does not know it controls access to another component. The target does not know a guard was consulted. The guard is a binary decision point — not a filter that modifies the brief. Useful when delegation is expensive and preconditions should be checked cheaply first.
+
+The guard's contract promises structured JSON output (`{ proceed, reason }`). The delegation code parses that structure directly. If the guard returns unparseable output, the control fails safe by blocking — a guard that cannot clearly approve is a guard that has not approved.
+
+Different from `refine`: a guard makes a one-shot binary decision before work begins. Refinement improves work that has already been done.

--- a/packages/std/controls/map-reduce.md
+++ b/packages/std/controls/map-reduce.md
@@ -1,0 +1,79 @@
+---
+name: map-reduce
+kind: composite
+---
+
+# Map-Reduce
+
+Split input, delegate chunks to mappers in parallel, merge results with a reducer.
+
+### Metadata
+
+- `version`: 0.2.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `mapper`
+- `reducer`
+
+### Shape
+
+- `self`: partition input into chunks, fan out to mappers, collect results, delegate to reducer
+- `delegates`:
+  - `mapper`: process one chunk of the input
+  - `reducer`: merge all mapper outputs into a single result
+- `prohibited`: none
+
+### Requires
+
+- &controlState exists at __controlState with:
+    mapper: string         -- component name for each mapper
+    reducer: string        -- component name for the reducer
+    task_brief: string     -- overall task description
+    chunks: any[]          -- the pre-partitioned input chunks
+
+### Ensures
+
+- Each mapper receives one chunk and the overall task brief as context
+- Mapper does not know other mappers exist or what chunks they received
+- All mappers execute in parallel
+- Reducer receives ALL mapper outputs and the overall task brief
+- Reducer reasons about how to merge — handles conflicts and overlaps
+- &controlState.result contains the merged output
+- &controlState.mapper_results contains individual mapper outputs
+
+### Delegation
+
+```javascript
+const { mapper, reducer, task_brief, chunks } = __controlState;
+
+// Map phase — all mappers run in parallel
+const mapperResults = await Promise.all(
+  chunks.map((chunk, i) => {
+    const mapBrief = `${task_brief}\n\nProcess this chunk (${i + 1} of ${chunks.length}):\n${typeof chunk === 'string' ? chunk : JSON.stringify(chunk)}`;
+    return rlm(mapBrief, null, { use: mapper });
+  })
+);
+
+// Reduce phase
+const reduceBrief = `Merge these ${mapperResults.length} results into a single coherent output. Handle conflicts and overlaps.\n\nOverall task: ${task_brief}\n\nResults to merge:\n${mapperResults.map((r, i) => `--- Chunk ${i + 1} ---\n${r}`).join("\n\n")}`;
+const merged = await rlm(reduceBrief, null, { use: reducer });
+
+__controlState.result = merged;
+__controlState.mapper_results = mapperResults;
+return(merged);
+```
+
+### Notes
+
+The parent is responsible for partitioning the input into chunks before delegating to map-reduce. Mappers do not know other mappers exist. The reducer does not know it is part of a map-reduce pipeline.
+
+Mappers run in parallel by default (`Promise.all`). For sequential execution (e.g., when mappers share rate-limited resources), replace `Promise.all` with a `for` loop — but this sacrifices the primary advantage of map-reduce.
+
+Different from `fan-out`: map-reduce includes a reducer that merges results into a single output. Fan-out returns all results to the parent, which decides how to use them.

--- a/packages/std/controls/pipeline.md
+++ b/packages/std/controls/pipeline.md
@@ -1,0 +1,67 @@
+---
+name: pipeline
+kind: composite
+---
+
+# Pipeline
+
+Sequential transformation through multiple stages. Each stage sees only its predecessor's output.
+
+### Metadata
+
+- `version`: 0.2.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `stages`
+
+### Shape
+
+- `self`: pass output of each stage as input to the next, no curation between stages
+- `delegates`:
+  - `stage_1..stage_N`: transform input to output
+- `prohibited`: none
+
+### Requires
+
+- &controlState exists at __controlState with:
+    stages: string[]       -- ordered list of component names
+    task_brief: string     -- initial input (goes to stage 1)
+
+### Ensures
+
+- Stage 1 receives the task brief as its input
+- Stage N receives stage N-1's output as its input — not the original brief
+- The pipeline does NOT curate between stages — it is a pure pass-through
+- If curation is needed: insert a role (e.g., summarizer) as an explicit stage
+- Each stage operates on a clean interface — no accumulated context
+- &controlState.result contains the final stage's output
+- &controlState.stage_outputs contains each stage's output
+
+### Delegation
+
+```javascript
+const { stages, task_brief } = __controlState;
+const stageOutputs = [];
+let currentInput = task_brief;
+
+for (let i = 0; i < stages.length; i++) {
+  const output = await rlm(currentInput, null, { use: stages[i] });
+  stageOutputs.push(output);
+  currentInput = String(output);
+}
+
+__controlState.result = currentInput;
+__controlState.stage_outputs = stageOutputs;
+return(currentInput);
+```
+
+### Notes
+
+No stage knows it is part of a pipeline. Each receives input and produces output. The isolation between stages is the structural guarantee — each stage operates on a clean interface defined solely by its predecessor's output. If stage 3 needs information from stage 1, insert an intermediate stage that carries it forward, or restructure the pipeline.

--- a/packages/std/controls/race.md
+++ b/packages/std/controls/race.md
@@ -1,0 +1,104 @@
+---
+name: race
+kind: composite
+---
+
+# Race
+
+Multiple delegates work on the same task in parallel. First acceptable result wins. Others are cancelled.
+
+### Metadata
+
+- `version`: 0.1.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `candidates`
+
+### Shape
+
+- `self`: dispatch same brief to all candidates, accept first good result, cancel rest
+- `delegates`:
+  - `candidate_1..candidate_N`: attempt the task
+- `prohibited`: waiting for all candidates when one has already succeeded
+
+### Requires
+
+- &controlState exists at __controlState with:
+    candidates: string[]    -- component names for each candidate
+    task_brief: string      -- the task (same brief goes to all candidates)
+    acceptance_criteria: string -- (optional) declarative description of what makes a result
+                                  acceptable. Default: any non-error result is accepted.
+
+### Ensures
+
+- All candidates receive the same brief and start in parallel
+- First result that meets acceptance criteria is returned immediately
+- Remaining candidates are cancelled (best-effort)
+- No candidate knows other candidates exist
+- If no candidate produces an acceptable result: return null with all attempts in failure_history
+- &controlState.result contains the winning result (or null)
+- &controlState.winner contains the winning candidate's name (or null)
+- &controlState.attempts contains the number of candidates that completed before a winner
+
+### Delegation
+
+```javascript
+const { candidates, task_brief, acceptance_criteria } = __controlState;
+
+// All candidates race in parallel
+const results = await Promise.all(
+  candidates.map(async (candidate) => {
+    try {
+      const result = await rlm(task_brief, null, { use: candidate });
+      return { candidate, result, error: null };
+    } catch (e) {
+      return { candidate, result: null, error: e.message };
+    }
+  })
+);
+
+// Evaluate results in order of candidate preference (first in list = highest preference)
+for (const entry of results) {
+  if (entry.error) continue;
+
+  if (acceptance_criteria) {
+    const evalBrief = `Does this result meet the acceptance criteria?\n\nCriteria: "${acceptance_criteria}"\n\nResult:\n${String(entry.result).slice(0, 2000)}\n\nRespond with JSON: { "acceptable": true/false }`;
+    const evalResult = await rlm(evalBrief, null, {});
+    try {
+      const jsonMatch = String(evalResult).match(/\{[\s\S]*"acceptable"[\s\S]*\}/);
+      const evaluation = JSON.parse(jsonMatch[0]);
+      if (!evaluation.acceptable) continue;
+    } catch {
+      // Unparseable evaluation — treat as acceptable (fail open)
+    }
+  }
+
+  __controlState.result = entry.result;
+  __controlState.winner = entry.candidate;
+  __controlState.attempts = results.indexOf(entry) + 1;
+  return(entry.result);
+}
+
+// No winner
+__controlState.result = null;
+__controlState.winner = null;
+__controlState.attempts = candidates.length;
+return(null);
+```
+
+### Notes
+
+No candidate knows other candidates exist. Each receives the same brief and works independently.
+
+True cancellation depends on the runtime. In environments without preemption, all candidates run to completion and the first acceptable result (in preference order) wins. The `candidates` array order expresses preference — if two candidates both succeed, the earlier-listed one wins.
+
+Different from `fan-out`: fan-out waits for ALL results and returns the full collection. Race returns the FIRST acceptable result. Use race for speculative execution, redundancy, or when multiple approaches might work but you only need one.
+
+Different from `fallback-chain`: fallback-chain tries candidates sequentially (A, then B if A fails, then C). Race tries all candidates simultaneously. Use fallback-chain when later candidates are cheaper or less preferred and should only run if earlier ones fail. Use race when all candidates are worth trying in parallel.

--- a/packages/std/controls/refine.md
+++ b/packages/std/controls/refine.md
@@ -1,0 +1,95 @@
+---
+name: refine
+kind: composite
+---
+
+# Refine
+
+Iteratively improve a result through delegation rounds until a quality threshold is met.
+
+### Metadata
+
+- `version`: 0.2.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `refiner`
+- `evaluator`
+
+### Shape
+
+- `self`: manage refinement rounds, pass evaluator feedback to refiner
+- `delegates`:
+  - `refiner`: produce or improve a result
+  - `evaluator`: score the result 0..1 and suggest improvements
+- `prohibited`: none
+
+### Requires
+
+- &controlState exists at __controlState with:
+    refiner: string        -- component name for the refiner
+    evaluator: string      -- component name for the evaluator
+    task_brief: string     -- the task
+    max_rounds: number     -- (optional, default 3)
+    threshold: number      -- (optional, default 0.8) score at which to stop
+
+### Ensures
+
+- Round 1: refiner produces initial result from the task brief
+- Evaluator scores the result (0..1) and provides specific improvement suggestions
+- If score >= threshold: return immediately
+- If score < threshold: refiner receives the result, score, and suggestions
+- Each round accumulates improvement — refiner sees its own prior output
+- Returns when threshold met or max_rounds exhausted
+- &controlState.result contains the final output
+- &controlState.score contains the final score
+- &controlState.rounds_used contains the number of rounds
+
+### Delegation Loop
+
+```javascript
+const { refiner, evaluator, task_brief, max_rounds = 3, threshold = 0.8 } = __controlState;
+let currentResult = null;
+let currentScore = 0;
+let roundsUsed = 0;
+
+for (let round = 0; round < max_rounds; round++) {
+  roundsUsed = round + 1;
+
+  // Refiner produces or improves
+  let refinerBrief = round === 0
+    ? task_brief
+    : `Improve this result. Current score: ${currentScore}.\n\nOriginal task: ${task_brief}\n\nCurrent result:\n${currentResult}\n\nImprovement suggestions:\n${__controlState._lastSuggestions}`;
+
+  currentResult = await rlm(refinerBrief, null, { use: refiner });
+
+  // Evaluator scores
+  const evalBrief = `Score this result from 0 to 1 and provide specific improvement suggestions.\n\nTask: ${task_brief}\n\nResult:\n${currentResult}`;
+  const evaluation = await rlm(evalBrief, null, { use: evaluator });
+
+  // Parse score from evaluation
+  const scoreMatch = String(evaluation).match(/(\d+\.?\d*)/);
+  currentScore = scoreMatch ? parseFloat(scoreMatch[1]) : 0;
+  if (currentScore > 1) currentScore = currentScore / 100; // handle percentage
+  __controlState._lastSuggestions = evaluation;
+
+  if (currentScore >= threshold) break;
+}
+
+__controlState.result = currentResult;
+__controlState.score = currentScore;
+__controlState.rounds_used = roundsUsed;
+return(currentResult);
+```
+
+### Notes
+
+The refiner does not know it is in a refinement loop. The evaluator does not know its score controls iteration.
+
+Different from `retry-with-learning`: refinement improves work that is mediocre — the result exists but is not good enough. Retry-with-learning recovers from failure — the result is broken or absent. Refinement uses a continuous quality score (0..1) and improvement suggestions. Retry uses binary failure detection and failure analysis. A result that scores 0.4 needs refinement. A result that throws an error or returns nothing needs retry.

--- a/packages/std/controls/retry-with-learning.md
+++ b/packages/std/controls/retry-with-learning.md
@@ -1,0 +1,111 @@
+---
+name: retry-with-learning
+kind: composite
+---
+
+# Retry With Learning
+
+Retry a component, passing failure analysis to each subsequent attempt. Each retry differs because it receives the history of all prior failures.
+
+### Metadata
+
+- `version`: 0.2.0
+- `role`: coordinator
+
+### Runtime
+
+- `state.reads`: &controlState
+- `state.writes`: &controlState
+
+### Slots
+
+- `target`
+
+### Shape
+
+- `self`: analyze failures, enrich briefs with failure history, track attempts
+- `delegates`:
+  - `target`: execute the task
+- `prohibited`: none
+
+### Requires
+
+- &controlState exists at __controlState with:
+    target: string          -- component name to retry
+    task_brief: string      -- the original task
+    max_retries: number     -- (optional, default 3)
+    failure_criteria: string -- (optional) declarative description of what constitutes failure.
+                                The coordinator interprets this against the result.
+                                e.g., "result contains 'no results found' or is empty"
+                                Default: retry on thrown error only.
+
+### Ensures
+
+- First attempt: target receives the original brief
+- On failure: analyze what went wrong, construct enriched brief with:
+    original task, what was tried, why it failed, what to try differently
+- Each retry receives the FULL failure history, not just the last attempt
+- Returns on first success
+- After max_retries: returns the last result with &controlState.failure_history
+- &controlState.result contains the final output
+- &controlState.attempts contains the attempt count
+- &controlState.failure_history contains analysis of each failed attempt
+
+### Delegation Loop
+
+```javascript
+const { target, task_brief, max_retries = 3, failure_criteria } = __controlState;
+const failures = [];
+
+for (let attempt = 0; attempt < max_retries; attempt++) {
+  let brief = task_brief;
+  if (failures.length > 0) {
+    brief += `\n\nPrior attempts failed. You MUST try a different approach.\n`;
+    failures.forEach((f, i) => {
+      brief += `\nAttempt ${i + 1}: ${f.summary}\nFailure reason: ${f.reason}\n`;
+    });
+  }
+
+  try {
+    const result = await rlm(brief, null, { use: target });
+
+    // Evaluate failure_criteria declaratively against the result
+    if (failure_criteria) {
+      const evalBrief = `Does this result satisfy the failure criteria? Criteria: "${failure_criteria}"\n\nResult:\n${String(result).slice(0, 2000)}\n\nRespond with JSON: { "is_failure": true/false, "reason": "..." }`;
+      const evalResult = await rlm(evalBrief, null, {});
+      try {
+        const jsonMatch = String(evalResult).match(/\{[\s\S]*"is_failure"[\s\S]*\}/);
+        const evaluation = JSON.parse(jsonMatch[0]);
+        if (evaluation.is_failure) {
+          failures.push({ summary: String(result).slice(0, 200), reason: evaluation.reason });
+          continue;
+        }
+      } catch {
+        // If evaluation is unparseable, treat as success — fail open on ambiguity
+      }
+    }
+
+    __controlState.result = result;
+    __controlState.attempts = attempt + 1;
+    __controlState.failure_history = failures;
+    return(result);
+  } catch (e) {
+    failures.push({ summary: `Error: ${e.message}`, reason: e.message });
+  }
+}
+
+__controlState.result = null;
+__controlState.attempts = max_retries;
+__controlState.failure_history = failures;
+return(null);
+```
+
+### Notes
+
+The target component does not know it is being retried. Each invocation looks like a fresh delegation — the failure history appears as context in the brief, not as retry metadata.
+
+The `failure_criteria` parameter is a declarative string, not a function. The coordinator interprets it against the result using natural language evaluation, consistent with Prose's file-based contract model. Examples: `"result contains 'error' or is empty"`, `"result does not include a valid URL"`, `"result has fewer than 3 items"`.
+
+Different from `refine`: retry-with-learning recovers from failure — the result is broken, empty, or wrong. Refinement improves mediocrity — the result exists but is not good enough. Retry passes failure analysis. Refinement passes improvement suggestions. A result that throws an error needs retry. A result that scores 0.4 needs refinement.
+
+Different from `fallback-chain`: retry-with-learning retries the SAME component with enriched context. Fallback-chain tries DIFFERENT components in preference order.

--- a/packages/std/delivery/email-notifier.md
+++ b/packages/std/delivery/email-notifier.md
@@ -1,0 +1,150 @@
+---
+name: email-notifier
+kind: service
+---
+
+### Shape
+
+- `self`: send an HTML email via a configured email provider
+- `delegates`: none
+- `prohibited`: modifying content substance — you deliver, you do not edit
+
+### Requires
+
+- html: rendered HTML email body, ready to send
+- to: recipient email address, or list of addresses
+- subject: email subject line
+- cc: (optional) additional recipients to copy — address or list of addresses
+- bcc: (optional) additional recipients to blind copy — address or list of addresses
+- from_name: (optional, default from EMAIL_FROM_NAME) display name for the sender
+- from_email: (optional, default from EMAIL_FROM_ADDRESS) sender email address
+- reply_to: (optional) reply-to address — this is how recipients give feedback, always set it when provided
+- attachments: (optional) list of attachments, each with filename, content (base64), and mime_type
+
+### Ensures
+
+- sent: confirmation with message ID and timestamp
+- provider: which email provider handled the send
+
+### Errors
+
+- delivery-failed: the email provider rejected the send request or returned a non-success status
+- invalid-recipient: one or more addresses in to, cc, or bcc are malformed or undeliverable
+- auth-failed: the EMAIL_API_KEY is invalid, expired, or lacks send permission
+- provider-not-configured: EMAIL_PROVIDER is not set or is not a recognized value
+- missing-from: neither from_email nor EMAIL_FROM_ADDRESS is set — cannot send without a sender
+
+### Environment
+
+- EMAIL_PROVIDER: which provider to use — one of "resend", "sendgrid", "postmark", "ses", "smtp"
+- EMAIL_API_KEY: API key for the provider (required for resend, sendgrid, postmark)
+- EMAIL_FROM_ADDRESS: default sender email address
+- EMAIL_FROM_NAME: default sender display name
+- SMTP_HOST: (required for smtp provider) SMTP server hostname
+- SMTP_PORT: (optional, default 587) SMTP server port
+- SMTP_USER: (required for smtp provider) SMTP username
+- SMTP_PASS: (required for smtp provider) SMTP password
+- SMTP_SECURE: (optional, default "true") use TLS — set to "false" for local dev with Mailpit
+
+### Invariants
+
+- the html body is sent exactly as provided — no rewriting, no stripping, no wrapping
+- if reply_to is provided, the Reply-To header is always set — never silently drop it
+
+### Strategies
+
+- SMTP is the default and recommended provider — it works with any email service (Loops, Postmark, SendGrid, SES, Mailpit) via standard credentials
+- for local development, pair with Mailpit (localhost:1025, no auth, SMTP_SECURE=false) for a local inbox UI at http://localhost:8025
+- when to is a list: send a single email with all addresses in the To field — do not send separate emails per recipient
+- when attachments are provided: encode as multipart MIME with the HTML body as the primary part
+
+### SMTP implementation (primary)
+
+When EMAIL_PROVIDER is "smtp", send the email using Python's smtplib via the Bash tool. This is the most reliable approach on Claude Code because Python's email and smtplib modules handle MIME encoding, headers, and TLS correctly.
+
+Write a Python script to a temporary file and execute it. The script must:
+
+1. Read the HTML body from a file (pass the path as an argument, do not inline large HTML in the command)
+2. Build a proper MIME message with email.mime.multipart and email.mime.text
+3. Set all headers: From, To, Cc, Bcc, Reply-To, Subject, X-Mailer, List-Unsubscribe
+4. Connect via smtplib.SMTP (or SMTP_SSL if SMTP_SECURE is true and port is 465)
+5. Call starttls() if SMTP_SECURE is true and port is not 465
+6. Authenticate with SMTP_USER/SMTP_PASS if provided (skip auth for Mailpit)
+7. Send and return the message ID
+
+Here is the reference implementation. Use this as the template — adapt only the variable values:
+
+```python
+#!/usr/bin/env python3
+import smtplib, sys, os
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+# Read HTML body from file
+html_path = sys.argv[1]
+with open(html_path, 'r') as f:
+    html_body = f.read()
+
+# Build message
+msg = MIMEMultipart('alternative')
+msg['From'] = f"{os.environ.get('EMAIL_FROM_NAME', 'OpenProse')} <{os.environ.get('EMAIL_FROM_ADDRESS', 'noreply@openprose.ai')}>"
+msg['To'] = sys.argv[2]          # recipient email
+msg['Subject'] = sys.argv[3]     # subject line
+if os.environ.get('REPLY_TO'):
+    msg['Reply-To'] = os.environ['REPLY_TO']
+if os.environ.get('CC'):
+    msg['Cc'] = os.environ['CC']
+msg['X-Mailer'] = 'OpenProse/1.0'
+
+# Attach HTML part
+msg.attach(MIMEText(html_body, 'html', 'utf-8'))
+
+# Send
+host = os.environ.get('SMTP_HOST', 'localhost')
+port = int(os.environ.get('SMTP_PORT', '587'))
+secure = os.environ.get('SMTP_SECURE', 'true').lower() == 'true'
+user = os.environ.get('SMTP_USER', '')
+password = os.environ.get('SMTP_PASS', '')
+
+if secure and port == 465:
+    server = smtplib.SMTP_SSL(host, port)
+else:
+    server = smtplib.SMTP(host, port)
+    if secure:
+        server.starttls()
+
+if user and password:
+    server.login(user, password)
+
+recipients = [msg['To']]
+if msg.get('Cc'):
+    recipients += [a.strip() for a in msg['Cc'].split(',')]
+if os.environ.get('BCC'):
+    recipients += [a.strip() for a in os.environ['BCC'].split(',')]
+
+server.sendmail(msg['From'], recipients, msg.as_string())
+server.quit()
+print(f"Sent to {msg['To']} via {host}:{port}")
+```
+
+To use this: write the HTML to a temp file, write the script to a temp file, then run:
+```bash
+python3 /tmp/send_email.py /tmp/email_body.html "remi@aicepower.com" "⚡ AICE Daily Brief — 3 anomalies, est. €247/day"
+```
+
+### API-based providers (alternative)
+
+When EMAIL_PROVIDER is "resend": POST to https://api.resend.com/emails with header "Authorization: Bearer $EMAIL_API_KEY" and JSON body {"from": "...", "to": "...", "subject": "...", "html": "..."}
+
+When EMAIL_PROVIDER is "sendgrid": POST to https://api.sendgrid.com/v3/mail/send with header "Authorization: Bearer $EMAIL_API_KEY"
+
+When EMAIL_PROVIDER is "postmark": POST to https://api.postmarkapp.com/email with header "X-Postmark-Server-Token: $EMAIL_API_KEY"
+
+For API providers, use curl via the Bash tool. Read the HTML body from a file and pass it in the JSON payload (escape properly for JSON).
+
+### Common rules
+
+- always set Reply-To if reply_to is provided — this is how customers give feedback, never silently drop it
+- always set X-Mailer: OpenProse/1.0
+- the html body must be sent exactly as provided — no rewriting, no stripping, no wrapping in additional markup
+- if the send fails, return the error message from the server — do not retry automatically, let the caller decide

--- a/packages/std/delivery/email-renderer.md
+++ b/packages/std/delivery/email-renderer.md
@@ -1,0 +1,44 @@
+---
+name: email-renderer
+kind: service
+---
+
+### Shape
+
+- `self`:
+  - populate named slots in an email shell by generating json-render specs from structured report data
+  - using only components from the provided catalog
+- `delegates`: none
+- `prohibited`:
+  - writing raw HTML — all output is json-render specs; modifying the email shell — the shell is fixed infrastructure; using components not in the catalog — specs must reference only cataloged components; re-analyzing data or modifying report content — you decide slot content
+  - you do not re-interpret the data
+
+### Requires
+
+- report: structured report data to render (domain-specific, opaque to this contract)
+- slot_definitions: list of named slots the email shell exposes (e.g., `summary`, `detail`, `footer_cta`)
+- slot_catalog: reference to the component catalog — defines which json-render components are available and their accepted props
+
+### Ensures
+
+- slots: dict of slot_name → json-render spec, one entry per slot defined in slot_definitions
+- every spec is a valid json-render object (`{ root, elements }`) referencing only catalog components
+- slots adapt to report content — empty or irrelevant sections get appropriate alternative content, not blank space
+
+### Errors
+
+- empty-report: the report contains no data to render
+- unknown-slot: a slot_name is not present in slot_definitions
+- unknown-component: a spec references a component not in the catalog
+
+### Invariants
+
+- the email shell structure is never modified — only slot contents are produced
+- output is pure json-render specs — never raw HTML, never inline styles, never layout markup
+
+### Strategies
+
+- generate a json-render spec per slot — each spec is a `{ root, elements }` object where elements reference components from the catalog; the rendering infrastructure handles converting specs to email-safe HTML
+- adapt slot content to the report — when a section has no relevant data, produce an appropriate alternative (e.g., a placeholder or positive-status message) rather than an empty spec
+- keep specs minimal — only include the data each component needs; do not duplicate report fields unnecessarily
+- when a report field is missing or null: use the catalog's default/empty-state component for that slot rather than omitting the slot entirely

--- a/packages/std/delivery/file-writer.md
+++ b/packages/std/delivery/file-writer.md
@@ -1,0 +1,53 @@
+---
+name: file-writer
+kind: service
+---
+
+### Shape
+
+- `self`:
+  - write content to a file at a local
+  - S3
+  - or GCS destination
+- `delegates`: none
+- `prohibited`:
+  - modifying the content substance — you serialize and write
+  - you do not edit
+
+### Requires
+
+- content: structured output to write
+- destination: file path or URI — local path, s3:// URI, or gs:// URI
+- format: (optional, default "md") output format — one of "md", "json", "csv", "html"
+
+### Ensures
+
+- written_path: the resolved path or URI where the file was written
+- bytes_written: the size of the written file in bytes
+
+### Errors
+
+- write-failed: the write operation failed (disk full, network error, service unavailable)
+- path-not-found: the parent directory or bucket does not exist
+- permission-denied: insufficient permissions to write to the destination
+
+### Environment
+
+- AWS_ACCESS_KEY_ID: (optional) required for S3 destinations
+- AWS_SECRET_ACCESS_KEY: (optional) required for S3 destinations
+- GOOGLE_APPLICATION_CREDENTIALS: (optional) required for GCS destinations
+
+### Invariants
+
+- content is serialized faithfully in the requested format — no fields added, removed, or transformed beyond format encoding
+- if the destination already exists, it is overwritten (not appended)
+
+### Strategies
+
+- when format is "json": serialize the content as formatted JSON
+- when format is "csv": serialize the content as CSV with headers derived from the data structure
+- when format is "html": write the content as an HTML document
+- when format is "md": write the content as Markdown
+- when destination is an S3 URI: use AWS SDK or CLI to upload
+- when destination is a GCS URI: use Google Cloud SDK or CLI to upload
+- when destination is a local path: write directly to the filesystem

--- a/packages/std/delivery/html-renderer.md
+++ b/packages/std/delivery/html-renderer.md
@@ -1,0 +1,41 @@
+---
+name: html-renderer
+kind: service
+---
+
+### Shape
+
+- `self`: render an HTML document from a template and structured data
+- `delegates`: none
+- `prohibited`:
+  - fetching external data
+  - modifying the data — you render what you're given
+
+### Requires
+
+- template: path to an HTML template with placeholder markers
+- data: structured output from programs
+- output_path: where to write the rendered HTML
+- strict: (optional, default false) boolean — if true, error on missing data fields; if false, use "data pending" markers for missing fields
+
+### Ensures
+
+- rendered: confirmation the file was written successfully
+- html_path: the output file path
+- all template placeholders are resolved to data values, or marked "data pending" in non-strict mode
+
+### Errors
+
+- template-not-found: the template path does not exist or is not readable
+- data-incomplete: (strict mode only) one or more template placeholders have no corresponding data field
+
+### Invariants
+
+- template structure, styling, and layout are preserved exactly — only placeholder markers are replaced
+- output HTML is valid if the input template was valid
+
+### Strategies
+
+- when rendering: replace all placeholder markers in the template with corresponding values from the data. Preserve the template's structure, styling, and layout.
+- when strict is true and a data field is missing: signal data-incomplete error listing all unresolved placeholders
+- when strict is false and a data field is missing: insert a visible "data pending" marker in place of the missing value

--- a/packages/std/delivery/human-gate.md
+++ b/packages/std/delivery/human-gate.md
@@ -1,0 +1,43 @@
+---
+name: human-gate
+kind: service
+---
+
+### Shape
+
+- `self`:
+  - present output for human review
+  - block until approved or rejected
+- `delegates`: none
+- `prohibited`:
+  - modifying the content
+  - approving on behalf of the human
+  - proceeding without explicit approval when gate_level requires it
+
+### Requires
+
+- content: the output to review
+- gate_level: one of "all", "external", "none"
+- review_channel: where to present the review request — e.g. Slack channel ID or email address
+
+### Ensures
+
+- approved: boolean — true if the reviewer approved, or if gate_level is "none" (auto-approved without review)
+- feedback: (optional) structured edits from the reviewer, suitable for `apply(content, feedback)` — present only when the reviewer provides modifications
+- if gate_level is "none": approved is true immediately with no human review and no feedback
+
+### Errors
+
+- reviewer-timeout: the reviewer did not respond within the configured review window
+- channel-unreachable: the review channel could not be contacted (invalid channel, permissions issue, or service unavailable)
+
+### Invariants
+
+- content substance is preserved unless feedback explicitly modifies it
+- when gate_level is "all" or "external", a human must have explicitly approved before approved is true
+
+### Strategies
+
+- when gate_level is "all": post every output for review, block until the reviewer responds
+- when gate_level is "external": only review content that will be sent outside the org (outreach emails, reports to customers)
+- when gate_level is "none": skip review entirely — return approved: true with no feedback

--- a/packages/std/delivery/slack-notifier.md
+++ b/packages/std/delivery/slack-notifier.md
@@ -1,0 +1,41 @@
+---
+name: slack-notifier
+kind: service
+---
+
+### Shape
+
+- `self`:
+  - format content for Slack
+  - deliver via webhook or API
+- `delegates`: none
+- `prohibited`:
+  - modifying the content substance — you format and deliver
+  - you do not edit research or analysis
+
+### Requires
+
+- content: structured output to deliver
+- channel: Slack channel name
+- format: (optional, default "summary+attachment") one of "summary+attachment", "full", "alert"
+
+### Ensures
+
+- delivered: confirmation with timestamp and permalink
+- attachment_url: link to the uploaded file — present only when format is "summary+attachment"
+
+### Errors
+
+- webhook-failed: the Slack webhook returned a non-2xx status or was unreachable
+- channel-not-found: the specified channel does not exist or the bot lacks permission to post there
+
+### Environment
+
+- SLACK_WEBHOOK_URL: webhook for posting messages
+- SLACK_BOT_TOKEN: (required for "summary+attachment" format which uploads files via the Slack API; optional for "full" and "alert" which use webhook only)
+
+### Strategies
+
+- when format is "summary+attachment": post a concise summary in the message body and attach the full content as a file (requires SLACK_BOT_TOKEN for file upload)
+- when format is "full": post the entire content inline via webhook
+- when format is "alert": post a short notification with a link to the full content via webhook

--- a/packages/std/delivery/webhook-notifier.md
+++ b/packages/std/delivery/webhook-notifier.md
@@ -1,0 +1,44 @@
+---
+name: webhook-notifier
+kind: service
+---
+
+### Shape
+
+- `self`: deliver content to an HTTP endpoint via webhook
+- `delegates`: none
+- `prohibited`:
+  - modifying the content substance — you serialize and deliver
+  - you do not edit
+
+### Requires
+
+- content: structured output to deliver
+- url: the destination HTTP endpoint
+- method: (optional, default "POST") HTTP method — one of "POST", "PUT", "PATCH"
+- headers: (optional) additional HTTP headers as key-value pairs (e.g. Content-Type, X-Custom-Header)
+- auth: (optional) authentication configuration — one of: bearer token string, basic auth credentials, or header-based API key
+
+### Ensures
+
+- response_status: the HTTP status code returned by the endpoint
+- response_body: the response body from the endpoint (may be empty)
+- delivered: confirmation with timestamp
+
+### Errors
+
+- request-failed: the HTTP request could not be completed (DNS failure, connection refused, non-2xx status)
+- timeout: the endpoint did not respond within the configured timeout window
+- auth-failed: the provided authentication credentials were rejected (401/403)
+
+### Invariants
+
+- content is serialized faithfully — no fields added, removed, or transformed beyond format encoding
+
+### Strategies
+
+- when auth is a bearer token: include it as Authorization: Bearer header
+- when auth is basic credentials: include it as Authorization: Basic header
+- when auth is an API key: include it in the specified header
+- when no Content-Type header is provided: default to application/json
+- when response status is non-2xx: signal request-failed with the status code and response body for diagnosis

--- a/packages/std/evals/contract-grader.md
+++ b/packages/std/evals/contract-grader.md
@@ -1,0 +1,137 @@
+---
+name: contract-grader
+kind: program
+---
+
+# Contract Grader
+
+The most fundamental eval: did the program do what it promised? Given a completed run, evaluate whether each service's `ensures` clause was actually satisfied by its output. This operates at per-service granularity — a program can have some services that satisfied their contracts and others that did not.
+
+Contract grading is distinct from inspection. The inspector evaluates runtime fidelity (did Press run correctly?) and task effectiveness (did the output achieve the goal?). The contract grader evaluates contract satisfaction (did each service produce what it declared it would produce?). A program can pass inspection but fail contract grading if its contracts are vague and the inspector cannot distinguish "met" from "not met."
+
+### Services
+
+- extractor
+- grader
+- scorer
+
+### Requires
+
+- subject: run — the completed run to grade
+
+### Ensures
+
+- grade: structured contract satisfaction report containing:
+    - run_id: string
+    - program: string
+    - overall_score: 0-100 percentage of contract clauses satisfied
+    - overall_verdict: "satisfied" (all services pass), "partial" (some services pass), or "violated" (majority of services fail)
+    - services: list of per-service grades, each containing:
+        - name: service name
+        - ensures_clauses: list of the service's declared ensures clauses
+        - each clause has: text (the declared clause), verdict ("satisfied", "partially_satisfied", "violated", "not_evaluable"), evidence (specific output content that supports the verdict), confidence (0-100 how certain the grader is)
+        - service_score: 0-100 percentage of clauses satisfied for this service
+    - conditional_ensures: list of conditional ensures clauses (if X: Y) with whether the condition was triggered and whether the degraded output was provided
+    - unevaluable_clauses: list of ensures clauses that are too vague to grade, with explanation of why
+    - recommendations: suggestions for making unevaluable clauses more specific
+
+### Errors
+
+- missing-program: the run directory does not contain program.md
+- missing-manifest: the run directory does not contain manifest.md (cannot determine expected services)
+- no-outputs: the run has no bindings at all (nothing to grade)
+
+### Invariants
+
+- every ensures clause in every service is accounted for — either graded or listed as unevaluable
+- the overall_score is the arithmetic mean of service_scores, weighted by number of clauses per service
+
+### Strategies
+
+- when grading a clause: read the declared ensures text, then read the actual output in the service's bindings. Determine if the output satisfies the commitment. Be strict — "a summary" is satisfied by any summary, but "a 2-3 paragraph summary preserving key claims" requires paragraphs, requires 2-3 of them, and requires that key claims from the input are present.
+- when a clause mentions a specific format (JSON, markdown, list): check that the output is in that format
+- when a clause mentions a specific count ("3+ sources", "at least 5"): count the actual items
+- when a clause mentions a quality criterion ("critically evaluated", "well-sourced"): apply informed judgment but note the subjectivity in the confidence score (lower confidence for subjective criteria)
+- when a clause is too vague to evaluate meaningfully: mark as "not_evaluable" and explain why. "A good report" is not evaluable. "A report containing X, Y, and Z" is.
+- when conditional ensures exist: first determine if the condition was triggered (did the error occur?), then grade the conditional output if so
+- when a service errored: check if the program declared that error and provided a conditional ensures, then grade the degraded path
+
+---
+
+## extractor
+
+Read the run's artifacts and extract all contract information: what each service promised and what each service produced.
+
+### Requires
+
+- subject: the run binding
+
+### Ensures
+
+- contracts: for each service in the run, a structured record containing:
+    - name: service name
+    - ensures_clauses: list of ensures clauses from the service's source file in `services/`
+    - conditional_ensures: list of conditional ensures clauses
+    - actual_output: content of the service's bindings (truncated to 2000 chars per binding if longer)
+    - had_error: boolean (whether `__error.md` exists in workspace)
+    - error_name: the error name if errored, null otherwise
+- program_ensures: the top-level program's ensures clauses
+- program_output: the final output binding content
+
+### Errors
+
+- missing-program: program.md not found
+- missing-manifest: manifest.md not found
+
+### Strategies
+
+- read services from `services/*.md` in the run directory — these are the snapshots from when the program ran
+- read ensures clauses by parsing the contract section of each service file
+- read actual output from `bindings/{service}/` directories
+- for large outputs: include enough content to evaluate each clause, but truncate responsibly
+
+---
+
+## grader
+
+Evaluate each ensures clause against the actual output. This is the core judgment service — it must be precise, evidence-based, and honest about uncertainty.
+
+### Requires
+
+- contracts: extracted contract information from extractor
+
+### Ensures
+
+- grades: for each service, for each ensures clause: verdict, evidence, and confidence
+- each grade has: service_name, clause_text, verdict ("satisfied" / "partially_satisfied" / "violated" / "not_evaluable"), evidence (quoted output content or absence thereof), confidence (0-100)
+
+### Strategies
+
+- grade each clause independently — do not let the verdict on one clause influence another
+- when quoting evidence: use exact text from the output, not paraphrases
+- when a clause has multiple sub-requirements (e.g., "summary with key claims AND confidence scores"): all sub-requirements must be met for "satisfied", some met for "partially_satisfied"
+- when confidence is below 50: mark as "not_evaluable" rather than guessing — it is better to flag an ambiguous clause than to give a false verdict
+- when a service errored and has a conditional ensures: grade the conditional path, not the primary ensures
+- assign confidence based on clause specificity: specific, measurable clauses get high confidence (80-100), subjective quality clauses get medium confidence (50-80), vague clauses get low confidence (below 50)
+
+---
+
+## scorer
+
+Aggregate per-clause grades into per-service and overall scores. Format the final report.
+
+### Requires
+
+- grades: per-clause verdicts from grader
+- contracts: from extractor (for context and recommendations)
+
+### Ensures
+
+- grade: the final output matching the program's top-level ensures schema exactly
+
+### Strategies
+
+- compute service_score as: (satisfied_clauses + 0.5 * partially_satisfied_clauses) / total_evaluable_clauses * 100
+- compute overall_score as weighted mean of service_scores, weighted by clause count
+- for recommendations on unevaluable clauses: suggest specific rewrites that would make the clause testable (e.g., "change 'a good summary' to 'a 2-3 paragraph summary that includes all named entities from the input'")
+- when all clauses are satisfied: still check for conditional ensures that were not tested — note them as untested paths

--- a/packages/std/evals/cross-run-differ.md
+++ b/packages/std/evals/cross-run-differ.md
@@ -1,0 +1,135 @@
+---
+name: cross-run-differ
+kind: program
+---
+
+# Cross-Run Differ
+
+Given 2 or more runs of the same program (different models, inputs, or program versions), produce a structured comparison of outputs, timing, cost, and quality. This enables A/B testing across model tiers, input variations, and program iterations.
+
+### Services
+
+- collector
+- differ
+- recommender
+
+### Requires
+
+- subjects: run[] — completed runs to compare (minimum 2, must be runs of the same program or explicitly related programs)
+
+### Ensures
+
+- comparison: structured diff report containing:
+    - program: the program name (or names if comparing across versions)
+    - runs: list of run metadata (run_id, model, timestamp, duration, status)
+    - output_diff: per-service structured comparison of outputs across runs, highlighting semantic differences (not just textual diffs)
+    - timing_diff: per-service and total duration comparison with relative speedup/slowdown
+    - cost_diff: token usage comparison across runs (if available from state.md or events)
+    - quality_diff: if inspector results are available for these runs, compare scores; otherwise note "no inspection data"
+    - summary: narrative comparison highlighting the most significant differences and their likely causes
+    - recommendation: which run produced the best result and why, or "inconclusive" with reasoning
+
+### Errors
+
+- insufficient-runs: fewer than 2 runs provided
+- different-programs: runs are of different programs with no declared relationship (cannot meaningfully compare)
+- missing-outputs: one or more runs have no bindings (nothing to compare)
+
+### Invariants
+
+- all runs in the comparison are listed, even if some have missing data — partial comparisons are reported, not silently dropped
+- textual diffs are computed deterministically; quality comparisons are judgment calls and are labeled as such
+
+### Strategies
+
+- when comparing outputs: focus on semantic differences, not formatting differences. Two outputs that say the same thing in different words are equivalent. Two outputs that reach different conclusions are substantively different.
+- when runs used different models: note the model tier for each run and consider whether differences are model-capability artifacts
+- when runs used different inputs: separate input-driven differences from program-behavior differences
+- when runs are of different versions of the same program: highlight which program changes caused which output changes
+- when one run failed and another succeeded: this is the most important finding — lead with it
+
+---
+
+## collector
+
+Read all runs and extract comparable data. Validate that the runs are meaningfully comparable.
+
+### Requires
+
+- subjects: the run[] binding
+
+### Ensures
+
+- run-data: for each run, a structured record containing:
+    - run_id: string
+    - program_name: from program.md
+    - program_hash: content hash of program.md (to detect version differences)
+    - model: model used (if specified in program or manifest)
+    - status: "complete", "failed", or "partial"
+    - duration: total run time from state.md timestamps
+    - services: list of service names with per-service completion status and duration
+    - outputs: map of service name to binding content (truncated to 2000 chars per binding)
+    - token_count: total tokens if available from events or cost.json
+- comparability: assessment of whether these runs are meaningfully comparable, with explanation
+
+### Errors
+
+- insufficient-runs: fewer than 2 valid runs
+- different-programs: programs have different names and no structural similarity
+
+### Strategies
+
+- when extracting duration: parse the first timestamp from state.md header and the `---end` timestamp, compute the difference
+- when programs have the same name but different content: they are version comparisons — flag the differences
+- when programs have different names but similar structure: warn but allow comparison if the user explicitly provided them
+- when token data is not available: note "token data unavailable" rather than estimating
+
+---
+
+## differ
+
+Produce structured diffs across all dimensions: output content, timing, cost, and quality.
+
+### Requires
+
+- run-data: collected data from collector
+
+### Ensures
+
+- diffs: structured comparison containing:
+    - output_diff: per-service comparison with semantic similarity assessment and highlighted divergences
+    - timing_diff: per-service duration comparison with relative percentages
+    - cost_diff: token comparison with relative percentages (or "unavailable")
+    - quality_diff: inspector score comparison if available
+    - key_differences: ranked list of the most significant differences across all dimensions
+
+### Strategies
+
+- for output comparison: identify the highest-value output (usually the final service's binding) and compare it in detail first, then compare intermediate services
+- for timing comparison: normalize to the fastest run as baseline, report others as percentage slower
+- for cost comparison: normalize to the cheapest run as baseline
+- when more than 2 runs: present as a table with one column per run, not pairwise comparisons
+- when outputs are identical: explicitly note "outputs are identical" — this is an important finding (means the model/input change had no effect)
+
+---
+
+## recommender
+
+Synthesize the diffs into actionable recommendations.
+
+### Requires
+
+- diffs: structured comparison from differ
+- run-data: from collector (for context)
+
+### Ensures
+
+- comparison: the final output matching the program's top-level ensures schema, with recommendation and summary
+
+### Strategies
+
+- when one run is clearly better on all dimensions: recommend it clearly
+- when runs trade off (one faster, another higher quality): present the tradeoff and let the user decide, but state which dimension matters more for this type of program
+- when differences are negligible: recommend the cheaper/faster run and note that quality is equivalent
+- when a run failed: recommend investigating the failure before drawing conclusions from the comparison
+- always ground recommendations in evidence from the diffs — never make unsupported claims about run quality

--- a/packages/std/evals/eval-calibrator.md
+++ b/packages/std/evals/eval-calibrator.md
@@ -1,0 +1,201 @@
+---
+name: eval-calibrator
+kind: program
+---
+
+# Eval Calibrator
+
+Validate that light inspections reliably predict deep inspection outcomes. This is the meta-eval — it measures whether the fast, cheap eval (light) is a trustworthy proxy for the thorough, expensive eval (deep). If light and deep agree consistently, teams can use light inspections in CI and reserve deep inspections for investigation.
+
+### Services
+
+- sampler
+- runner
+- comparator
+- statistician
+- advisor
+
+### Requires
+
+- subjects: run[] — completed runs to calibrate on (minimum 3, recommended 10+)
+
+### Ensures
+
+- report: calibration report containing:
+    - sample_size: number of runs analyzed
+    - agreement_rate: percentage of runs where light and deep verdicts match (pass/partial/fail)
+    - score_correlation: Pearson correlation between light and deep scores for runtime_fidelity and task_effectiveness
+    - disagreements: list of runs where light and deep diverged, each with both verdicts, both scores, and the nature of the disagreement
+    - bias_direction: whether light tends to be optimistic (scores higher than deep) or pessimistic (scores lower) or neutral
+    - confidence: "high" (20+ runs, agreement > 90%), "medium" (10+ runs, agreement > 75%), or "low" (fewer runs or lower agreement)
+    - recommendations: prioritized list of improvements to light eval criteria based on disagreement patterns
+
+### Errors
+
+- insufficient-runs: fewer than 3 runs provided
+- homogeneous-sample: all runs are from the same program (calibration requires diversity)
+
+### Invariants
+
+- all statistical calculations are performed deterministically via code execution, never by LLM arithmetic
+- every run in the sample receives both a light and deep inspection — no run is skipped
+
+### Strategies
+
+- when sample is small (3-5 runs): lower confidence accordingly, note that results are preliminary
+- when all runs agree: still report the result but flag that adversarial or edge-case runs would strengthen the calibration
+- when disagreements cluster around a specific failure mode: highlight that mode as the priority improvement target
+
+---
+
+## sampler
+
+Select and validate the sample of runs for calibration. Ensure diversity across programs, outcomes, and complexity.
+
+### Requires
+
+- subjects: the run[] binding from the caller
+
+### Ensures
+
+- sample: validated list of run paths with metadata (program name, completion status, service count) sorted by diversity score
+- sample-stats: summary of sample composition (programs represented, success/failure ratio, size distribution)
+
+### Errors
+
+- insufficient-runs: fewer than 3 valid runs in the input
+- homogeneous-sample: all runs are from the same program
+
+### Strategies
+
+- when more runs are provided than needed: prefer a diverse subset — different programs, mix of pass/fail, different sizes
+- when validating: confirm each run has state.md, program.md, and at least one binding
+
+---
+
+## runner
+
+Execute the inspector on each sampled run at both depths. This service composes `std/evals/inspector` — it does not re-implement inspection logic.
+
+### Shape
+
+- `self`:
+  - invoke inspector at both depths for each run
+  - collect results
+- `delegates`:
+  - `inspector`: perform the actual inspection
+- `prohibited`:
+  - performing inspection logic directly
+  - judging run quality
+
+
+### Requires
+
+- sample: validated run list from sampler
+
+### Ensures
+
+- inspections: for each run in the sample, a pair of inspection results — one from `depth: light` and one from `depth: deep`
+- each inspection pair has: run_id, light_inspection (full inspector output), deep_inspection (full inspector output)
+
+### Errors
+
+- inspector-failed: the inspector program itself failed on one or more runs (include which runs and why)
+
+### Strategies
+
+- for each run: invoke `std/evals/inspector` with `depth: light`, then invoke again with `depth: deep`
+- if inspector fails on a run: record the failure, continue to next run, report partial results
+- do not attempt to inspect a run and its inspection simultaneously — sequential per run, parallel across runs if possible
+
+---
+
+## comparator
+
+Compare light and deep inspection results for each run. Identify agreements, disagreements, and patterns.
+
+### Requires
+
+- inspections: paired light/deep results from runner
+
+### Ensures
+
+- comparisons: for each run, a structured comparison containing:
+    - run_id: string
+    - verdict_match: boolean (light verdict == deep verdict)
+    - runtime_fidelity_delta: deep score minus light score (positive means light underestimated)
+    - task_effectiveness_delta: deep score minus light score
+    - flag_overlap: flags found by both, flags found only by light, flags found only by deep
+    - disagreement_type: null if agree, or one of "false_positive" (light flagged, deep did not), "false_negative" (light missed, deep caught), "severity_mismatch" (same flag, different severity), "verdict_split" (different verdict category)
+    - notes: explanation of significant differences
+
+### Strategies
+
+- when scores differ by less than 10 points but verdicts match: classify as agreement with minor calibration noise
+- when verdicts differ: always classify as disagreement regardless of score proximity
+- when light finds flags that deep does not: this is a false positive — note it but recognize it may indicate light is being overly cautious (not necessarily bad)
+
+---
+
+## statistician
+
+Compute aggregate statistics from the comparisons. All calculations must be performed via code execution — never by LLM arithmetic.
+
+### Shape
+
+- `self`: compute statistics using code execution
+- `prohibited`:
+  - performing arithmetic mentally
+  - estimating correlations without calculation
+
+
+### Requires
+
+- comparisons: per-run comparison data from comparator
+
+### Ensures
+
+- statistics: computed metrics containing:
+    - agreement_rate: percentage of verdict matches (with 95% confidence interval)
+    - score_correlation: Pearson r for runtime_fidelity scores and task_effectiveness scores between light and deep
+    - mean_score_delta: average (deep - light) for each score type
+    - bias_direction: "optimistic" if mean delta < -5 (light scores higher), "pessimistic" if > 5, "neutral" otherwise
+    - disagreement_breakdown: count by disagreement_type
+    - confidence_level: "high", "medium", or "low" per the program's ensures criteria
+
+### Errors
+
+- computation-failed: code execution failed (include the error)
+
+### Strategies
+
+- when computing correlation with fewer than 5 points: report "insufficient data for correlation" instead of a misleading r value
+- when computing confidence intervals: use Wilson score interval for proportions, not the normal approximation
+- always show your work: include the raw numbers alongside computed statistics
+
+---
+
+## advisor
+
+Analyze disagreement patterns and recommend improvements to the light evaluation criteria.
+
+### Requires
+
+- comparisons: from comparator
+- statistics: from statistician
+
+### Ensures
+
+- recommendations: prioritized list of improvements, each with:
+    - priority: 1 (highest) through N
+    - target: which aspect of light eval to change
+    - rationale: what disagreement pattern motivates this
+    - proposed_change: specific description of what to adjust
+    - expected_impact: how much this would improve agreement rate
+
+### Strategies
+
+- when agreement is high (> 90%): recommendations should focus on edge cases and maintaining reliability
+- when agreement is low (< 75%): recommendations should focus on the most common disagreement type first
+- when light is consistently optimistic: recommend adding specific structural checks that catch the issues deep finds
+- when light is consistently pessimistic: recommend relaxing specific criteria that trigger false positives

--- a/packages/std/evals/inspector.md
+++ b/packages/std/evals/inspector.md
@@ -1,0 +1,169 @@
+---
+name: inspector
+kind: program
+---
+
+# Post-Run Inspector
+
+Analyze a completed Prose run for runtime fidelity (did Press execute the program correctly?) and task effectiveness (did the program accomplish its goal?). This is the foundational eval — every other eval in the standard library depends on inspector output.
+
+### Services
+
+- index
+- extractor
+- evaluator
+- synthesizer
+
+### Requires
+
+- subject: run — the completed run to inspect
+- depth: inspection depth — "light" (fast, checks structure and outputs exist) or "deep" (thorough, reads all artifacts, traces execution against program spec)
+
+### Ensures
+
+- inspection: structured inspection report containing:
+    - run_id: the inspected run's identifier
+    - program: the program that was run
+    - depth: which depth was performed
+    - runtime_fidelity: score (0-100) measuring how faithfully Press executed the program
+    - task_effectiveness: score (0-100) measuring how well the program accomplished its stated goal
+    - services: per-service breakdown with status, timing, contract satisfaction
+    - flags: list of specific issues found, each with severity (info / warning / critical) and evidence
+    - verdict: overall assessment — "pass", "partial", or "fail"
+    - summary: 2-3 sentence human-readable summary
+
+### Errors
+
+- missing-artifacts: the run directory is missing critical files (state.md, program.md, or manifest.md)
+- corrupted-state: state.md exists but cannot be parsed (no event markers, no header)
+
+### Invariants
+
+- inspection output is deterministic for a given run and depth — the same run inspected twice at the same depth produces the same scores and verdict
+
+### Strategies
+
+- when depth is light: check structural completeness only — state.md has `---end` or `---error`, all declared services have bindings, output files are non-empty, no `__error.md` files. Do not read output content in detail. Target: under 30 seconds, under 10K tokens.
+- when depth is deep: read program.md to understand intent, read manifest.md to understand expected wiring, trace state.md event markers against the manifest's execution order, read each service's workspace artifacts and bindings, evaluate output quality against the program's ensures clauses. Target: thorough analysis, no shortcuts.
+- when a service has `__error.md`: read it, classify the error, check whether the program's conditional ensures handled the degradation correctly
+- when scoring runtime fidelity: weight heavily on execution order correctness (did services run in the right order?), binding integrity (did outputs get copied correctly?), and state.md completeness (are all markers present?)
+- when scoring task effectiveness: weight heavily on whether the program's top-level ensures clauses are satisfied by the final output in bindings
+
+---
+
+## index
+
+The index is a persistent agent that maintains a registry of all inspections performed. It enables deduplication (skip re-inspecting the same run at the same depth) and cross-inspection queries.
+
+### Runtime
+
+- `persist`: user
+
+
+### Requires
+
+- subject: the run binding from the caller
+
+### Ensures
+
+- prior-inspections: JSON list of any prior inspections of this run, with their depth and verdict. Empty list if none found.
+
+### Strategies
+
+- maintain a compact registry: run_id, program, depth, verdict, timestamp
+- when queried about a run: return all matching entries
+- keep the registry under 500 entries by evicting oldest entries
+
+---
+
+## extractor
+
+Read the run's artifacts and produce a structured extraction suitable for evaluation. The extractor does not judge — it reads and organizes.
+
+### Requires
+
+- subject: the run binding
+- depth: "light" or "deep"
+- prior-inspections: from index
+
+### Ensures
+
+- extraction: structured data containing:
+    - run_id: string
+    - program_name: string
+    - completed: boolean (state.md has `---end`)
+    - failed: boolean (state.md has `---error`)
+    - error_count: number of `✗` markers in state.md
+    - services_declared: list of service names from manifest
+    - services_completed: list of service names with `✓` markers
+    - services_errored: list of service names with `✗` markers
+    - bindings_present: list of binding paths that exist and are non-empty
+    - bindings_missing: list of expected bindings that are absent or empty
+    - (deep only) program_source: full content of program.md
+    - (deep only) manifest_summary: execution order and wiring from manifest.md
+    - (deep only) service_outputs: map of service name to first 500 chars of each binding
+    - (deep only) workspace_artifacts: map of service name to list of files in workspace
+    - (deep only) error_details: contents of any `__error.md` files
+
+### Errors
+
+- unreadable-run: cannot read required files from the run directory
+
+### Strategies
+
+- when depth is light and a prior deep inspection exists: note "prior deep available" in extraction but do not skip light extraction (light is cheap, always re-run)
+- when reading large files: truncate to relevant portions, never attempt to load entire multi-MB outputs
+- when state.md uses `->` instead of `→`: accept both forms per spec
+
+---
+
+## evaluator
+
+Apply judgment to the extraction. Score runtime fidelity and task effectiveness independently. The evaluator is the most critical service — it must be precise, evidence-based, and calibrated.
+
+### Requires
+
+- extraction: structured extraction from extractor
+- depth: "light" or "deep"
+
+### Ensures
+
+- evaluation: structured judgment containing:
+    - runtime_fidelity: object with score (0-100), breakdown (execution_order, binding_integrity, state_completeness, error_handling — each 0-100), and evidence (list of specific observations)
+    - task_effectiveness: object with score (0-100), breakdown (output_existence, output_substance, contract_satisfaction, goal_alignment — each 0-100), and evidence (list of specific observations)
+    - flags: list of issues, each with id, severity (info / warning / critical), description, and evidence
+    - verdict: "pass" (both scores >= 70, no critical flags), "partial" (one score < 70 or critical flags present but run completed), or "fail" (either score < 40 or run did not complete)
+
+### Errors
+
+- insufficient-data: extraction is too sparse to evaluate (e.g., light extraction of a failed run with no bindings)
+
+### Strategies
+
+- when depth is light: evaluate only structural metrics — completion, binding existence, error absence. Score conservatively (cap at 85 for runtime fidelity, 80 for task effectiveness) since light cannot verify content quality.
+- when depth is deep: evaluate everything — trace execution against manifest, read outputs against ensures, check for shape violations, assess output quality
+- when scoring: use the full 0-100 range. A perfect run scores 95-100, not 100 (reserve 100 for extraordinary cases). A run with minor issues scores 70-85. A run with significant problems scores 40-69. A fundamentally broken run scores below 40.
+- when a run failed but produced partial output: evaluate what exists. A failed run can still have high task effectiveness if the partial output is useful.
+- when evidence conflicts: note the conflict explicitly in flags rather than silently resolving it
+
+---
+
+## synthesizer
+
+Combine evaluation results into the final inspection report. Format for both machine consumption (structured JSON) and human readability (summary text).
+
+### Requires
+
+- extraction: from extractor
+- evaluation: from evaluator
+- prior-inspections: from index
+
+### Ensures
+
+- inspection: the final inspection report matching the program's top-level ensures schema exactly
+
+### Strategies
+
+- when prior inspections exist: note trends (e.g., "this run scored higher/lower than previous inspections of the same program")
+- when formatting: the inspection must be valid JSON with a `summary` field containing markdown prose — machine-parseable with a human-readable summary embedded
+- when the verdict is "fail": the summary must lead with the most critical issue and its evidence, not with boilerplate

--- a/packages/std/evals/platform-improver.md
+++ b/packages/std/evals/platform-improver.md
@@ -1,0 +1,132 @@
+---
+name: platform-improver
+kind: program
+---
+
+# Platform Improver
+
+Given an inspection report and a symptom description, diagnose whether the issue belongs to the Prose language layer, the Forme framework layer, or the Press runtime layer, and propose a targeted fix for the correct layer. The three-layer architecture (Prose/Forme/Press) means that a single symptom can have its root cause in any layer, and fixing the wrong layer creates compensatory complexity.
+
+### Services
+
+- triager
+- analyst
+- proposer
+
+### Requires
+
+- inspection: run — a completed inspector run showing the problematic behavior
+- symptom: description of what went wrong or what should be better (e.g., "services ran sequentially despite no dependencies", "output was empty despite no errors", "wrong model was used for the critic service")
+
+### Ensures
+
+- diagnosis: structured analysis containing:
+    - layer: which layer owns the fix — "prose" (the program's .md files), "forme" (the wiring algorithm in std/ops/wire), or "press" (the runtime execution engine)
+    - confidence: 0-100 confidence that this is the correct layer
+    - reasoning: chain of evidence from symptom to layer attribution
+    - root_cause: precise description of what went wrong in the identified layer
+    - proposed_fix: description of the change needed
+    - diff: unified diff against the relevant source file (program source for prose, wire.md for forme, prose.md/forme.md specs for press)
+    - side_effects: what else might change if this fix is applied
+    - verification: how to verify the fix works (which eval to run, what to look for)
+- if symptom is ambiguous: diagnosis includes alternative hypotheses ranked by likelihood
+
+### Errors
+
+- insufficient-evidence: the inspection does not contain enough data to diagnose the symptom
+- symptom-not-reproducible: the inspection shows no evidence of the described symptom
+
+### Invariants
+
+- never propose fixing two layers simultaneously — if the root cause spans layers, identify the primary layer and note the secondary as a follow-up
+- never make a layer more complex to compensate for another layer's bug — the fix must make the system simpler or equal, never more complex
+
+### Strategies
+
+- when triaging to prose layer: the issue is in what the author wrote — bad contracts, missing strategies, wrong shapes, insufficient error declarations. The fix is editing the program's .md files.
+- when triaging to forme layer: the issue is in how components were wired — wrong dependency resolution, incorrect execution order, missed parallelization, bad contract matching. The fix is in `std/ops/wire` or the wiring algorithm.
+- when triaging to press layer: the issue is in how the runtime executed — session spawning errors, binding copy failures, state.md corruption, context management bugs, delegation protocol errors. The fix is in the runtime spec or implementation.
+- when the symptom could be any layer: start with the most common cause (prose > forme > press — author errors are more common than framework bugs, which are more common than runtime bugs)
+
+---
+
+## triager
+
+Read the inspection output and symptom, determine which layer most likely owns the issue. This is the critical judgment — misattribution means wasted effort.
+
+### Requires
+
+- inspection: the inspection run binding
+- symptom: the symptom description
+
+### Ensures
+
+- triage: layer attribution containing:
+    - primary_layer: "prose", "forme", or "press"
+    - confidence: 0-100
+    - evidence: list of specific inspection findings that point to this layer
+    - alternative_layers: list of other plausible layers with lower confidence and reasoning
+    - symptom_category: classification of the symptom type (e.g., "execution_order", "missing_output", "wrong_model", "contract_violation", "state_corruption", "delegation_failure")
+
+### Strategies
+
+- indicators of prose layer issues: contract violations (ensures not satisfied), shape violations (service did work it should delegate), missing error handling (undeclared errors), vague strategies (no concrete guidance)
+- indicators of forme layer issues: wrong execution order despite correct dependency declarations, services wired to wrong inputs, missing parallelization despite independent services, incorrect manifest generation
+- indicators of press layer issues: state.md markers missing or malformed, bindings not copied despite workspace containing the output, session spawning failures, delegation protocol errors, context window exhaustion
+- when confidence is below 60: require the analyst to investigate all plausible layers before committing
+
+---
+
+## analyst
+
+Deep-dive into the identified layer. Read the relevant source files and trace the causal chain from symptom to root cause.
+
+### Requires
+
+- triage: layer attribution from triager
+- inspection: the inspection run binding
+- symptom: the symptom description
+
+### Ensures
+
+- analysis: detailed root cause analysis containing:
+    - root_cause: precise description of the bug or deficiency
+    - causal_chain: ordered list of events from root cause to observed symptom
+    - affected_file: path to the file that needs changing
+    - affected_section: specific section or lines within the file
+    - current_behavior: what the affected code/spec currently does
+    - desired_behavior: what it should do instead
+
+### Errors
+
+- insufficient-evidence: cannot trace from symptom to root cause with available data
+
+### Strategies
+
+- for prose layer: read the program's .md files from the inspection run's `services/` and `program.md`. Trace which contract clause is violated, which shape boundary is breached, or which strategy is missing.
+- for forme layer: read the manifest.md from the inspection run. Compare the wiring graph against what the component contracts should produce. Check if `std/ops/wire` would produce different output with a fix.
+- for press layer: read state.md event markers in detail. Compare actual execution trace against what manifest.md prescribes. Look for gaps, ordering violations, or protocol errors in the session spawning and binding copy sequence.
+- when the triage confidence was low: investigate the alternative layers too and present findings for all candidates
+
+---
+
+## proposer
+
+Generate the concrete fix: a diff against the correct source file, with side effect analysis and verification plan.
+
+### Requires
+
+- analysis: root cause analysis from analyst
+- triage: layer attribution from triager
+
+### Ensures
+
+- diagnosis: the final output matching the program's top-level ensures schema, with diff and verification plan
+
+### Strategies
+
+- when the fix is in prose layer: generate a diff against the program's source .md file. The program author applies this.
+- when the fix is in forme layer: generate a diff against `std/ops/wire.md`. This is a standard library change.
+- when the fix is in press layer: generate a diff against the relevant spec file (`prose.md` for execution semantics, `forme.md` for wiring semantics). This is a platform change — flag it for maintainer review.
+- for side effect analysis: consider what other programs or evals might be affected by this change. A press-layer fix affects all programs. A forme-layer fix affects all multi-service programs. A prose-layer fix affects only the specific program.
+- for verification: specify which eval to run (inspector at depth:deep, contract-grader, or regression-tracker) and what the expected outcome should be after the fix

--- a/packages/std/evals/program-improver.md
+++ b/packages/std/evals/program-improver.md
@@ -1,0 +1,122 @@
+---
+name: program-improver
+kind: program
+---
+
+# Program Improver
+
+Given an inspection report and the inspected program's source, analyze the program for improvement opportunities and produce ranked proposals with diffs. This program operates on Prose v1 programs (.md format) and understands the full contract surface: requires, ensures, errors, invariants, strategies, environment, and shapes.
+
+### Services
+
+- locator
+- analyst
+- implementer
+
+### Requires
+
+- inspection: run — a completed inspector run whose output identifies issues with a program
+- source-path: path to the program's source directory (the .md files)
+
+### Ensures
+
+- improvements: ranked list of improvement opportunities, each containing:
+    - rank: priority position (1 = highest impact)
+    - category: one of "contract" (ensures/requires quality), "strategy" (missing or vague strategies), "shape" (delegation boundary violations), "structure" (service decomposition issues), "error-handling" (missing error declarations or conditional ensures), "efficiency" (unnecessary services or missing parallelization)
+    - description: what the problem is
+    - evidence: specific reference to inspection findings and program source
+    - diff: proposed change as a unified diff against the source file
+    - risk: "low" (safe refactor), "medium" (changes contract surface), or "high" (changes program behavior)
+- if no improvements found: empty list with explanation of why the program is sound
+
+### Errors
+
+- source-not-found: the source-path does not contain valid Prose program files
+- inspection-invalid: the inspection run output is not a valid inspector report
+
+### Strategies
+
+- when analyzing contracts: check that every ensures clause is specific enough to evaluate — vague ensures like "a good report" are improvement targets
+- when analyzing strategies: check that strategies cover the program's known failure modes — if the inspection shows failures, the program should have strategies to handle them
+- when analyzing shapes: verify that services with shape.delegates actually delegate (not collapse), and services with shape.prohibited do not violate boundaries
+- when proposing diffs: make minimal changes — one concern per diff. Never rewrite a program wholesale.
+- when ranking: prioritize contract violations and missing error handling over efficiency improvements
+
+---
+
+## locator
+
+Find and read the program source files. Validate that the source path contains a valid Prose program.
+
+### Requires
+
+- source-path: path to the program's source directory
+- inspection: the inspection run binding
+
+### Ensures
+
+- program-source: the entry point file content (the file with `kind: program`)
+- service-sources: map of service name to file content for each service in the program
+- inspection-output: the inspection report extracted from the inspection run's bindings
+
+### Errors
+
+- source-not-found: source-path does not exist or contains no `kind: program` file
+- inspection-invalid: cannot find or parse the inspection output from the run
+
+### Strategies
+
+- look for the entry point by scanning .md files for `kind: program` in frontmatter
+- resolve service files relative to the entry point's directory
+- read the inspection output from the run's bindings directory
+
+---
+
+## analyst
+
+Examine the program source against the inspection findings. Identify every improvement opportunity with evidence from both sources.
+
+### Requires
+
+- program-source: entry point content from locator
+- service-sources: service file contents from locator
+- inspection-output: inspection report from locator
+
+### Ensures
+
+- analysis: list of improvement opportunities, each with category, description, evidence, affected file, and estimated impact
+- each opportunity has: a reference to the specific inspection finding that motivates it AND a reference to the specific source location that needs changing
+
+### Strategies
+
+- check contract quality: are ensures clauses specific and evaluable? are requires clauses typed clearly? are error conditions declared for plausible failure modes?
+- check strategy coverage: does every service that could fail have relevant strategies? do strategies reference concrete conditions, not vague heuristics?
+- check shape consistency: do shape.self lists match what the service actually does? do shape.delegates match the services list? are shape.prohibited entries respected in the service body?
+- check structural efficiency: are independent services wired for parallel execution? are there services that could be merged or split?
+- check error handling: does the program have conditional ensures for each declared error? are degradation paths specified?
+- when the inspection shows a "pass" verdict: still look for improvements — a passing program can still have quality issues
+- when the inspection shows a "fail" verdict: prioritize the root cause of failure above all other improvements
+
+---
+
+## implementer
+
+Transform analysis results into concrete diffs. Each diff must be minimal, correct, and independently applicable.
+
+### Requires
+
+- analysis: improvement opportunities from analyst
+- program-source: entry point content from locator
+- service-sources: service file contents from locator
+
+### Ensures
+
+- improvements: the final ranked list matching the program's top-level ensures schema, with diffs generated for each opportunity
+
+### Strategies
+
+- when generating diffs: use unified diff format with enough context lines (3+) to unambiguously locate the change
+- when multiple improvements affect the same file: ensure diffs are independently applicable (no conflicts if applied in isolation)
+- when a change affects the contract surface (requires/ensures): flag as "medium" risk since downstream consumers may depend on the current contract
+- when a change only affects strategies or internal service content: flag as "low" risk
+- when proposing new services or removing existing ones: flag as "high" risk

--- a/packages/std/evals/regression-tracker.md
+++ b/packages/std/evals/regression-tracker.md
@@ -1,0 +1,151 @@
+---
+name: regression-tracker
+kind: program
+---
+
+# Regression Tracker
+
+Maintain a registry of "known good" baseline runs for each program. When a new run completes, compare it against the baseline and flag regressions. This is the continuous quality gate — it answers "did this change make things worse?" without requiring a human to review every run.
+
+The registry is persistent at the project level, so baselines survive across runs and can be updated when a new run is confirmed as the new standard.
+
+### Services
+
+- registry
+- comparator
+- reporter
+
+### Requires
+
+- subject: run — the new run to compare against baseline
+- program-name: the program name to look up the baseline for (e.g., "deep-research", "anomaly-detective")
+- action: "check" (compare against baseline), "set-baseline" (register this run as the new baseline), or "list" (show all registered baselines)
+
+### Ensures
+
+- report: regression report containing:
+    - program: the program name
+    - action: which action was performed
+    - (for check) status: "pass" (no regressions), "regressed" (worse than baseline), or "improved" (better than baseline)
+    - (for check) baseline_run_id: which baseline was compared against
+    - (for check) new_run_id: the new run's ID
+    - (for check) dimensions: per-dimension comparison (contract_satisfaction, output_quality, timing, error_rate) each with baseline value, new value, delta, and verdict
+    - (for check) evidence: specific differences that support the overall status
+    - (for check) recommendation: "promote to baseline" (if improved), "investigate regression" (if regressed), or "no action needed" (if pass)
+    - (for set-baseline) confirmation: which run was registered as baseline for which program
+    - (for list) baselines: list of all registered baselines with program name, run_id, timestamp, and scores
+- if no baseline exists for this program: report notes "no baseline — registering this run as initial baseline" and performs set-baseline automatically
+
+### Errors
+
+- run-not-found: the subject run does not exist or is incomplete
+- baseline-corrupted: the registered baseline run no longer exists on disk
+
+### Strategies
+
+- when comparing against baseline: use contract-grader scores if available, otherwise use inspector scores, otherwise fall back to structural comparison (output existence and size)
+- when a regression is detected: identify the specific dimension that regressed and provide evidence — "task_effectiveness dropped from 85 to 62 because the synthesizer's output is missing the sources section"
+- when an improvement is detected: still compare carefully — an improvement in one dimension might mask a regression in another
+- when the baseline run no longer exists on disk: flag as corrupted and recommend setting a new baseline
+- when action is "check" but no baseline exists: automatically set this run as the baseline and report that
+
+---
+
+## registry
+
+Persistent agent that maintains the baseline registry. Maps program names to baseline run IDs and their scores.
+
+### Runtime
+
+- `persist`: project
+
+
+### Requires
+
+- subject: the run binding
+- program-name: the program name
+- action: "check", "set-baseline", or "list"
+
+### Ensures
+
+- registry-state: current state of the registry for this program, containing:
+    - has_baseline: boolean
+    - baseline_run_id: string or null
+    - baseline_scores: object with contract_satisfaction, runtime_fidelity, task_effectiveness scores (or null if no baseline)
+    - baseline_timestamp: when the baseline was registered
+    - all_baselines: (for "list" action) complete registry contents
+
+### Strategies
+
+- maintain a compact registry: program_name, baseline_run_id, baseline_scores, timestamp
+- when action is "set-baseline": update the registry entry for this program
+- when action is "check": return the current baseline without modifying the registry
+- when action is "list": return all entries
+- keep a history of previous baselines (last 5 per program) for trend analysis
+- when the registry grows beyond 100 programs: warn but do not evict — regression tracking should not lose data silently
+
+---
+
+## comparator
+
+Compare the new run against the baseline across all quality dimensions. This service reads artifacts from both runs.
+
+### Requires
+
+- subject: the new run binding
+- registry-state: from registry (contains baseline run ID and scores)
+
+### Ensures
+
+- comparison: structured comparison containing:
+    - baseline_run_id: string
+    - new_run_id: string
+    - dimensions: list of dimension comparisons, each with:
+        - name: "contract_satisfaction", "output_quality", "timing", "error_rate"
+        - baseline_value: number or descriptor
+        - new_value: number or descriptor
+        - delta: numeric difference (positive = improvement, negative = regression)
+        - verdict: "improved", "stable", "regressed"
+        - evidence: specific observations supporting the verdict
+    - overall_status: "pass", "regressed", or "improved" (regressed if any dimension regressed and delta exceeds threshold)
+- if no baseline: comparison is null (registry will handle auto-registration)
+
+### Errors
+
+- baseline-corrupted: baseline run directory does not exist or is missing critical files
+
+### Strategies
+
+- for contract_satisfaction: compare ensures clause satisfaction rates. Run contract-grader logic on both if needed, or use cached scores from registry.
+- for output_quality: compare final output content — is the new run's output as comprehensive, accurate, and well-structured as the baseline's?
+- for timing: compare durations from state.md. A slowdown of more than 50% is a regression. A speedup is an improvement.
+- for error_rate: compare error markers in state.md. Any new errors that the baseline did not have are regressions.
+- regression thresholds: contract_satisfaction drop > 10 points, output quality materially worse (judgment call), timing > 50% slower, any new errors
+- when baseline has cached scores: use them rather than re-reading all baseline artifacts (the registry stores scores for this reason)
+
+---
+
+## reporter
+
+Synthesize the comparison into the final regression report. Handle all three actions (check, set-baseline, list).
+
+### Requires
+
+- registry-state: from registry
+- comparison: from comparator (may be null for set-baseline and list actions)
+- action: the requested action
+- subject: the run binding
+- program-name: the program name
+
+### Ensures
+
+- report: the final output matching the program's top-level ensures schema
+
+### Strategies
+
+- for "check" with regression: lead with the most severe regression, include evidence, recommend investigation before promoting
+- for "check" with improvement: lead with the improvement, recommend promoting to baseline, but note any dimensions that stayed the same or slightly degraded
+- for "check" with pass: brief confirmation that the new run matches baseline quality
+- for "set-baseline": confirm registration with the run ID and scores that were recorded
+- for "list": format as a table with program name, baseline run ID, timestamp, and key scores
+- always include the recommendation field — this is the actionable output that CI pipelines will read

--- a/packages/std/examples/composed-reviewer/index.md
+++ b/packages/std/examples/composed-reviewer/index.md
@@ -1,0 +1,23 @@
+---
+name: composed-reviewer
+kind: program
+---
+
+### Description
+
+Demonstrates Level 1 composite instantiation — a writer with worker-critic review.
+
+### Services
+
+- `reviewed-draft`: `std/composites/worker-critic`
+  - `worker`: `writer`
+  - `critic`: `reviewer`
+  - `max_rounds`: 2
+
+### Requires
+
+- task_brief: a combined brief describing the topic and audience for the article
+
+### Ensures
+
+- article: a polished article that has passed quality review

--- a/packages/std/examples/composed-reviewer/reviewer.md
+++ b/packages/std/examples/composed-reviewer/reviewer.md
@@ -1,0 +1,29 @@
+---
+name: reviewer
+kind: service
+---
+
+### Description
+
+Evaluate a piece of writing against quality criteria and return a structured verdict.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- output: the article to review
+- criteria: quality standards to evaluate against (optional — uses editorial best practices if not provided)
+
+### Ensures
+
+- verdict: "accept" or "reject"
+- reasoning: why the verdict was reached
+- suggestions: specific, actionable improvements (empty list if accepted)
+
+### Strategies
+
+- evaluate clarity, specificity, and audience fit
+- flag vague claims, missing examples, or unsupported assertions
+- accept if the article is publishable as-is; reject if substantive improvements are needed

--- a/packages/std/examples/composed-reviewer/writer.md
+++ b/packages/std/examples/composed-reviewer/writer.md
@@ -1,0 +1,26 @@
+---
+name: writer
+kind: service
+---
+
+### Description
+
+Produce a well-structured article on a given topic for a specified audience.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- task_brief: a combined brief describing the topic and audience for the article
+
+### Ensures
+
+- output: a clear, well-structured article based on the brief
+
+### Strategies
+
+- open with a hook that connects the topic to the audience's concerns
+- use specific examples and named references rather than generic statements
+- keep paragraphs short and scannable

--- a/packages/std/examples/confident-writer/index.md
+++ b/packages/std/examples/confident-writer/index.md
@@ -1,0 +1,33 @@
+---
+name: confident-writer
+kind: program
+---
+
+# Confident Writer
+
+### Description
+
+Demonstrates Level 3 decorator syntax — a writer with stacked review and confidence measurement.
+
+### Services
+
+- `writer`
+  - `review`: `worker-critic(critic: reviewer, max_rounds: 2)`
+  - `confidence`: `stochastic-probe(analyst: variance-analyst, sample_size: 3)`
+
+### Requires
+
+- task_brief: a combined brief describing the topic and audience for the article
+
+### Ensures
+
+- article: a polished article that has been quality-reviewed and confidence-scored
+
+### Notes
+
+This program desugars to two nested composite instantiations:
+
+1. `worker-critic` wraps `writer` (primary slot) with `reviewer` as the critic
+2. `stochastic-probe` wraps the reviewed writer, running the entire worker-critic loop 3 times to measure output variance
+
+The confidence score in the output indicates whether the writer produces consistent quality (low variance) or inconsistent results (high variance) for this topic.

--- a/packages/std/examples/confident-writer/reviewer.md
+++ b/packages/std/examples/confident-writer/reviewer.md
@@ -1,0 +1,28 @@
+---
+name: reviewer
+kind: service
+---
+
+### Description
+
+Evaluate a piece of writing against quality criteria and return a structured verdict.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- output: the article to review
+
+### Ensures
+
+- verdict: "accept" or "reject"
+- reasoning: why the verdict was reached
+- suggestions: specific, actionable improvements (empty list if accepted)
+
+### Strategies
+
+- evaluate clarity, specificity, and audience fit
+- flag vague claims, missing examples, or unsupported assertions
+- accept if the article is publishable as-is; reject if substantive improvements are needed

--- a/packages/std/examples/confident-writer/variance-analyst.md
+++ b/packages/std/examples/confident-writer/variance-analyst.md
@@ -1,0 +1,31 @@
+---
+name: variance-analyst
+kind: service
+---
+
+### Description
+
+Analyze N identical-input responses for variance, classifying the material's determinism.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- responses: a set of N responses produced by identical runs of the same agent on the same material
+
+### Ensures
+
+- analysis: a structured assessment containing:
+    - classification: one of DETERMINISTIC, UNDERDETERMINED, or CHAOTIC
+    - variance_map: which aspects of the responses are stable vs. varying
+    - summary: a brief explanation of the classification
+
+### Strategies
+
+- compare responses pairwise, noting which claims, structures, and phrasings recur vs. diverge
+- classify as DETERMINISTIC when responses are substantively identical across all runs
+- classify as UNDERDETERMINED when specific aspects vary while others remain stable — identify the varying aspects
+- classify as CHAOTIC when responses vary widely with no stable core
+- for UNDERDETERMINED material, pinpoint which passages or aspects of the original material permit multiple valid readings

--- a/packages/std/examples/confident-writer/writer.md
+++ b/packages/std/examples/confident-writer/writer.md
@@ -1,0 +1,26 @@
+---
+name: writer
+kind: service
+---
+
+### Description
+
+Produce a well-structured article on a given topic for a specified audience.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- task_brief: a combined brief describing the topic and audience for the article
+
+### Ensures
+
+- output: a clear, well-structured article based on the brief
+
+### Strategies
+
+- open with a hook that connects the topic to the audience's concerns
+- use specific examples and named references rather than generic statements
+- keep paragraphs short and scannable

--- a/packages/std/memory/project-memory.md
+++ b/packages/std/memory/project-memory.md
@@ -1,0 +1,23 @@
+---
+name: project-memory
+kind: service
+---
+
+### Runtime
+
+- `persist`: project
+
+### Requires
+
+- mode: "ingest" (learn from content), "query" (answer questions), "update" (record decisions), or "summarize" (overview)
+- content: what to ingest, ask, record, or summarize
+
+### Ensures
+
+- result: ingestion confirmation, answer from project knowledge, update acknowledgment, or project summary depending on mode
+
+### Errors
+
+- unknown-mode: mode is not one of ingest, query, update, summarize
+
+This project's institutional memory. Knows architecture, design decisions (and WHY), key files, patterns, history, known issues, and team decisions. Uses `persist: project` for durable project-scoped knowledge.

--- a/packages/std/memory/project-memory.prose
+++ b/packages/std/memory/project-memory.prose
@@ -1,0 +1,118 @@
+# Project Memory
+# A persistent agent that understands this specific project
+#
+# Usage:
+#   prose run @openprose/lib/project-memory --backend sqlite+
+#
+# Recommended backend: sqlite+ (for durable project-scoped persistence)
+#
+# Modes:
+#   ingest: Read and understand content (code, docs, history)
+#   query: Ask questions about the project
+#   update: Record decisions, changes, or learnings
+#   summarize: Get an overview of the project
+#
+# The memory agent builds understanding over time. Ingest key files,
+# record decisions as you make them, and query when you need context.
+
+input mode: "Mode: ingest | query | update | summarize"
+input content: "Content to ingest, question to ask, update to record, or topic to summarize"
+
+# ============================================================
+# Agent
+# ============================================================
+
+agent memory:
+  model: opus
+  persist: project
+  prompt: """
+    You are this project's institutional memory.
+
+    You know:
+    - Architecture and design decisions (and WHY they were made)
+    - Key files, modules, and their purposes
+    - Patterns and conventions used in this codebase
+    - History of major changes and refactors
+    - Known issues, tech debt, and workarounds
+    - Dependencies and their purposes
+    - Configuration and environment setup
+    - Team decisions and their rationale
+
+    Principles:
+    - Remember the WHY, not just the WHAT.
+    - Track evolution—how things changed over time.
+    - Note uncertainty and gaps in your knowledge.
+    - Reference specific files, commits, or discussions when possible.
+    - Keep knowledge structured and retrievable.
+  """
+
+# ============================================================
+# Modes
+# ============================================================
+
+if **mode is ingest**:
+  output result = resume: memory
+    prompt: """
+      Ingest and understand this content:
+
+      {content}
+
+      This might be code, documentation, git history, PR discussions,
+      architecture diagrams, or any other project artifact.
+
+      Extract the important information and integrate it into your
+      understanding of this project. Note:
+      - What this tells you about the project
+      - How it connects to what you already know
+      - Any new patterns or conventions you observe
+    """
+
+elif **mode is query**:
+  output result = resume: memory
+    prompt: """
+      Question: {content}
+
+      Answer from your knowledge of this project.
+
+      When relevant:
+      - Reference specific files or modules
+      - Cite decisions or discussions you remember
+      - Note historical context
+      - Flag if you're uncertain or making inferences
+    """
+
+elif **mode is update**:
+  output result = resume: memory
+    prompt: """
+      Record this update:
+
+      {content}
+
+      This might be:
+      - A new architectural decision
+      - A change in direction or approach
+      - A lesson learned from debugging
+      - New context about requirements
+      - Tech debt being added or resolved
+
+      Integrate this into your project knowledge. Note the date
+      and how this relates to previous understanding.
+    """
+
+elif **mode is summarize**:
+  output result = resume: memory
+    prompt: """
+      Summarize your knowledge about: {content}
+
+      If this is a broad topic (or empty), give a project overview.
+      If specific, focus on that area.
+
+      Include:
+      - Current state of understanding
+      - Key decisions and their rationale
+      - Known issues or gaps
+      - Recent changes if relevant
+    """
+
+else:
+  throw "Unknown mode: {mode}. Use: ingest, query, update, or summarize"

--- a/packages/std/memory/user-memory.md
+++ b/packages/std/memory/user-memory.md
@@ -1,0 +1,23 @@
+---
+name: user-memory
+kind: service
+---
+
+### Runtime
+
+- `persist`: user
+
+### Requires
+
+- mode: "teach" (add knowledge), "query" (ask questions), or "reflect" (summarize topic)
+- content: what to teach, ask, or reflect on
+
+### Ensures
+
+- result: learning confirmation, answer from accumulated knowledge, or reflection with confidence levels and knowledge gaps
+
+### Errors
+
+- unknown-mode: mode is not one of teach, query, reflect
+
+Personal knowledge base persisting across all projects. Remembers technical preferences, architectural decisions, coding conventions, lessons learned, and domain knowledge. Uses `persist: user` for durable cross-project persistence.

--- a/packages/std/memory/user-memory.prose
+++ b/packages/std/memory/user-memory.prose
@@ -1,0 +1,93 @@
+# User Memory
+# A persistent agent that learns and remembers across all your projects
+#
+# Usage:
+#   prose run @openprose/lib/user-memory --backend sqlite+
+#
+# Recommended backend: sqlite+ (for durable cross-project persistence)
+#
+# Modes:
+#   teach: Add new knowledge
+#   query: Ask questions
+#   reflect: Summarize what you know about a topic
+#
+# The memory agent accumulates knowledge over time. Each interaction
+# builds on previous ones. Use liberally—teach it your preferences,
+# decisions, patterns, and lessons learned.
+
+input mode: "Mode: teach | query | reflect"
+input content: "What to teach, ask, or reflect on"
+
+# ============================================================
+# Agent
+# ============================================================
+
+agent memory:
+  model: opus
+  persist: user
+  prompt: """
+    You are the user's personal knowledge base, persisting across all projects.
+
+    You remember:
+    - Technical preferences (languages, frameworks, patterns they prefer)
+    - Architectural decisions and their reasoning
+    - Coding conventions and style preferences
+    - Mistakes they've learned from (and what to do instead)
+    - Domain knowledge they've accumulated
+    - Project contexts and how they relate
+    - Tools, libraries, and configurations they use
+    - Opinions and strong preferences
+
+    Principles:
+    - Be concise. Store knowledge efficiently.
+    - Prioritize actionable knowledge over trivia.
+    - Note confidence levels when uncertain.
+    - Update previous knowledge when new info contradicts it.
+    - Connect related pieces of knowledge.
+  """
+
+# ============================================================
+# Modes
+# ============================================================
+
+if **mode is teach**:
+  output result = resume: memory
+    prompt: """
+      Learn and remember this:
+
+      {content}
+
+      Integrate with your existing knowledge. If this updates or
+      contradicts something you knew before, note the change.
+
+      Respond with a brief confirmation of what you learned.
+    """
+
+elif **mode is query**:
+  output result = resume: memory
+    prompt: """
+      Question: {content}
+
+      Answer from your accumulated knowledge about this user.
+
+      If you know relevant context, share it.
+      If you're uncertain, say so.
+      If you don't know, say that clearly.
+    """
+
+elif **mode is reflect**:
+  output result = resume: memory
+    prompt: """
+      Reflect on your knowledge about: {content}
+
+      Summarize:
+      - What you know about this topic
+      - How confident you are
+      - Gaps in your knowledge
+      - What would be valuable to learn
+
+      Be honest about the limits of what you know.
+    """
+
+else:
+  throw "Unknown mode: {mode}. Use: teach, query, or reflect"

--- a/packages/std/ops/README.md
+++ b/packages/std/ops/README.md
@@ -1,0 +1,26 @@
+# std/ops
+
+Operational utilities for debugging, profiling, and validating Prose programs. These are the developer tools of the language -- the equivalent of `git status`, `cargo check`, and `go vet`. Each program maps to a `prose` CLI command.
+
+## Programs
+
+| Program | CLI Command | Description |
+|---------|-------------|-------------|
+| `lint.md` | `prose lint <file>` | Validate structure, schema, shapes, and contract compatibility |
+| `preflight.md` | `prose preflight <file>` | Check that dependencies are installed and environment variables are set |
+| `wire.md` | `prose run std/ops/wire` | Run Forme wiring to produce an execution manifest |
+| `status.md` | `prose status` | Show recent runs with program name, duration, and pass/fail status |
+| `diagnose.md` | `prose run std/ops/diagnose` | Diagnose why a run failed -- root cause analysis with fix recommendations |
+| `profiler.md` | `prose run std/ops/profiler` | Profile a run for cost, tokens, and time using actual API session data |
+
+## Two categories
+
+**Source-file tools** operate on program `.md` files before execution:
+- `lint` -- validates that the program is well-formed
+- `preflight` -- validates that the runtime environment is ready
+- `wire` -- produces the execution manifest (Forme wiring)
+
+**Run-artifact tools** operate on completed runs in `.prose/runs/`:
+- `status` -- lists recent runs and their outcomes
+- `diagnose` -- investigates a failed run to find the root cause
+- `profiler` -- breaks down cost, time, and token usage from actual session data

--- a/packages/std/ops/diagnose.md
+++ b/packages/std/ops/diagnose.md
@@ -1,0 +1,34 @@
+---
+name: diagnose
+kind: program
+---
+
+### Services
+
+- investigator
+- classifier
+- fixer
+
+### Requires
+
+- run-path: path to the failed or problematic run (e.g. `.prose/runs/20260408-...`)
+- focus: focus area -- "vm", "program", "context", or "external" (optional, default: auto-detect)
+
+### Ensures
+
+- report: diagnostic analysis with timeline, root cause, causal chain, and prioritized fix recommendations (immediate, permanent, prevention)
+
+### Errors
+
+- no-run: run directory does not exist or is missing state.md
+- incomplete-run: run is still in progress (no `---end` or `---error` marker)
+
+### Strategies
+
+- read the run's `state.md` execution log to identify the failure point from event markers
+- examine `workspace/` directories for `__error.md` files and intermediate artifacts
+- examine `bindings/` directories for missing or malformed outputs
+- read `services/*.md` component definitions to understand what each service was supposed to do
+- read `program.md` (the entry point snapshot) to understand the program's intent
+- classify the root cause by asking "why" iteratively until reaching the earliest intervention point
+- propose concrete fixes: show diffs for program errors, describe process changes for external errors

--- a/packages/std/ops/lint.md
+++ b/packages/std/ops/lint.md
@@ -1,0 +1,31 @@
+---
+name: lint
+kind: program
+---
+
+### Services
+
+- resolver
+- validator
+- checker
+
+### Requires
+
+- target: path to the program .md file to lint
+
+### Ensures
+
+- report: structured lint report with file-level validation results, contract compatibility checks, shape consistency checks, and warnings
+
+### Errors
+
+- not-found: target file does not exist
+- not-program: target file is not a valid program (missing or invalid `kind`)
+
+### Strategies
+
+- recursively resolve all services declared in the program's `services:` list, following nested service trees
+- validate each file's frontmatter against the Prose schema — valid `kind`, valid contract sections, valid shape structure
+- check that all services referenced in `services:` lists exist as files
+- verify that shape `delegates` entries reference known services
+- attempt basic contract matching — does each service's `requires` have a plausible match in another service's `ensures`

--- a/packages/std/ops/preflight.md
+++ b/packages/std/ops/preflight.md
@@ -1,0 +1,31 @@
+---
+name: preflight
+kind: program
+---
+
+### Services
+
+- resolver
+- env-checker
+- dep-checker
+
+### Requires
+
+- target: path to the program .md file to preflight
+
+### Ensures
+
+- report: preflight report listing dependency installation status and environment variable status (set/not set, never revealing values)
+
+### Errors
+
+- not-found: target file does not exist
+- not-program: target file is not a valid program
+
+### Strategies
+
+- resolve all services transitively from the program's `services:` list
+- collect all `environment:` declarations across the service tree
+- check each env var with `test -n "${VAR+x}"` via Bash — this returns whether the variable exists without ever reading its value. Never log, print, or include environment variable values in any output
+- check that all `use` dependencies are installed in `.deps/`
+- report readiness as pass (all satisfied) or fail (with missing items listed)

--- a/packages/std/ops/profiler.md
+++ b/packages/std/ops/profiler.md
@@ -1,0 +1,35 @@
+---
+name: profiler
+kind: program
+---
+
+### Services
+
+- detector
+- collector
+- calculator
+- analyzer
+- tracker
+
+### Requires
+
+- run-path: path to run, or "recent" for latest runs
+- scope: "single" (one run), "compare" (multiple runs), or "trend" (over time)
+
+### Ensures
+
+- report: profiling report with cost attribution, time attribution, per-agent breakdown, cache efficiency, hotspots, and optimization recommendations
+
+### Errors
+
+- no-data: could not find session data for this run
+
+### Strategies
+
+- detect the AI coding tool used (Claude Code, OpenCode, Amp, Codex) by checking for session directories (~/.claude/projects/, etc.)
+- locate the tool's session files (jsonl logs) corresponding to the run's timestamp
+- extract actual token counts, model identifiers, and timestamps from assistant messages in session logs -- never estimate from content length
+- fetch live pricing from the Anthropic pricing page rather than using hardcoded rates
+- calculate all metrics via inline Python scripts -- never do arithmetic in natural language
+- attribute costs and time separately for VM orchestration vs subagent sessions
+- for scope=compare, diff metrics across runs; for scope=trend, show progression over time

--- a/packages/std/ops/status.md
+++ b/packages/std/ops/status.md
@@ -1,0 +1,27 @@
+---
+name: status
+kind: program
+---
+
+### Services
+
+- scanner
+- summarizer
+
+### Requires
+
+- runs_dir: (optional, default ".prose/runs/") path to the runs directory
+
+### Ensures
+
+- summary: summary of recent runs showing run ID, program name, timestamp, duration, cost estimate, and pass/fail status
+
+### Errors
+
+- no-runs: no run data found in the runs directory
+
+### Strategies
+
+- scan the runs directory for run folders, sorted by timestamp descending
+- for each run, read the execution log to extract program name, duration, cost estimate, and final status
+- present as a table with the most recent runs first

--- a/packages/std/ops/wire.md
+++ b/packages/std/ops/wire.md
@@ -1,0 +1,35 @@
+---
+name: wire
+kind: program
+---
+
+### Services
+
+- resolver
+- matcher
+- manifest-writer
+
+Run Forme wiring to produce a manifest. This program implements the Forme container's
+wiring algorithm — reading component contracts, auto-wiring dependencies by semantic
+matching, and producing an execution manifest. Previously a top-level command, now
+available as `prose run std/ops/wire`.
+
+### Requires
+
+- target: path to the program .md file to wire
+
+### Ensures
+
+- manifest: manifest.md written to .prose/runs/{id}/ containing the full wiring graph
+
+### Errors
+
+- not-found: target file does not exist
+- unresolvable: one or more services could not be wired — no contract match found
+
+### Strategies
+
+- recursively resolve all services from the program's `services:` list
+- for each service, read its contract and build a dependency graph by matching `requires` entries to `ensures` entries from other services using semantic matching
+- detect cycles and report them as errors
+- write the execution manifest to .prose/runs/{id}/manifest.md with the full wiring graph and execution order

--- a/packages/std/roles/README.md
+++ b/packages/std/roles/README.md
@@ -1,0 +1,62 @@
+# std/roles
+
+Standard role definitions for OpenProse services. Each role is a reusable behavioral contract that defines what a service does, what it requires, and what it guarantees. Roles are the atoms -- everything else is molecules.
+
+## Roles by Category
+
+### Analysis
+
+| Role | Description |
+|------|-------------|
+| [classifier](classifier.md) | Assign a category label to an input given a defined category set |
+| [critic](critic.md) | Evaluate a work product against quality criteria and render a subjective verdict |
+| [verifier](verifier.md) | Check a result against formal constraints and report pass/fail for each |
+
+### Transformation
+
+| Role | Description |
+|------|-------------|
+| [extractor](extractor.md) | Pull structured data from unstructured input given a target schema |
+| [summarizer](summarizer.md) | Compress content while preserving specified key information |
+| [formatter](formatter.md) | Transform structured data into a specified output format with no information loss |
+
+### Creation
+
+| Role | Description |
+|------|-------------|
+| [researcher](researcher.md) | Investigate a topic using available tools and return sourced, confidence-scored findings |
+| [writer](writer.md) | Produce a written artifact given requirements, audience, and constraints |
+| [planner](planner.md) | Produce an ordered plan with dependencies, decision points, and fallback paths |
+
+### Flow
+
+| Role | Description |
+|------|-------------|
+| [router](router.md) | Select the best handler for an input from a set of candidates and explain the choice |
+
+## Decision Matrix
+
+| When you need to... | Use |
+|------|-----|
+| Label an input against a known taxonomy | **classifier** |
+| Judge whether work meets a quality bar | **critic** |
+| Check formal correctness against rules | **verifier** |
+| Lift structured fields from raw text | **extractor** |
+| Compress content without losing key points | **summarizer** |
+| Reshape data into Markdown, JSON, HTML, CSV | **formatter** |
+| Discover information via search or tools | **researcher** |
+| Create a new document, report, or email | **writer** |
+| Sequence work into an ordered plan | **planner** |
+| Dispatch a request to the right handler | **router** |
+
+## Common Confusions
+
+**Classifier vs. Router.** Classifier produces a label (data). Router selects a handler (action). A classifier says "this is a billing question." A router says "send this to the billing service."
+
+**Critic vs. Verifier.** Critic renders subjective quality judgments ("is this analysis thorough?"). Verifier checks objective formal constraints ("does this JSON match the schema?"). A result can pass verification and fail criticism, or vice versa.
+
+**Extractor vs. Formatter.** Extractor goes from unstructured to structured (raw text to schema). Formatter goes from structured to structured (data to Markdown). They point in opposite directions.
+
+**Summarizer vs. Writer.** Summarizer compresses existing content. Writer creates new content. If the input already contains the information and you need less of it, use summarizer. If you need to synthesize, argue, or explain, use writer.
+
+**Researcher vs. Extractor.** Researcher discovers new information using tools and search. Extractor lifts information already present in its input. If the data is in the input, extract. If the data needs to be found, research.

--- a/packages/std/roles/classifier.md
+++ b/packages/std/roles/classifier.md
@@ -1,0 +1,46 @@
+---
+name: classifier
+kind: service
+---
+
+# Classifier
+
+Assign a structured category label to an input item given a set of categories with descriptions. Use classifier when the task is labeling or categorization against a known taxonomy. Distinct from router (which selects a handler to delegate to) -- classifier produces a label, not a delegation decision.
+
+### Description
+
+Assign a category label to an input given a defined category set.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- item: the thing to classify
+- categories: the category set, each with a description of what belongs in it
+- rules: (optional) disambiguation rules for edge cases where categories overlap
+
+### Ensures
+
+- classification: a structured result containing:
+    - category: the selected category name
+    - confidence: a score from 0 to 1 where 0.5 means genuine uncertainty, not "probably"
+    - reasoning: which features of the item matched which category description
+- if the item fits multiple categories: the best fit is returned with reasoning about why alternatives were rejected
+- if the item fits no category: category is "uncategorized" with reasoning explaining why no category matched
+
+### Errors
+
+- empty-categories: the category set is empty or contains no usable descriptions
+- ambiguous-item: the item contains insufficient information to distinguish between two or more categories even after applying disambiguation rules
+
+### Strategies
+
+- when categories overlap: apply disambiguation rules first; if none exist, prefer the more specific category over the general one
+- when confidence is low: say so in the score rather than inflating confidence to avoid appearing uncertain
+- when the item is complex: decompose it into features and match each feature against category descriptions independently before synthesizing a verdict
+
+### Notes
+
+Classifier is a pure labeling function. It does not know what the classification will be used for. It does not route, delegate, or act on the result. For selecting a handler to delegate work to, use router. For evaluating quality, use critic. For checking formal correctness, use verifier.

--- a/packages/std/roles/critic.md
+++ b/packages/std/roles/critic.md
@@ -1,0 +1,49 @@
+---
+name: critic
+kind: service
+---
+
+# Critic
+
+Evaluate a work product against stated quality criteria and produce a structured accept/reject verdict with reasoning. Use critic when the judgment is subjective -- does this meet the bar? Is the writing clear? Is the analysis thorough? Distinct from verifier, which checks objective correctness against formal constraints.
+
+### Description
+
+Evaluate a work product against quality criteria and render a subjective verdict.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- result: the work product to evaluate
+- criteria: what constitutes acceptance (quality standards, not formal rules)
+- task: the original task description, for context on what the result was supposed to accomplish
+
+### Ensures
+
+- evaluation: a structured verdict containing:
+    - verdict: "accept" or "reject"
+    - reasoning: why the criteria are or are not met -- specific, not "looks good"
+    - issues: specific, actionable problems found (each states what is wrong and why)
+    - suggestions: concrete next steps to address each issue (not restatements of the issues)
+- if accepting: reasoning explains why criteria are satisfied, with evidence
+- if rejecting: at least one issue is listed
+- the critic does not fix the result -- it identifies problems and suggests directions
+
+### Errors
+
+- missing-criteria: no evaluable criteria were provided
+- incompatible-result: the result is not the type of artifact the criteria apply to (e.g., criteria for a report applied to raw data)
+
+### Strategies
+
+- when evaluating: parse criteria into individual conditions and assess each independently before synthesizing a verdict
+- when criteria conflict: note the tension explicitly rather than silently privileging one criterion over another
+- when the result is close to passing: do not lower the bar -- reject with specific guidance on what would make it acceptable
+- when accepting: still note minor issues as suggestions, even if they do not warrant rejection
+
+### Notes
+
+Critic renders quality judgments. Verifier checks formal correctness. A result can pass verification (all constraints satisfied) but fail criticism (poorly written, shallow analysis). A result can fail verification (missing required field) but be otherwise excellent work. Use critic for "is this good enough?" and verifier for "is this correct?"

--- a/packages/std/roles/extractor.md
+++ b/packages/std/roles/extractor.md
@@ -1,0 +1,44 @@
+---
+name: extractor
+kind: service
+---
+
+# Extractor
+
+Extract structured data from unstructured input according to a target schema. Use extractor when you need to transform raw text, logs, or observations into a defined data structure. Distinct from formatter (which transforms already-structured data into a different output format) -- extractor finds and lifts information from unstructured content.
+
+### Description
+
+Pull structured data from unstructured input given a target schema.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- input: the unstructured data (text, log output, raw observations, HTML, etc.)
+- schema: the target structure with field names, types, and descriptions of what each field should contain
+
+### Ensures
+
+- extracted: an object conforming to the target schema where:
+    - each field has a confidence indicator (high, medium, low)
+    - fields that cannot be confidently extracted are null with a reason -- never hallucinated
+    - no information in the output that was not in the input
+- if the input contains multiple valid extractions: all are returned, or the ambiguity is flagged, depending on the schema's cardinality
+
+### Errors
+
+- no-match: the input contains no information matching any field in the schema
+- format-unreadable: the input is corrupted, truncated, or in a format that cannot be parsed
+
+### Strategies
+
+- when evidence is ambiguous: prefer null over guessing -- a null with a reason is more useful than a fabricated value
+- when multiple interpretations exist: note all candidates and select the one with strongest textual evidence
+- when the input is large: scan for schema-relevant sections first, then extract from those sections rather than processing the entire input linearly
+
+### Notes
+
+Extractor is a strict information-lifting function. Its core invariant is that no information appears in the output that was not present in the input. For compressing existing content, use summarizer. For reshaping structured data into a different format, use formatter. For investigating a topic and producing new findings, use researcher.

--- a/packages/std/roles/formatter.md
+++ b/packages/std/roles/formatter.md
@@ -1,0 +1,44 @@
+---
+name: formatter
+kind: service
+---
+
+# Formatter
+
+Transform structured data into a specified output format -- Markdown, JSON, HTML, CSV, plain text, or any other target. Use formatter as the last mile of a pipeline, converting internal data structures into the presentation format the consumer needs. Distinct from extractor (which lifts structure from unstructured input) and writer (which creates new content) -- formatter reshapes existing structured data without adding or removing information.
+
+### Description
+
+Transform structured data into a specified output format with no information loss.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- data: the structured input to format
+- target_format: the desired output format (e.g., Markdown, JSON, HTML, CSV) with any style or layout requirements
+
+### Ensures
+
+- formatted: the data rendered in the target format where:
+    - all information from the input is present in the output -- no fields dropped silently
+    - the output is valid in the target format (valid JSON parses, valid HTML renders, valid CSV has consistent columns)
+    - missing or null fields are handled gracefully (omitted with a note, rendered as empty, or replaced with a placeholder -- consistent throughout)
+
+### Errors
+
+- unsupported-format: the target format is not recognized or cannot represent the input data
+- data-unstructured: the input data has no discernible structure to format
+
+### Strategies
+
+- when the data has nested structures: flatten or indent according to the target format's conventions, preserving hierarchy
+- when fields are missing: use a consistent strategy throughout (do not omit some nulls and placeholder others)
+- when the target format has length limits: truncate content fields before metadata fields, and indicate truncation
+- when multiple layout options exist: prefer the layout that makes the data scannable (tables over paragraphs for tabular data, lists over prose for enumerations)
+
+### Notes
+
+Formatter is a shape-preserving transformation. It does not analyze, summarize, or create -- it presents. For lifting structured data from unstructured input, use extractor. For compressing content, use summarizer. For creating new written content, use writer. Formatter is the role that makes output consumable by its final audience, whether that audience is a human reading Markdown or a system parsing JSON.

--- a/packages/std/roles/planner.md
+++ b/packages/std/roles/planner.md
@@ -1,0 +1,48 @@
+---
+name: planner
+kind: service
+---
+
+# Planner
+
+Given a goal and constraints, produce a structured plan with ordered steps, dependencies between them, decision points, and fallback paths. Use planner when the task requires sequencing work, identifying what depends on what, and anticipating failure modes. This is the natural coordinator role -- it decides what to do, not how to do each step.
+
+### Description
+
+Produce an ordered plan with dependencies, decision points, and fallback paths.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- goal: what the plan should achieve
+- constraints: limits on time, resources, tools, or scope
+- context: (optional) current state, prior attempts, or known blockers
+
+### Ensures
+
+- plan: an ordered sequence of steps, each with:
+    - step: what to do
+    - depends_on: which prior steps must complete before this one can start
+    - success_criteria: how to know this step is done
+    - fallback: what to do if this step fails
+- assumptions: explicit statements about what the plan takes for granted (if any assumption is wrong, the plan may need revision)
+- decision_points: moments where the path forward depends on information not yet available, with the options and how to choose between them
+
+### Errors
+
+- goal-infeasible: the goal cannot be achieved within the stated constraints
+- insufficient-context: not enough information to plan meaningfully (e.g., "make it better" with no current state)
+
+### Strategies
+
+- when the goal is large: decompose into phases with clear milestones; each phase should be independently valuable if later phases are cut
+- when constraints are tight: identify the critical path and protect it; flag steps that can be parallelized or deferred
+- when prior attempts exist: diagnose what went wrong before planning a new approach
+- when uncertainty is high: front-load information-gathering steps that resolve the biggest unknowns
+
+### Notes
+
+Planner produces plans. It does not execute them. It does not research the domain, write the deliverables, or evaluate the results -- those are jobs for researcher, writer, and critic respectively. Planner is the role that sequences and coordinates. For classifying inputs, use classifier. For selecting a handler, use router.

--- a/packages/std/roles/researcher.md
+++ b/packages/std/roles/researcher.md
@@ -1,0 +1,47 @@
+---
+name: researcher
+kind: service
+---
+
+# Researcher
+
+Investigate a topic using web search, document analysis, or other available tools. Return structured findings with sources cited, recency noted, and confidence scored. Use researcher when the task requires discovering information that is not already in the input. This is the most common service pattern in production programs -- funding scanners, market researchers, competitive mappers, and signal detectors are all researchers.
+
+### Description
+
+Investigate a topic using available tools and return sourced, confidence-scored findings.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- topic: the question or subject to investigate
+- scope: (optional) constraints on the investigation -- time period, geography, source types, depth
+
+### Ensures
+
+- findings: a list of sourced claims, each with:
+    - claim: a specific, falsifiable statement
+    - source: where the claim came from (URL, document name, or tool output)
+    - date: when the source was published or accessed
+    - confidence: 0 to 1, reflecting source quality and corroboration
+- sources: all sources consulted, including those that did not yield useful findings, with a relevance note for each
+- if sources are unavailable or insufficient: partial findings flagged as incomplete, with an explanation of what could not be determined
+
+### Errors
+
+- no-results: no relevant sources found after exhausting available search strategies
+- scope-too-narrow: the scope constraints exclude all available evidence
+
+### Strategies
+
+- when few sources found: broaden search terms, try synonyms, check adjacent topics
+- when many low-quality sources: prioritize primary sources, official filings, and academic publications over aggregator sites
+- when findings conflict across sources: report the conflict explicitly with confidence reflecting the disagreement, rather than picking a winner silently
+- when recency matters: note the publication date of every source and flag anything older than the scope implies
+
+### Notes
+
+Researcher discovers new information. Extractor lifts structured data from content already provided. Summarizer compresses content already provided. Writer produces artifacts from requirements already known. Researcher is the role that goes out and finds things. Every claim must be traceable to a source -- unsourced claims are not findings, they are speculation.

--- a/packages/std/roles/router.md
+++ b/packages/std/roles/router.md
@@ -1,0 +1,45 @@
+---
+name: router
+kind: service
+---
+
+# Router
+
+Given an input and a set of possible handlers with descriptions, select the best handler and explain why. Use router when the task is a delegation decision -- which service, path, or action should handle this request? Distinct from classifier (which assigns a label from a taxonomy) -- router makes a dispatch decision that determines what happens next.
+
+### Description
+
+Select the best handler for an input from a set of candidates and explain the choice.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- input: the request, message, or data to be routed
+- handlers: a list of possible handlers, each with a name and description of what it handles well
+
+### Ensures
+
+- routing: a structured decision containing:
+    - selected: the name of the chosen handler
+    - rationale: why this handler is the best match for this input, referencing specific features of the input and the handler's description
+    - confidence: 0 to 1, reflecting how clearly the input matches the selected handler versus alternatives
+    - runner_up: (if confidence is below 0.8) the second-best handler and why it was not chosen
+
+### Errors
+
+- no-match: none of the handlers are appropriate for this input
+- ambiguous-input: the input is too vague to make a meaningful routing decision
+
+### Strategies
+
+- when multiple handlers could work: select the most specific match rather than the most general one
+- when confidence is low: include the runner-up so the caller can implement fallback logic
+- when the input is multi-part: route based on the primary intent, noting if secondary parts would be better served by a different handler
+- when handler descriptions overlap: focus on the distinguishing capabilities of each handler rather than their shared features
+
+### Notes
+
+Router makes delegation decisions. Classifier assigns labels. The key distinction: a classifier's output is data (a category), while a router's output is an action (send this to handler X). In a pipeline, router typically sits at the front, directing incoming requests to the appropriate service. For labeling inputs against a taxonomy, use classifier. For planning a sequence of steps, use planner.

--- a/packages/std/roles/summarizer.md
+++ b/packages/std/roles/summarizer.md
@@ -1,0 +1,45 @@
+---
+name: summarizer
+kind: service
+---
+
+# Summarizer
+
+Compress large content while preserving key information specified by the caller. Use summarizer when you need to reduce volume without losing what matters. Distinct from extractor (which lifts specific fields from unstructured input) and writer (which creates new content) -- summarizer compresses existing content faithfully.
+
+### Description
+
+Compress content while preserving specified key information.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- content: the material to summarize
+- preserve: what must survive compression (key facts, decisions, open questions, specific entities, etc.)
+
+### Ensures
+
+- summary: a compressed version of the content where:
+    - length is proportional to information density, not input length
+    - everything in the output was in the input -- no fabrication
+    - all items listed in "preserve" appear in the summary
+    - structure of the original is maintained where it carries meaning (e.g., a list of decisions stays a list, not a paragraph)
+- if the input is already concise: return it mostly unchanged rather than rephrasing for the sake of rephrasing
+
+### Errors
+
+- empty-content: the input contains no substantive content to summarize
+- preserve-conflict: a preserve item cannot be found in the input content
+
+### Strategies
+
+- when compressing: prioritize distinctions, decisions, and open questions over background and filler
+- when preserving structure: keep concrete details (names, numbers, specific claims) over vague descriptions
+- when the input has repetition: collapse repeated points into a single mention with a note on frequency if relevant
+
+### Notes
+
+Summarizer is a compression function. It does not create new analysis, draw conclusions, or restructure the argument -- it reduces volume while keeping what the caller specified as important. For creating new written artifacts, use writer. For extracting specific fields into a schema, use extractor.

--- a/packages/std/roles/verifier.md
+++ b/packages/std/roles/verifier.md
@@ -1,0 +1,45 @@
+---
+name: verifier
+kind: service
+---
+
+# Verifier
+
+Check a work product against formal, objective constraints and report which checks passed and which were violated. Use verifier when correctness can be determined mechanically -- schema validation, assertion checking, rule compliance, boundary conditions. Distinct from critic, which renders subjective quality judgments.
+
+### Description
+
+Check a result against formal constraints and report pass/fail for each.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- result: the work product to verify
+- constraints: formal rules the result must satisfy (as executable assertions, declarative rules, a schema, or a checklist of objective conditions)
+
+### Ensures
+
+- verification: a structured result containing:
+    - valid: true if all constraints pass, false if any are violated
+    - violations: list of failed checks, each stating which constraint failed, what the actual value was, and what was expected
+    - checks_passed: list of constraints that were satisfied
+- every constraint appears in either checks_passed or violations -- none are skipped
+
+### Errors
+
+- unparseable-constraints: the constraints cannot be interpreted as checkable conditions
+- inaccessible-result: the result is missing, empty, or in a format that cannot be inspected
+
+### Strategies
+
+- when constraints are executable: write and run code to test assertions rather than reasoning about them
+- when constraints are semantic: reason carefully and report with lower confidence, noting that the check was not mechanically verified
+- when a constraint is ambiguous: check the most restrictive interpretation and note the ambiguity
+- when many constraints exist: check all of them and report the full results, not just the first failure
+
+### Notes
+
+Verifier checks formal correctness. Critic evaluates subjective quality. A result can be valid (verifier passes) but poor (critic rejects) -- it satisfies all rules but the analysis is shallow. A result can be invalid (verifier fails) but otherwise well-crafted -- excellent writing that misses a required field. Use verifier for "does this satisfy the rules?" and critic for "is this good?"

--- a/packages/std/roles/writer.md
+++ b/packages/std/roles/writer.md
@@ -1,0 +1,46 @@
+---
+name: writer
+kind: service
+---
+
+# Writer
+
+Produce a written artifact -- a report, email, brief, proposal, code, or any other document -- given requirements and constraints. Use writer when the task is creating new content rather than compressing, extracting, or reformatting existing content. Distinct from summarizer (which compresses) and formatter (which reshapes) -- writer does the creative work.
+
+### Description
+
+Produce a written artifact given requirements, audience, and constraints.
+
+### Metadata
+
+- `version`: 0.1.0
+
+### Requires
+
+- brief: what to write, including the purpose and key points to cover
+- audience: who will read this and what they need from it
+- format: (optional) structural requirements -- length, sections, tone, style guide
+
+### Ensures
+
+- artifact: the written document where:
+    - every claim is specific rather than vague ("revenue grew 40% YoY" not "revenue grew significantly")
+    - structure follows the format requirements if provided, or uses a sensible default structure
+    - content addresses the audience's needs and knowledge level
+    - no filler -- every sentence earns its place
+
+### Errors
+
+- insufficient-brief: the brief does not contain enough information to produce a meaningful artifact
+- contradictory-requirements: the format or audience constraints conflict with each other (e.g., "write a 100-word comprehensive technical analysis")
+
+### Strategies
+
+- when the brief is rich: organize around the strongest points first, not the order they appear in the brief
+- when the audience is non-technical: lead with implications and actions, put methodology and details in appendices or later sections
+- when length is constrained: cut redundancy and background before cutting substance
+- when tone is unspecified: match the formality of the brief and the expectations of the audience
+
+### Notes
+
+Writer creates new content. Summarizer compresses existing content. Formatter reshapes structured data into a presentation format. Researcher gathers information. In a typical pipeline, researcher finds the data, writer turns it into a document, and formatter handles the final presentation. Writer is the role that synthesizes, argues, explains, and persuades.

--- a/skills/open-prose/deps.md
+++ b/skills/open-prose/deps.md
@@ -26,7 +26,7 @@ A `use` statement names an explicit git host, owner, repo, and path. The
 canonical form is `host/owner/repo/path`:
 
 ```prose
-use "github.com/openprose/std/evals/inspector"
+use "github.com/openprose/prose/packages/std/evals/inspector"
 ```
 
 Parsed as:
@@ -37,9 +37,9 @@ Parsed as:
 | Owner | `openprose` |
 | Repo | `std` |
 | Path | `evals/inspector` |
-| Clone URL | `github.com/openprose/std` |
-| Local clone | `.deps/github.com/openprose/std/` |
-| Resolved file | `.deps/github.com/openprose/std/evals/inspector.md` |
+| Clone URL | `github.com/openprose/prose/packages/std` |
+| Local clone | `.deps/github.com/openprose/prose/packages/std/` |
+| Resolved file | `.deps/github.com/openprose/prose/packages/std/evals/inspector.md` |
 
 The first path segment is the host (must contain a dot — `github.com`,
 `gitlab.com`, `codeberg.org`, `git.company.com`). The next two segments are
@@ -49,15 +49,26 @@ repository.
 Any git host works. Nothing in the resolver privileges GitHub — it's the
 common case, not a default.
 
-### `std/` Shorthand
+### `std/` and `co/` Shorthands
 
-`std/` expands to `github.com/openprose/std/`:
+The OpenProse monorepo hosts two packages. Both get shorthands:
+
+- `std/` → `github.com/openprose/prose/packages/std/`
+- `co/` → `github.com/openprose/prose/packages/co/`
 
 ```prose
 use "std/evals/inspector"
 # equivalent to:
-use "github.com/openprose/std/evals/inspector"
+use "github.com/openprose/prose/packages/std/evals/inspector"
+
+use "co/programs/company-repo-checker"
+# equivalent to:
+use "github.com/openprose/prose/packages/co/programs/company-repo-checker"
 ```
+
+Both shorthands resolve into the same clone of `openprose/prose` under
+`.deps/github.com/openprose/prose/`; `packages/std/` and `packages/co/` are
+sibling subdirectories inside that clone.
 
 ### Bare `owner/repo` Form
 
@@ -95,7 +106,7 @@ In `### Services`, use the full path — aliases are for execution blocks only.
 
 When the VM or Forme encounters a `use` path at runtime:
 
-1. Expand `std/` shorthand to `github.com/openprose/std/` if applicable
+1. Expand `std/` shorthand to `github.com/openprose/prose/packages/std/` if applicable
 2. Parse `{host}/{owner}/{repo}` from the first three segments
 3. Check `.deps/{host}/{owner}/{repo}/` exists on disk
 4. If not found, error immediately (see Error Handling below)
@@ -117,7 +128,7 @@ Scans the project for dependency references and clones missing dependencies.
    - service names in `### Services` that start with `std/` or `host/owner/repo/`
    - `compose:` paths that start with `std/` or `host/owner/repo/`
 2. **Parse** each dependency path to extract `{host, owner, repo}` triples (the first segment is the host if it contains a dot)
-3. **Expand** `std/` shorthand to `github.com/openprose/std/`
+3. **Expand** `std/` shorthand to `github.com/openprose/prose/packages/std/`
 4. For each unique `{host, owner, repo}`:
    a. If `.deps/{host}/{owner}/{repo}/` does not exist, full clone: `git clone {host}/{owner}/{repo} .deps/{host}/{owner}/{repo}/`
    b. If `prose.lock` has a pinned SHA for this repo, checkout: `git checkout {sha}`
@@ -183,22 +194,22 @@ Bumps all pinned SHAs to the latest HEAD of their default branch.
 
 ## `prose.lock` Format
 
-Plaintext. One line per dependency. Format: `owner/repo sha`.
+Plaintext. One line per dependency. Format: `host/owner/repo sha`.
 
 ```
 # prose.lock — pinned dependency versions
 # Do not edit unless you know what you're doing
-openprose/std a1b2c3d4e5f6
-alice/research f6e5d4c3b2a1
-alice/utils 9c8d7e6f5a4b
+github.com/openprose/prose a1b2c3d4e5f6
+github.com/alice/research f6e5d4c3b2a1
+gitlab.com/bob/utils 9c8d7e6f5a4b
 ```
 
 Rules:
 - One dependency per line
-- Format: `{owner}/{repo} {sha}` (space-separated)
+- Format: `{host}/{owner}/{repo} {sha}` (space-separated)
 - Comments start with `#`
 - Direct and transitive dependencies listed flat — no nesting, no hierarchy markers
-- URL is derivable: `github.com/{owner}/{repo}`
+- Host is explicit — no default is assumed, so any git provider works uniformly
 - Order does not matter (but `prose install` writes them sorted alphabetically)
 
 `prose.lock` is **committed to git**. It ensures reproducible builds — anyone cloning the project gets the same dependency versions.
@@ -209,30 +220,39 @@ Rules:
 
 ```
 .deps/
-├── openprose/
-│   └── std/                          # Full clone of github.com/openprose/std
-│       ├── evals/
-│       │   ├── inspector.md
-│       │   ├── vm-improver.md
-│       │   ├── program-improver.md
-│       │   ├── cost-analyzer.md
-│       │   ├── calibrator.md
-│       │   ├── profiler.md
-│       │   └── error-forensics.md
-│       └── memory/
-│           ├── user-memory.md
-│           └── project-memory.md
-├── alice/
-│   └── research-pipeline/            # Full clone of github.com/alice/research-pipeline
-│       └── ...
-└── bob/
-    └── toolkit/                      # Transitive dep, also a full clone
-        └── ...
+├── github.com/
+│   ├── openprose/
+│   │   └── prose/                       # Full clone of github.com/openprose/prose
+│   │       ├── packages/
+│   │       │   ├── std/                 # Standard library (resolved by `std/` shorthand)
+│   │       │   │   ├── evals/
+│   │       │   │   │   ├── inspector.md
+│   │       │   │   │   ├── contract-grader.md
+│   │       │   │   │   └── regression-tracker.md
+│   │       │   │   └── memory/
+│   │       │   │       ├── user-memory.md
+│   │       │   │       └── project-memory.md
+│   │       │   └── co/                  # Company-as-prose (resolved by `co/` shorthand)
+│   │       │       └── programs/
+│   │       │           └── company-repo-checker.md
+│   │       └── ...
+│   ├── alice/
+│   │   └── research-pipeline/           # Full clone of github.com/alice/research-pipeline
+│   │       └── ...
+│   └── bob/
+│       └── toolkit/                     # Transitive dep, also a full clone
+│           └── ...
+└── gitlab.com/
+    └── team/
+        └── repo/                        # Any git host works; host is part of the path
 ```
 
 **`.deps/` MUST be in `.gitignore`.** It is a cache, fully reproducible from `prose.lock` via `prose install`.
 
-Each entry under `.deps/` is a full git clone (or shallow clone) of the corresponding GitHub repository, checked out to the SHA pinned in `prose.lock`.
+Each entry under `.deps/` is a full git clone (or shallow clone) of the
+corresponding repository, checked out to the SHA pinned in `prose.lock`. The
+host is part of the cache key so repos with the same `owner/repo` name on
+different hosts do not collide.
 
 ---
 
@@ -247,7 +267,7 @@ At execution time, the VM and Forme resolve `use` paths by reading from `.deps/`
 If a dependency is missing or `.deps/` does not exist:
 
 ```
-[Error] Dependency not found: openprose/std
+[Error] Dependency not found: github.com/openprose/prose
   Run `prose install` to install dependencies.
 ```
 
@@ -261,10 +281,10 @@ When Forme resolves a service listed in `### Services`, it checks `.deps/` as pa
 
 1. Same directory as the entry point: `./researcher.md`
 2. A subdirectory matching the name: `./researcher/index.md`
-3. **`.deps/` directory:** `.deps/{owner}/{repo}/{path}.md`
-4. Registry shorthand (if contains `/`): fetch from `https://p.prose.md/{path}` (compatibility path)
+3. **`.deps/` directory:** `.deps/{host}/{owner}/{repo}/{path}.md`
+4. Bare `owner/repo` identifiers: reserved for the OpenProse registry (future home at `p.prose.md`); inert today
 
-A service name like `std/evals/inspector` in `### Services` resolves to `.deps/openprose/std/evals/inspector.md` after `std/` shorthand expansion.
+A service name like `std/evals/inspector` in `### Services` resolves to `.deps/github.com/openprose/prose/packages/std/evals/inspector.md` after `std/` shorthand expansion.
 
 ---
 
@@ -272,9 +292,9 @@ A service name like `std/evals/inspector` in `### Services` resolves to `.deps/o
 
 When the VM encounters a `use` statement during execution:
 
-1. Expand shorthand (`std/` → `openprose/std/`)
-2. Parse `owner/repo` and remaining path
-3. Read the program from `.deps/{owner}/{repo}/{path}.md`
+1. Expand shorthand (`std/` → `github.com/openprose/prose/packages/std/`; `co/` → `github.com/openprose/prose/packages/co/`)
+2. Parse `{host}/{owner}/{repo}` and remaining path
+3. Read the program from `.deps/{host}/{owner}/{repo}/{path}.md`
 4. Parse the imported program's contract (`### Requires` / `### Ensures`)
 5. Register the import (with alias if `as` was used)
 
@@ -303,7 +323,7 @@ docs, install counts, eval scores, callable runtimes).
 | Use case | Resolution |
 |----------|------------|
 | `use "github.com/owner/repo/path"` in a program | `.deps/github.com/owner/repo/` if cached, clone from GitHub if not |
-| `use "std/..."` in a program | Expands to `github.com/openprose/std/...` then resolves as above |
+| `use "std/..."` or `use "co/..."` in a program | Expands to `github.com/openprose/prose/packages/{std\|co}/...` then resolves as above |
 | `prose run github.com/owner/repo/path` at the CLI | Same algorithm as `use` |
 | `prose run github.com/owner/repo/path@{version}` | That specific version — cached copy wins, fetch otherwise |
 | `prose run ... --offline` | `.deps/` only; error on miss |
@@ -326,7 +346,7 @@ when the declared `prose.lock` SHA is not yet on disk.
 | Update command | `prose install --update` |
 | Lockfile | `prose.lock` (plaintext, committed) |
 | Cache directory | `.deps/{host}/{owner}/{repo}/` (gitignored) |
-| Shorthand | `std/` → `github.com/openprose/std/` |
+| Shorthands | `std/` → `github.com/openprose/prose/packages/std/`; `co/` → `github.com/openprose/prose/packages/co/` |
 | Clone strategy | Full clone (supports SHA checkout without refetch) |
 | Transitive deps | Multi-pass scan until stable (errors on cycles) |
 | Version conflicts | Auto-resolve to newer SHA with warning |

--- a/skills/open-prose/examples/registry-import/index.md
+++ b/skills/open-prose/examples/registry-import/index.md
@@ -6,11 +6,11 @@ kind: program
 ### Services
 
 - `local-analyzer`
-- `openprose/std/evals/inspector`
+- `std/evals/inspector`
 
 ### Description
 
-Demonstrates importing a service from the external standard library. The `openprose/std/evals/inspector` service is installed and pinned by `prose install`. Local and dependency services are wired together by Forme using the same contract-matching algorithm.
+Demonstrates importing a service from the external standard library. The `std/evals/inspector` service is installed and pinned by `prose install`. Local and dependency services are wired together by Forme using the same contract-matching algorithm.
 
 ### Requires
 

--- a/skills/open-prose/forme.md
+++ b/skills/open-prose/forme.md
@@ -120,11 +120,12 @@ For each entry in `### Services`, locate the corresponding `.md` file:
 1. Same directory as the entry point: `./researcher.md`
 2. A subdirectory matching the name: `./researcher/index.md`
 3. `.deps/` directory (for git-native deps installed via `prose install` — see `deps.md`):
-   - Expand `std/` shorthand to `openprose/std/`
-   - Map the service name to `.deps/{owner}/{repo}/{path}.md`
-   - Example: `openprose/std/evals/inspector` → `.deps/openprose/std/evals/inspector.md`
-   - Example: `alice/tools/formatter` → `.deps/alice/tools/formatter.md`
-4. Registry shorthand (if contains `/`): fetch from `https://p.prose.md/{path}` (compatibility path)
+   - Expand `std/` shorthand to `github.com/openprose/prose/packages/std/`
+   - Expand `co/` shorthand to `github.com/openprose/prose/packages/co/`
+   - Map the service name to `.deps/{host}/{owner}/{repo}/{path}.md`
+   - Example: `std/evals/inspector` → `.deps/github.com/openprose/prose/packages/std/evals/inspector.md`
+   - Example: `github.com/alice/tools/formatter` → `.deps/github.com/alice/tools/formatter.md`
+4. Bare `owner/repo` identifiers (no host prefix): reserved for the OpenProse registry (future home at `p.prose.md`); inert today
 
 **Composite resolution:**
 
@@ -874,7 +875,7 @@ The runtime:
 
 For single-component programs (no `services` list), Phase 1 is skipped — the file is passed directly to the Prose VM.
 
-**Note:** `prose wire` is no longer a top-level command. In normal usage, `prose run` invokes wiring automatically as Phase 1 when it detects a multi-service program. If a standalone wire-only helper is added to `openprose/std`, it should call this same algorithm rather than defining a second one.
+**Note:** `prose wire` is no longer a top-level command. In normal usage, `prose run` invokes wiring automatically as Phase 1 when it detects a multi-service program. If a standalone wire-only helper is added to `packages/std/`, it should call this same algorithm rather than defining a second one.
 
 ---
 

--- a/skills/open-prose/guidance/antipatterns.md
+++ b/skills/open-prose/guidance/antipatterns.md
@@ -910,7 +910,7 @@ Copying library programs into your project instead of using `use` statements.
 
 ```prose
 # Good: Reference the canonical source
-use "openprose/std/evals/inspector"
+use "std/evals/inspector"
 ```
 
 The only exception is if you genuinely need to fork and modify a program — in that case, fork the repo on GitHub and reference your fork.

--- a/skills/open-prose/guidance/patterns.md
+++ b/skills/open-prose/guidance/patterns.md
@@ -898,12 +898,12 @@ let review = session: structured-reviewer
 Declare dependencies via `use` statements. Run `prose install` to clone repos into `.deps/`. Commit `prose.lock`, gitignore `.deps/`.
 
 ```prose
-# Good: Use standard library programs
-use "openprose/std/evals/inspector"
-use "openprose/std/memory/project-memory"
+# Good: Use standard library programs (via shorthand)
+use "std/evals/inspector"
+use "std/memory/project-memory"
 
-# Good: Use third-party programs
-use "alice/research-pipeline" as research
+# Good: Use third-party programs with an explicit git host
+use "github.com/alice/research-pipeline" as research
 
 let result = research(topic: "quantum computing")
 ```
@@ -915,10 +915,10 @@ Pin versions via `prose.lock`. Run `prose install --update` deliberately — don
 Prefer explicit, stable import paths in examples and shared programs. Shorthands can remain convenient in an interactive shell, but published docs should show the path that resolves unambiguously.
 
 ```prose
-# Good: explicit
-use "openprose/std/evals/inspector"
+# Good: explicit git host
+use "github.com/openprose/prose/packages/std/evals/inspector"
 
-# Also valid when the runtime supports std shorthand
+# Also valid (and preferred for readability): std shorthand
 use "std/evals/inspector"
 ```
 

--- a/skills/open-prose/help.md
+++ b/skills/open-prose/help.md
@@ -115,7 +115,7 @@ We started with YAML. The problem: loops, conditionals, and variable declaration
 
 ### How do dependencies work?
 
-OpenProse uses a git-native dependency model -- GitHub is the registry. A program can reference dependencies with `use "owner/repo/path"`, dependency-like entries in `### Services`, or `compose:` paths. Run `prose install` to clone dependencies into `.deps/` and pin their versions in `prose.lock`. The lockfile is committed to git; `.deps/` is gitignored (it's a cache, reproducible from the lockfile). `std/` is shorthand for `openprose/std/` -- the standard library. At runtime, dependencies are read from disk only -- no network calls. If deps are missing, `prose run` errors and tells you to run `prose install`.
+OpenProse uses a git-native dependency model -- any git host works, written explicitly as `host/owner/repo/path` (e.g. `github.com/alice/research`). A program can reference dependencies with `use "host/owner/repo/path"`, dependency-like entries in `### Services`, or `compose:` paths. Run `prose install` to clone dependencies into `.deps/` and pin their versions in `prose.lock`. The lockfile is committed to git; `.deps/` is gitignored (it's a cache, reproducible from the lockfile). `std/` is shorthand for `github.com/openprose/prose/packages/std/` (the standard library) and `co/` is shorthand for `github.com/openprose/prose/packages/co/` (company-as-prose). At runtime, dependencies are read from disk only -- no network calls. If deps are missing, `prose run` errors and tells you to run `prose install`.
 
 ### Why not LangChain/CrewAI/AutoGen?
 

--- a/skills/open-prose/state/filesystem.md
+++ b/skills/open-prose/state/filesystem.md
@@ -85,15 +85,23 @@ File-based state persists all execution artifacts to disk. This enables:
 
 # Dependencies (in working directory, outside .prose/)
 .deps/                                      # Cloned dependency repos (gitignored)
-├── openprose/
-│   └── std/                                # Full clone of github.com/openprose/std
-│       ├── evals/
-│       │   └── inspector.md
-│       └── memory/
-│           └── project-memory.md
-└── alice/
-    └── research/
-        └── ...
+├── github.com/
+│   ├── openprose/
+│   │   └── prose/                          # Full clone of github.com/openprose/prose
+│   │       └── packages/
+│   │           ├── std/                    # Standard library
+│   │           │   ├── evals/
+│   │           │   │   └── inspector.md
+│   │           │   └── memory/
+│   │           │       └── project-memory.md
+│   │           └── co/                     # Company-as-prose
+│   │               └── programs/
+│   │                   └── company-repo-checker.md
+│   └── alice/
+│       └── research/
+│           └── ...
+└── gitlab.com/
+    └── ...
 prose.lock                                  # Pinned dependency SHAs (committed to git)
 
 # User-level state (in home directory)


### PR DESCRIPTION
## Summary

Move `openprose/std` (its own repo) and the local `company-as-prose/` package into this repository under `packages/std/` and `packages/co/`. Update the skill docs so `std/` and `co/` shorthands expand to the new paths.

**Motivation:** concentrate attention on one repository. `openprose/std` was a genuinely useful asset nobody could find — ~50 stars on its own repo told a much worse story than 1,106 on `openprose/prose` would. Same logic applies to co once it matures.

## Layout

```
openprose/prose/
├── skills/open-prose/       # language spec (unchanged)
├── packages/                # new — holds all first-party libraries
│   ├── std/                 # moved from openprose/std
│   └── co/                  # moved from company-as-prose
├── rfcs/
├── examples/
└── README.md
```

`packages/` (rather than flat top-level `std/` + `co/`) keeps the root bounded. New libraries can land under `packages/` without cluttering root or competing with spec infrastructure. Matches pnpm/Deno/monorepo conventions.

## Shorthand resolution

Both shorthands expand into the same clone of `openprose/prose`, different subdirectories:

- `std/` → `github.com/openprose/prose/packages/std/`
- `co/` → `github.com/openprose/prose/packages/co/`

Users writing `use "std/..."` and `use "co/..."` don't see `packages/` — it's a bury-the-extra-segment detail. Users writing the full form get unambiguous paths.

## std vs co — the split

Codified in `packages/co/README.md` so the next person doesn't have to rediscover it:

- **std** — use-case-agnostic primitives. Inspector, contract-grader, retry, fan-out, worker-critic, human-gate. Things that make *prose programs work*.
- **co** — company-operations-shaped patterns. Starter repo checkers, scheduled intake, windowed analytics, GTM pipelines, fleet monitors. Things that make *prose programs produce business value*.

## Files changed

### New

- `packages/std/` — full contents of `openprose/std` minus `.git`
- `packages/co/` — full contents of `company-as-prose/` minus `.git`; README updated to reflect new name and location

### Updated — skill docs

- `skills/open-prose/deps.md` — shorthand section now covers both `std/` and `co/`; `prose.lock` format row updated to `host/owner/repo sha`; `.deps/` directory structure redrawn with the `{host}/{owner}/{repo}/packages/{std,co}/` shape; Forme-interaction and VM-interaction sections updated; Summary table shorthands row lists both
- `skills/open-prose/forme.md` — Step 2 resolution order updated for both shorthands and the host-keyed `.deps/` layout
- `skills/open-prose/help.md` — "How do dependencies work?" Q&A rewritten
- `skills/open-prose/state/filesystem.md` — `.deps/` directory tree redrawn
- `skills/open-prose/guidance/patterns.md`, `.../antipatterns.md` — examples migrated from deprecated `use "openprose/std/..."` to `use "std/..."` or `use "github.com/..."`
- `skills/open-prose/examples/registry-import/index.md` — sample service reference switched to `std/evals/inspector`

### Updated — repo README

- `README.md` — Stdlib badge replaced with internal `packages/std/` link plus new `packages/co/` link; "Standard Library" section rewritten as "Libraries" covering both packages

## Out of scope

- **Tooling changes** to `prose install` and Forme's `.deps/` writer to actually adopt the `{host}/{owner}/{repo}/` layout. This PR is spec-only. Existing tooling continues to work against whatever layout it currently implements; the spec now describes the target.
- **Retiring the `openprose/std` GitHub repo.** Delete separately after this merges (archive or redirect README to `openprose/prose/packages/std/`).

## Test plan

- [ ] `use "std/evals/inspector"` in a program resolves to `packages/std/evals/inspector.md` on disk after `prose install`
- [ ] `use "co/programs/company-repo-checker"` resolves to `packages/co/programs/company-repo-checker.md`
- [ ] Repo README's "Libraries" section renders; both package links work
- [ ] No remaining `openprose/std` (as a repo reference) in `skills/` or `README.md` — only `CHANGELOG.md` (historical) should retain any
- [ ] Spot check that existing programs in `customers/` and `examples/` that use `std/` shorthand continue to read cleanly against the new docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)