### PR TITLE
Prepare CLI 0.1.1 release

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish. Must match cli/package.json, for example 0.1.0."
+        description: "Version to publish. Must match cli/package.json, for example 1.2.3."
         required: true
         type: string
       npm_tag:

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,36 +8,6 @@ The CLI does not replace the OpenProse VM or execute programs by itself. The
 selected harness still runs the prompt, loads the OpenProse skill/specs, spawns
 agents when available, and writes run state.
 
-## Publication Status
-
-This package is release prep. The npm package and GitHub release tarball used by
-`install.sh` are intended install paths, but these docs do not assume either has
-been published yet. For now, use a local checkout or a private release source.
-
-## Release Workflow
-
-CLI releases are published by the manual `CLI Publish` GitHub Actions workflow
-after the version bump has landed on `main`. The workflow is intentionally
-manual-only and checks that:
-
-- the actor and triggering actor are `irl-dan` or `josemontesdeoca`;
-- the run is executing from `main`;
-- the requested version matches `cli/package.json` and `install.sh`;
-- the Git tag, GitHub release, and npm package version do not already exist.
-
-`dry_run` defaults to `true`. A dry run builds and verifies the npm package and
-the Linux/macOS release tarballs without publishing. For a real release, run the
-workflow with `dry_run` set to `false`; the publish job then waits on the
-GitHub `release` environment before creating the public release artifacts.
-
-One-time repository setup:
-
-- Create a GitHub environment named `release` with required reviewers
-  `irl-dan` and `josemontesdeoca`.
-- Configure npm trusted publishing for `@openprose/prose-cli` with repository
-  `openprose/prose`, workflow `.github/workflows/cli-publish.yml`, and
-  environment `release`.
-
 ## Requirements
 
 - Node.js 18 or newer
@@ -47,7 +17,20 @@ One-time repository setup:
 
 ## Install
 
-From the repository root:
+From npm:
+
+```bash
+npm install --global @openprose/prose-cli
+prose --help
+```
+
+From the GitHub release tarball:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openprose/prose/main/cli/install.sh | sh
+```
+
+From a repository checkout:
 
 ```bash
 cd cli
@@ -57,30 +40,19 @@ npm link
 prose --help
 ```
 
-For project-local use before publication:
+For project-local use:
 
 ```bash
 npm install --save-dev ../path/to/prose/cli
 npx prose run inspector.md
 ```
 
-Future npm registry path:
-
-```bash
-npm install --global @openprose/prose-cli
-prose --help
-```
-
-Future GitHub release tarball path:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/openprose/prose/main/cli/install.sh | sh
-```
-
 The installer supports `PROSE_VERSION`, `PROSE_BASE_URL`, `PROSE_INSTALL_DIR`,
 `PROSE_BIN_DIR`, `PROSE_SHA256`, and `PROSE_SHA256_URL` overrides for pinned or
 private releases. By default it downloads and verifies the `.sha256` file next
 to the release tarball.
+
+Maintainers can find the release process in [RELEASE.md](RELEASE.md).
 
 ## Harnesses
 

--- a/cli/RELEASE.md
+++ b/cli/RELEASE.md
@@ -1,0 +1,78 @@
+# Prose CLI Release Process
+
+This document is for maintainers publishing `@openprose/prose-cli` and the
+matching GitHub Release tarballs.
+
+The CLI is released from `main` with the manual `CLI Publish` GitHub Actions
+workflow. The workflow uses npm trusted publishing, so maintainers should not
+create or store an npm automation token for routine releases.
+
+## Before Releasing
+
+1. Confirm the CLI checks are green on `main`.
+2. Choose a new npm version. npm package versions are immutable, so never reuse
+   a version that already exists on npm.
+3. Open a small release-prep pull request that updates:
+   - `cli/package.json`
+   - `cli/package-lock.json`
+   - `cli/install.sh` `DEFAULT_VERSION`
+4. Merge the release-prep pull request after CI passes.
+
+## Dry Run
+
+Run the `CLI Publish` workflow manually from `main` with:
+
+- `version`: the exact version in `cli/package.json`
+- `npm_tag`: `latest` for stable releases, or `next` for prereleases
+- `dry_run`: `true`
+
+The dry run validates the package, runs tests, builds release tarballs, verifies
+their checksums, and runs `npm publish --dry-run`. It does not create a tag,
+GitHub Release, or npm publication.
+
+## Publish
+
+After the dry run passes, run the same `CLI Publish` workflow again from `main`
+with:
+
+- `version`: the exact version in `cli/package.json`
+- `npm_tag`: the intended npm dist-tag
+- `dry_run`: `false`
+
+The publish job targets the protected `release` environment. A maintainer with
+permission to approve that environment must approve the workflow before the
+final publish job can proceed.
+
+When approved, the workflow:
+
+1. Verifies the package and release tarballs.
+2. Creates a draft GitHub Release for `v<version>`.
+3. Publishes `@openprose/prose-cli` to npm with provenance.
+4. Publishes the GitHub Release with tarball assets and checksums.
+
+If npm publishing fails after the draft GitHub Release is created, the workflow
+attempts to delete the draft release and tag.
+
+## Verification
+
+After publishing, verify the public install paths:
+
+```bash
+npm view @openprose/prose-cli@latest version
+tmpdir="$(mktemp -d)"
+npm install --global --prefix "$tmpdir/npm-global" @openprose/prose-cli
+"$tmpdir/npm-global/bin/prose" --version
+```
+
+For the tarball installer, use a temporary install location too:
+
+```bash
+tmpdir="$(mktemp -d)"
+PROSE_INSTALL_DIR="$tmpdir/install" \
+  PROSE_BIN_DIR="$tmpdir/bin" \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/openprose/prose/main/cli/install.sh)"
+"$tmpdir/bin/prose" --version
+```
+
+Check that the GitHub Release for `v<version>` exists and includes all expected
+tarball and `.sha256` assets.

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Installs the Node-based Prose CLI from a verified release tarball.
-DEFAULT_VERSION="0.1.0"
+DEFAULT_VERSION="0.1.1"
 DEFAULT_REPO_URL="https://github.com/openprose/prose"
 
 log() {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openprose/prose-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.90",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Run OpenProse commands through Codex, Claude, or SDK-backed agent harnesses.",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/cli/tests/install/install.test.ts
+++ b/cli/tests/install/install.test.ts
@@ -20,6 +20,7 @@ const testDir = dirname(fileURLToPath(import.meta.url));
 const cliDir = resolve(testDir, "..", "..");
 const installScript = join(cliDir, "install.sh");
 const buildScript = join(cliDir, "scripts", "build-release-tarball.mjs");
+const packageVersion = (JSON.parse(readFileSync(join(cliDir, "package.json"), "utf8")) as { version: string }).version;
 
 function run(command: string, args: string[], options: Parameters<typeof spawnSync>[2] = {}) {
 	return spawnSync(command, args, {
@@ -352,11 +353,11 @@ describe("build-release-tarball.mjs", () => {
 			]);
 
 			expect(result.status).toBe(0);
-			expect(result.stdout).toContain("Package name: prose-0.1.0-linux-x64");
-			expect(result.stdout).toContain(`Archive path: ${join(temp, "prose-0.1.0-linux-x64.tar.gz")}`);
-			expect(result.stdout).toContain(`Checksum path: ${join(temp, "prose-0.1.0-linux-x64.tar.gz.sha256")}`);
+			expect(result.stdout).toContain(`Package name: prose-${packageVersion}-linux-x64`);
+			expect(result.stdout).toContain(`Archive path: ${join(temp, `prose-${packageVersion}-linux-x64.tar.gz`)}`);
+			expect(result.stdout).toContain(`Checksum path: ${join(temp, `prose-${packageVersion}-linux-x64.tar.gz.sha256`)}`);
 			expect(result.stdout).toContain("Production npm target: linux/x64");
-			expect(existsSync(join(temp, "prose-0.1.0-linux-x64.tar.gz"))).toBe(false);
+			expect(existsSync(join(temp, `prose-${packageVersion}-linux-x64.tar.gz`))).toBe(false);
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- Document the Prose CLI maintainer release process in `cli/RELEASE.md`
- Keep `cli/README.md` focused on user installation and usage
- Bump the CLI package and installer default version to `0.1.1`
- Make release tarball dry-run test expectations derive from `package.json`

## Validation

- `npm run typecheck`
- `npm test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/cli-*.yml`
- `git diff --check`
- `npm run build`
- `npm publish --dry-run`
- Verified `@openprose/prose-cli@0.1.1` is not published yet and `latest` is still `0.1.0`
