### PR TITLE
feat(co): agent-readiness as safe first-run demo program

### DIFF
--- a/packages/co/README.md
+++ b/packages/co/README.md
@@ -22,17 +22,29 @@ Which expands to `github.com/openprose/prose/packages/co/programs/company-repo-c
 packages/co/
   README.md
   programs/
+    agent-readiness.md
     company-repo-checker.md
   evals/
+    agent-readiness.eval.md
     company-repo-checker.eval.md
 ```
+
+## Programs
+
+- **`agent-readiness`** — narrow intake a founder can run in under a minute:
+  scores how accessible their site is to AI agents (well-known paths,
+  plain-HTML parseability, structured metadata) and writes a screenshot-ready
+  markdown report to `~/prose-<company>/agent-readiness.md`. Safe first-run
+  demo: three prompts, one WebFetch batch, one report.
+- **`company-repo-checker`** — static gate that verifies a company-as-prose
+  repository still matches the shared layout before expensive runtime evals
+  or fleet monitors do more work.
 
 Future additions should help a new company get started without copying
 OpenProse, Inc.'s private business logic:
 
 - starter repository architecture
 - company system map
-- native repo checker
 - customer package checker
 - eval ladder
 - fixture and run-replay conventions

--- a/packages/co/evals/agent-readiness.eval.md
+++ b/packages/co/evals/agent-readiness.eval.md
@@ -1,0 +1,84 @@
+---
+name: agent-readiness.eval
+kind: test
+subject: agent-readiness
+tier: workflow
+contract_version: v1
+---
+
+
+# Agent Readiness — Workflow Eval
+
+Protects the demo-facing entry point for new users: every run must produce a
+grounded, short, actionable report the caller can screenshot.
+
+### Fixtures
+
+- fixture: agent_friendly_domain
+  company_name: OpenProse
+  domain: prose.md
+  focus: all
+  expected_result: overall_score >= 60 and report_path exists
+- fixture: js_wall_marketing_site
+  company_name: FictionalJsApp
+  domain: a known JS-rendered marketing page with no `/llms.txt`
+  focus: marketing-site
+  expected_result: parseability score <= 40 and exactly one top_fix names
+    a plain-HTML fallback
+- fixture: missing_well_knowns
+  company_name: Bare
+  domain: a domain returning 404 on `/llms.txt`, `/sitemap.xml`,
+    `/.well-known/ai-plugin.json`
+  focus: all
+  expected_result: discoverability score <= 30 and top_fixes[0] names
+    `/llms.txt`
+- fixture: unreachable_domain
+  company_name: GhostCo
+  domain: a domain that does not respond
+  focus: all
+  expected_result: errors contains `domain_unreachable` and no overall_score
+    is produced
+
+### Expects
+
+- path: workspace_dir
+  predicate: exists_on_disk and matches(^.*/prose-[a-z0-9-]+/$)
+- path: report_path
+  predicate: exists_on_disk and ends_with("agent-readiness.md")
+- path: overall_score
+  predicate: is_integer_between(0, 100)
+- path: dimension_scores
+  predicate: every_value_is_integer_between(0, 100)
+- path: top_fixes
+  predicate: length == 3 and every_item_names_a_file_path_or_url
+- path: report
+  predicate: contains_section("Raw Probe Results") and
+    every_finding_grounds_in_raw_probe_results
+
+### Expects Not
+
+- path: report
+  predicate: no_recommendation_without_file_path
+- path: report
+  predicate: no_ungrounded_score (every score has at least one evidence bullet)
+- path: execution
+  predicate: no_javascript_execution_attempted
+- path: execution
+  predicate: no_fetch_outside_target_origin (probes stay on the user's domain)
+- path: workspace_dir
+  predicate: no_write_outside_workspace_dir
+
+### Performance Tracked Over Time
+
+- metric: wall_clock_seconds
+  source: OpenProse run telemetry
+  direction: down
+  alert_when: p95 > 60s
+- metric: ungrounded_finding_rate
+  source: human triage of demo runs
+  direction: down
+  alert_when: more than 1 ungrounded finding in a rolling 10 runs
+- metric: caller_screenshot_rate
+  source: demo feedback ("did you share the report?")
+  direction: up
+  alert_when: share rate drops below 50% in a rolling 10 demos

--- a/packages/co/programs/agent-readiness.md
+++ b/packages/co/programs/agent-readiness.md
@@ -1,0 +1,163 @@
+---
+name: agent-readiness
+kind: program
+---
+
+
+# Agent Readiness
+
+Probe a company's website for signals AI agents look for when discovering and
+using a product: well-known paths, machine-readable metadata, structured
+documentation, and plain-HTML accessibility. Produce a scored markdown report
+with three concrete, file-path-level fixes.
+
+Designed as a short interactive intake that asks for the minimum input,
+fetches a fixed set of well-known paths (no JavaScript rendering required),
+and writes the report to a fresh per-company workspace the caller can open
+immediately.
+
+### Requires
+
+- `company_name`: company name (e.g. "Acme")
+- `domain`: primary domain or full URL (e.g. `acme.com` or `https://acme.com`)
+- `focus`: what agents most need to access — one of `marketing-site`,
+  `product-docs`, `public-api`, or `all`. Default `all`.
+
+### Ensures
+
+- `workspace_dir`: absolute path to a newly created per-company workspace at
+  `~/prose-<slug>/` where `<slug>` is lowercased, hyphenated `company_name`
+- `report_path`: absolute path to the written report markdown file at
+  `<workspace_dir>/agent-readiness.md`
+- `overall_score`: integer 0-100 summarizing agent readiness under the
+  selected focus
+- `dimension_scores`: map of dimension → integer 0-100 for each applicable
+  dimension (discoverability, parseability, structure, api_readiness)
+- `top_fixes`: three concrete, file-path-level recommendations, ordered by
+  expected impact
+
+### Strategies
+
+- fetch, never guess — every finding is grounded in a real WebFetch of a
+  real URL; a 404 is a finding, not a failure
+- probe a fixed, small set of paths so the run is fast and reproducible:
+    - always: `/robots.txt`, `/llms.txt`, `/llms-full.txt`, `/sitemap.xml`,
+      `/.well-known/ai-plugin.json`, homepage
+    - if focus includes product-docs: add `/docs`, `/docs/`, `/api`, `/help`
+    - if focus includes public-api: add `/openapi.json`, `/openapi.yaml`,
+      `/swagger.json`, `/.well-known/openapi.json`, `/.well-known/mcp.json`,
+      `/api/openapi.json`
+- for the homepage, fetch the raw HTML and inspect: `<title>`,
+  `<meta name="description">`, OpenGraph tags (`og:title`, `og:description`),
+  JSON-LD (`<script type="application/ld+json">`), and whether meaningful
+  body text is visible in the plain HTML
+- never try to execute JavaScript — if the page requires JS to show content,
+  that lowers the parseability score, it does not fail the run
+- score each applicable dimension 0-100 with brief per-finding evidence:
+    - discoverability: robots allows agents, llms.txt present, sitemap
+      present
+    - parseability: homepage renders content in plain HTML, not JS-wall
+    - structure: title, description, OpenGraph, JSON-LD present
+    - api_readiness: openapi/mcp endpoints present, docs index linked
+- compute overall_score as the equal-weighted mean of applicable
+  dimensions; omit dimensions the focus excludes and renormalize
+- top_fixes must name the exact file to add or change, not abstract advice;
+  bad: "improve discoverability"; good: "add `/llms.txt` at the domain root
+  with a 150-word product summary and links to your top three docs pages"
+- keep the report short enough to screenshot: one page of findings plus one
+  page of raw probe results
+
+### Workflow
+
+1. If any of `company_name`, `domain`, or `focus` is missing, `ask_user`
+   for it. Present `focus` as a numbered multi-choice with four options and
+   `all` as the default.
+2. Normalize `domain` to an origin URL: prepend `https://` if missing, strip
+   trailing slash. Derive `<slug>` by lowercasing `company_name` and
+   replacing non-alphanumeric runs with `-`.
+3. Compute `workspace_dir` as `~/prose-<slug>/`. Create the directory if it
+   does not exist.
+4. Fetch the fixed probe set for the selected focus via WebFetch. Record
+   for each probe: URL, HTTP status (or "fetch failed"), content length,
+   and a one-line content summary.
+5. Fetch the homepage HTML. Inspect for title, description, OpenGraph tags,
+   JSON-LD, and plain-HTML body content. Record findings.
+6. Score each applicable dimension 0-100 with one to three pieces of
+   evidence per score.
+7. Compute `overall_score` as the renormalized mean of applicable dimensions.
+8. Choose `top_fixes`: the three highest-impact, lowest-effort changes,
+   each naming the exact file to add or change.
+9. Write the report to `<workspace_dir>/agent-readiness.md` in the format
+   below.
+10. Return `workspace_dir`, `report_path`, `overall_score`,
+    `dimension_scores`, and `top_fixes`. Print a single summary line:
+    `Agent readiness: {overall_score}/100. Report: {report_path}`.
+
+### Errors
+
+- `domain_unreachable`: the homepage returned no response or a 5xx. Ask the
+  user to confirm the domain, then stop without producing a score.
+- `domain_invalid`: the input could not be normalized to an https URL. Ask
+  the user for a cleaner domain.
+
+### Output Format
+
+The written report has this structure:
+
+```markdown
+# Agent Readiness Report — {company_name}
+
+**Domain:** {origin}
+**Date:** {YYYY-MM-DD}
+**Focus:** {focus}
+**Overall Score:** {overall_score}/100
+
+## Summary
+
+{2-3 sentence narrative framing the score in terms of what agents can and
+cannot do with this domain today}
+
+## Discoverability — {score}/100
+
+- ✓ / ✗ {evidence line}
+- ...
+
+## Parseability — {score}/100
+
+- ✓ / ✗ {evidence line}
+- ...
+
+## Structure — {score}/100
+
+- ✓ / ✗ {evidence line}
+- ...
+
+## API Readiness — {score}/100   (omit if focus excludes it)
+
+- ✓ / ✗ {evidence line}
+- ...
+
+## Top 3 Fixes
+
+1. **{exact file path or URL}** — {what to add and why it matters for agents}
+2. **{...}** — {...}
+3. **{...}** — {...}
+
+## Raw Probe Results
+
+| Path | Status | Summary |
+|------|--------|---------|
+| /robots.txt | 200 | Allows all user agents |
+| /llms.txt | 404 | Not present |
+| ... | ... | ... |
+```
+
+### Invariants
+
+- Every finding in the report is grounded in a real WebFetch result in the
+  Raw Probe Results table. A reader can reproduce every ✓ or ✗ by opening
+  the listed path in their own browser.
+- The three top_fixes are each executable by a single engineer in under a
+  day; no "rearchitect the site" recommendations.
+- The run never modifies the target domain and never posts, submits, or
+  writes anywhere outside `<workspace_dir>` on the local filesystem.


### PR DESCRIPTION
## Summary

- Adds `co/programs/agent-readiness` — a narrow, bulletproof first-run program. Three prompts (company name, domain, focus), one WebFetch batch over a fixed set of well-known paths, one screenshot-ready markdown report written to `~/prose-<company>/agent-readiness.md`.
- Adds the paired eval `co/evals/agent-readiness.eval.md`. Guards the demo invariants: every finding grounds in a Raw Probe Results row, every top_fix names an exact file path, and any JavaScript execution or cross-origin fetch fails the eval.
- Updates `packages/co/README.md` package shape and adds a `## Programs` section describing both programs.

## Why

Designed as the YC-founders first experience: a founder runs `claude "prose run co/programs/agent-readiness"`, answers three questions, and gets back a report they can screenshot and tweet. The probe set is deliberately narrow — all static well-known paths — so the run cannot fail on a JS-wall, a missing API, or an auth boundary. The meta angle lands naturally: an agent is telling you how agent-ready your site is.

The four scored dimensions: discoverability (llms.txt, sitemap, robots allows agents), parseability (homepage readable in plain HTML), structure (title, description, OpenGraph, JSON-LD), and api-readiness (openapi, mcp, docs index). Focus selector skips dimensions the caller doesn't care about and renormalizes.

Top fixes must name exact file paths to add or change — "add /llms.txt at the domain root with a 150-word product summary", not "improve discoverability". Eval enforces this.

## Test plan

- [ ] `claude "prose run co/programs/agent-readiness"` prompts for company_name, domain, focus (numbered multi-choice), creates `~/prose-<slug>/`, writes `agent-readiness.md`, prints the one-line summary
- [ ] Running against a known-good domain (prose.md) produces an overall_score and a Raw Probe Results table
- [ ] Running against a JS-wall marketing site produces a parseability score ≤ 40 and a top_fix that names a plain-HTML fallback
- [ ] Running against a domain with all 404s on well-knowns produces discoverability ≤ 30 with top_fixes[0] naming `/llms.txt`
- [ ] Running against an unreachable domain returns `domain_unreachable` and does not produce a score

🤖 Generated with [Claude Code](https://claude.com/claude-code)