### PR TITLE
Preload OpenProse skill in CLI harnesses

### DIFF
--- a/.github/workflows/cli-real-harness-smoke.yml
+++ b/.github/workflows/cli-real-harness-smoke.yml
@@ -34,23 +34,37 @@ concurrency:
 
 jobs:
   smoke:
-    name: Smoke ${{ github.event_name == 'workflow_dispatch' && inputs.harness || 'all' }} harness
+    name: Smoke ${{ matrix.harness }} harness
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        harness:
+          - codex-sdk
+          - codex
+          - claude-sdk
+          - claude
     defaults:
       run:
         working-directory: cli
     env:
-      REQUESTED_HARNESS: ${{ github.event_name == 'workflow_dispatch' && inputs.harness || 'all' }}
+      SHOULD_RUN: ${{ github.event_name != 'workflow_dispatch' || inputs.harness == 'all' || inputs.harness == matrix.harness }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       PROSE_CODEX_APPROVAL_POLICY: never
       PROSE_CODEX_SANDBOX_MODE: danger-full-access
     steps:
+      - name: Skip unrequested harness
+        if: ${{ env.SHOULD_RUN != 'true' }}
+        run: echo "Skipping ${{ matrix.harness }} because workflow_dispatch requested ${{ inputs.harness }}."
+
       - name: Checkout
+        if: ${{ env.SHOULD_RUN == 'true' }}
         uses: actions/checkout@v4
 
       - name: Setup Node
+        if: ${{ env.SHOULD_RUN == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -58,85 +72,17 @@ jobs:
           cache-dependency-path: cli/package-lock.json
 
       - name: Install dependencies
+        if: ${{ env.SHOULD_RUN == 'true' }}
         run: npm ci
 
       - name: Build CLI
+        if: ${{ env.SHOULD_RUN == 'true' }}
         run: npm run build
 
       - name: Install Claude Code CLI when requested
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.harness == 'all' || inputs.harness == 'claude' || inputs.harness == 'claude-sdk' }}
+        if: ${{ env.SHOULD_RUN == 'true' && startsWith(matrix.harness, 'claude') }}
         run: npm install --global @anthropic-ai/claude-code
 
       - name: Run real harness smokes
-        run: |
-          set -euo pipefail
-
-          should_run() {
-            [ "$REQUESTED_HARNESS" = "all" ] || [ "$REQUESTED_HARNESS" = "$1" ]
-          }
-
-          require_env() {
-            name="$1"
-            value="$(eval "printf '%s' \"\${$name:-}\"")"
-            [ -n "$value" ] || {
-              printf '%s\n' "Missing required secret: $name" >&2
-              exit 1
-            }
-          }
-
-          run_smoke() {
-            harness="$1"
-            workspace="$RUNNER_TEMP/prose-$harness-smoke"
-            mkdir -p "$workspace"
-            cat > "$workspace/smoke.md" <<'EOF'
-          ---
-          name: harness-smoke
-          kind: program
-          ---
-
-          ### Ensures
-
-          - message: exactly `PROSE_HARNESS_SMOKE_OK`
-
-          ### Instructions
-
-          Return only `PROSE_HARNESS_SMOKE_OK`. Do not edit files.
-          EOF
-
-            git -C "$workspace" init --initial-branch=main >/dev/null
-            git -C "$workspace" config user.email "ci@openprose.local"
-            git -C "$workspace" config user.name "OpenProse CI"
-            git -C "$workspace" add smoke.md
-            git -C "$workspace" commit -m "Add smoke program" >/dev/null
-
-            (
-              cd "$workspace"
-              timeout 180 node "$GITHUB_WORKSPACE/cli/dist/index.js" run smoke.md --harness "$harness"
-            ) | tee "$RUNNER_TEMP/prose-$harness-smoke.out"
-
-            grep -q "PROSE_HARNESS_SMOKE_OK" "$RUNNER_TEMP/prose-$harness-smoke.out"
-          }
-
-          export PATH="$PWD/node_modules/.bin:$PATH"
-
-          if should_run codex-sdk; then
-            require_env OPENAI_API_KEY
-            run_smoke codex-sdk
-          fi
-
-          if should_run codex; then
-            require_env OPENAI_API_KEY
-            codex --version
-            run_smoke codex
-          fi
-
-          if should_run claude-sdk; then
-            require_env ANTHROPIC_API_KEY
-            run_smoke claude-sdk
-          fi
-
-          if should_run claude; then
-            require_env ANTHROPIC_API_KEY
-            claude --version
-            run_smoke claude
-          fi
+        if: ${{ env.SHOULD_RUN == 'true' }}
+        run: npm run smoke:harness -- --harness "${{ matrix.harness }}"

--- a/.github/workflows/cli-release-check.yml
+++ b/.github/workflows/cli-release-check.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check release helper syntax
         run: node --check cli/scripts/build-release-tarball.mjs
 
+      - name: Check harness smoke helper syntax
+        run: node --check cli/scripts/smoke-harness.mjs
+
   node-checks:
     name: Node ${{ matrix.node-version }} checks
     runs-on: ubuntu-latest

--- a/cli/package.json
+++ b/cli/package.json
@@ -51,6 +51,7 @@
     "build": "npm run clean && tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest --run",
+    "smoke:harness": "node scripts/smoke-harness.mjs",
     "dev": "tsx src/index.ts",
     "clean": "rm -rf dist",
     "release:tarball": "node scripts/build-release-tarball.mjs",

--- a/cli/scripts/smoke-harness.mjs
+++ b/cli/scripts/smoke-harness.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const cliDir = resolve(scriptDir, "..");
+const harnesses = ["codex-sdk", "codex", "claude-sdk", "claude"];
+const okToken = "PROSE_HARNESS_SMOKE_OK";
+const skillSentinel = "PROSE_SKILL_BOOTSTRAP_VISIBLE";
+
+const usage = `Usage: node scripts/smoke-harness.mjs [options]
+
+Smoke-test one or more real Prose CLI harnesses.
+
+Options:
+  --harness <name>   Harness to run: all, codex-sdk, codex, claude-sdk, claude (default: all)
+  --cli <path>       Built CLI entrypoint (default: ./dist/index.js)
+  --timeout <ms>     Per-harness timeout in milliseconds (default: 180000)
+  --keep-temp        Keep temporary HOME/workspace directories for inspection
+  -h, --help         Show this help
+`;
+
+function parseArgs(argv) {
+	const options = {
+		cli: join(cliDir, "dist", "index.js"),
+		harness: "all",
+		keepTemp: false,
+		timeout: 180_000,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		const equalsIndex = arg.indexOf("=");
+		const flag = equalsIndex === -1 ? arg : arg.slice(0, equalsIndex);
+		const inlineValue = equalsIndex === -1 ? undefined : arg.slice(equalsIndex + 1);
+		const readValue = () => {
+			if (inlineValue !== undefined) {
+				return inlineValue;
+			}
+			const value = argv[index + 1];
+			if (!value || value.startsWith("-")) {
+				throw new Error(`missing value for ${flag}`);
+			}
+			index += 1;
+			return value;
+		};
+
+		switch (flag) {
+			case "--cli":
+				options.cli = resolve(cliDir, readValue());
+				break;
+			case "--harness":
+				options.harness = readValue();
+				break;
+			case "--timeout":
+				options.timeout = Number.parseInt(readValue(), 10);
+				if (!Number.isFinite(options.timeout) || options.timeout <= 0) {
+					throw new Error("--timeout must be a positive integer");
+				}
+				break;
+			case "--keep-temp":
+				options.keepTemp = true;
+				break;
+			case "-h":
+			case "--help":
+				options.help = true;
+				break;
+			default:
+				throw new Error(`unknown option: ${arg}`);
+		}
+	}
+
+	if (options.harness !== "all" && !harnesses.includes(options.harness)) {
+		throw new Error(`unknown harness: ${options.harness}`);
+	}
+
+	return options;
+}
+
+function requestedHarnesses(name) {
+	return name === "all" ? harnesses : [name];
+}
+
+function requiredSecret(harness) {
+	return harness.startsWith("claude") ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
+}
+
+function run(command, args, options) {
+	const result = spawnSync(command, args, {
+		cwd: options.cwd,
+		encoding: "utf8",
+		env: options.env ?? process.env,
+		timeout: options.timeout,
+	});
+
+	if (result.error) {
+		replayOutput(result);
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		replayOutput(result);
+		throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+	}
+
+	return {
+		stderr: result.stderr ?? "",
+		stdout: result.stdout ?? "",
+	};
+}
+
+function replayOutput(result) {
+	if (result.stdout) {
+		process.stdout.write(result.stdout);
+	}
+	if (result.stderr) {
+		process.stderr.write(result.stderr);
+	}
+}
+
+function writeSkill(home) {
+	const agentsRoot = join(home, ".agents", "skills", "open-prose");
+	const claudeRoot = join(home, ".claude", "skills", "open-prose");
+	const skill = `---
+name: open-prose
+description: Prose CLI smoke skill
+---
+
+# Prose CLI Smoke Skill
+
+This skill was installed by the Prose CLI harness smoke test.
+
+If you can see ${skillSentinel}, and the user asks to run the smoke program,
+return only ${okToken}.
+
+${skillSentinel}
+`;
+
+	for (const root of [agentsRoot, claudeRoot]) {
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, "SKILL.md"), skill);
+	}
+}
+
+function writeWorkspace(workspace) {
+	mkdirSync(workspace, { recursive: true });
+	writeFileSync(
+		join(workspace, "smoke.md"),
+		`---
+name: harness-smoke
+kind: program
+---
+
+### Instructions
+
+Return only \`${okToken}\` if the preloaded OpenProse skill text includes
+\`${skillSentinel}\`. Otherwise return \`PROSE_HARNESS_SMOKE_BOOTSTRAP_MISSING\`.
+Do not edit files.
+`,
+	);
+
+	run("git", ["init", "--initial-branch=main"], { cwd: workspace });
+	run("git", ["config", "user.email", "ci@openprose.local"], { cwd: workspace });
+	run("git", ["config", "user.name", "OpenProse CI"], { cwd: workspace });
+	run("git", ["add", "smoke.md"], { cwd: workspace });
+	run("git", ["commit", "-m", "Add smoke program"], { cwd: workspace });
+}
+
+function smokeHarness(harness, options) {
+	const secret = requiredSecret(harness);
+	if (!process.env[secret]) {
+		throw new Error(`Missing required secret: ${secret}`);
+	}
+
+	const root = mkdtempSync(join(tmpdir(), `prose-${harness}-smoke-`));
+	const home = join(root, "home");
+	const workspace = join(root, "workspace");
+
+	try {
+		mkdirSync(join(home, ".codex"), { recursive: true });
+		writeSkill(home);
+		writeWorkspace(workspace);
+
+		const env = {
+			...process.env,
+			HOME: home,
+			PATH: `${join(cliDir, "node_modules", ".bin")}:${process.env.PATH ?? ""}`,
+			PROSE_CODEX_APPROVAL_POLICY: process.env.PROSE_CODEX_APPROVAL_POLICY ?? "never",
+			PROSE_CODEX_SANDBOX_MODE: process.env.PROSE_CODEX_SANDBOX_MODE ?? "danger-full-access",
+			XDG_CONFIG_HOME: join(home, ".config"),
+		};
+
+		if (harness === "codex") {
+			run("codex", ["--version"], { cwd: workspace, env, timeout: options.timeout });
+		}
+		if (harness === "claude") {
+			run("claude", ["--version"], { cwd: workspace, env, timeout: options.timeout });
+		}
+
+		const result = run(
+			process.execPath,
+			[options.cli, "run", "smoke.md", "--harness", harness],
+			{ cwd: workspace, env, timeout: options.timeout },
+		);
+		const output = `${result.stdout}\n${result.stderr}`;
+
+		if (!output.includes(okToken)) {
+			replayOutput(result);
+			throw new Error(`Smoke output for ${harness} did not include ${okToken}`);
+		}
+		process.stdout.write(`${harness}: ${okToken}\n`);
+	} finally {
+		if (options.keepTemp) {
+			process.stderr.write(`Kept smoke directory: ${root}\n`);
+		} else {
+			rmSync(root, { recursive: true, force: true });
+		}
+	}
+}
+
+function main() {
+	const options = parseArgs(process.argv.slice(2));
+	if (options.help) {
+		process.stdout.write(usage);
+		return;
+	}
+
+	for (const harness of requestedHarnesses(options.harness)) {
+		process.stderr.write(`Smoking ${harness}...\n`);
+		smokeHarness(harness, options);
+	}
+}
+
+try {
+	main();
+} catch (error) {
+	process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+	process.exitCode = 1;
+}

--- a/cli/src/commands/base.ts
+++ b/cli/src/commands/base.ts
@@ -3,7 +3,7 @@ import type { CommandName } from "../prose/index.js";
 import { canonicalPrompt, CommandModelError, usageFor } from "../prose/index.js";
 import { createHarness, type HarnessName } from "../harnesses/index.js";
 import type { Harness, WritableStreamLike } from "../harnesses/types.js";
-import { ensureOpenProseSkill } from "../skills/open-prose.js";
+import { ensureOpenProseSkill, loadOpenProseSkillBootstrap, type OpenProseSkillBootstrap } from "../skills/open-prose.js";
 
 export interface SkillPreflightOptions {
 	harness: string;
@@ -14,6 +14,7 @@ export interface SkillPreflightOptions {
 }
 
 export type SkillPreflight = (options: SkillPreflightOptions) => Promise<void>;
+export type SkillBootstrapLoader = (options: SkillPreflightOptions) => Promise<OpenProseSkillBootstrap | undefined>;
 
 export interface ForwardRunOptions {
 	command: CommandName;
@@ -24,6 +25,7 @@ export interface ForwardRunOptions {
 	stderr: WritableStreamLike;
 	signal?: AbortSignal;
 	harnessFactory?: (name: string) => Harness;
+	skillBootstrap?: SkillBootstrapLoader | false;
 	skillPreflight?: SkillPreflight | false;
 }
 
@@ -90,9 +92,18 @@ export async function runForwardedProseCommand(options: ForwardRunOptions): Prom
 	if (shouldRunSkillPreflight(options)) {
 		await runSkillPreflight(harness, options);
 	}
+	const skillBootstrap = shouldLoadSkillBootstrap(options)
+		? await runSkillBootstrapLoader(harness, options)
+		: undefined;
 
 	const selectedHarness = (options.harnessFactory ?? createHarness)(harness);
 	return selectedHarness.run(prompt, {
+		...(skillBootstrap === undefined
+			? {}
+			: {
+					additionalDirectories: skillBootstrap.additionalDirectories,
+					systemPromptAppend: skillBootstrap.systemPromptAppend,
+				}),
 		cwd: options.cwd,
 		env: { ...options.env },
 		stdout: options.stdout,
@@ -107,6 +118,14 @@ function shouldRunSkillPreflight(options: ForwardRunOptions): boolean {
 	}
 
 	return options.skillPreflight !== undefined || options.harnessFactory === undefined;
+}
+
+function shouldLoadSkillBootstrap(options: ForwardRunOptions): boolean {
+	if (options.skillBootstrap === false || options.skillPreflight === false) {
+		return false;
+	}
+
+	return options.skillBootstrap !== undefined || options.skillPreflight !== undefined || options.harnessFactory === undefined;
 }
 
 async function runSkillPreflight(harness: string, options: ForwardRunOptions): Promise<void> {
@@ -127,6 +146,27 @@ async function runSkillPreflight(harness: string, options: ForwardRunOptions): P
 		env: options.env,
 		stderr: options.stderr,
 		...(options.signal === undefined ? {} : { signal: options.signal }),
+	});
+}
+
+async function runSkillBootstrapLoader(
+	harness: string,
+	options: ForwardRunOptions,
+): Promise<OpenProseSkillBootstrap | undefined> {
+	if (options.skillBootstrap !== undefined && options.skillBootstrap !== false) {
+		return options.skillBootstrap({
+			harness,
+			cwd: options.cwd,
+			env: options.env,
+			stderr: options.stderr,
+			...(options.signal === undefined ? {} : { signal: options.signal }),
+		});
+	}
+
+	return loadOpenProseSkillBootstrap({
+		harness,
+		cwd: options.cwd,
+		env: options.env,
 	});
 }
 

--- a/cli/src/harnesses/claude-sdk.ts
+++ b/cli/src/harnesses/claude-sdk.ts
@@ -27,10 +27,22 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 					prompt,
 					options: {
 						abortController,
+						...(runOptions.additionalDirectories === undefined
+							? {}
+							: { additionalDirectories: runOptions.additionalDirectories }),
 						...(runOptions.cwd === undefined ? {} : { cwd: runOptions.cwd }),
 						...(runOptions.env === undefined ? {} : { env: runOptions.env }),
 						includePartialMessages: true,
 						stderr: (chunk: string) => runOptions.stderr.write(chunk),
+						...(runOptions.systemPromptAppend === undefined
+							? {}
+							: {
+									systemPrompt: {
+										type: "preset",
+										preset: "claude_code",
+										append: runOptions.systemPromptAppend,
+									},
+								}),
 					},
 				}),
 			).catch((error: unknown) => {

--- a/cli/src/harnesses/claude.ts
+++ b/cli/src/harnesses/claude.ts
@@ -3,10 +3,21 @@ import { createProcessHarness, type ProcessHarnessOptions } from "./process-harn
 export function createClaudeHarness(options: ProcessHarnessOptions = {}) {
   return createProcessHarness(
     "claude",
-    (prompt) => ({
+    (prompt, runOptions) => ({
       command: "claude",
-      args: ["-p", prompt],
+      args: [
+        ...additionalDirectoryArgs(runOptions.additionalDirectories),
+        ...(runOptions.systemPromptAppend === undefined
+          ? []
+          : ["--append-system-prompt", runOptions.systemPromptAppend]),
+        "-p",
+        prompt,
+      ],
     }),
     options,
   );
+}
+
+function additionalDirectoryArgs(directories: readonly string[] | undefined): string[] {
+  return (directories ?? []).flatMap((directory) => ["--add-dir", directory]);
 }

--- a/cli/src/harnesses/codex-cli.ts
+++ b/cli/src/harnesses/codex-cli.ts
@@ -1,4 +1,4 @@
-import { codexCliRuntimeArgs } from "./codex-options.js";
+import { codexCliRuntimeArgs, codexDeveloperInstructionArgs } from "./codex-options.js";
 import { createProcessHarness, type ProcessHarnessOptions } from "./process-harness.js";
 import type { HarnessRunOptions } from "./types.js";
 
@@ -7,7 +7,12 @@ export function createCodexCliHarness(options: ProcessHarnessOptions = {}) {
 		"codex",
 		(prompt, runOptions) => ({
 			command: "codex",
-			args: ["exec", ...codexCliRuntimeArgs(runOptions.env), prompt],
+			args: [
+				"exec",
+				...codexCliRuntimeArgs(runOptions.env, runOptions.additionalDirectories),
+				...codexDeveloperInstructionArgs(runOptions.systemPromptAppend),
+				prompt,
+			],
 		}),
 		options,
 	);

--- a/cli/src/harnesses/codex-options.ts
+++ b/cli/src/harnesses/codex-options.ts
@@ -3,31 +3,56 @@ import type { CodexThreadOptions } from "./types.js";
 const CODEX_SANDBOX_MODES = ["read-only", "workspace-write", "danger-full-access"] as const;
 const CODEX_APPROVAL_POLICIES = ["never", "on-request", "on-failure", "untrusted"] as const;
 
-export function codexCliRuntimeArgs(env: Record<string, string | undefined> | undefined): string[] {
+export function codexCliRuntimeArgs(
+	env: Record<string, string | undefined> | undefined,
+	additionalDirectories: readonly string[] = [],
+): string[] {
 	const args: string[] = [];
 	const sandboxMode = codexEnvOption("PROSE_CODEX_SANDBOX_MODE", CODEX_SANDBOX_MODES, env);
 	const approvalPolicy = codexEnvOption("PROSE_CODEX_APPROVAL_POLICY", CODEX_APPROVAL_POLICIES, env);
 
+	args.push("--ephemeral");
 	if (sandboxMode !== undefined) {
 		args.push("--sandbox", sandboxMode);
 	}
 	if (approvalPolicy !== undefined) {
 		args.push("--config", `approval_policy="${approvalPolicy}"`);
 	}
+	for (const directory of additionalDirectories) {
+		args.push("--add-dir", directory);
+	}
 
 	return args;
 }
 
+export function codexDeveloperInstructionArgs(systemPromptAppend: string | undefined): string[] {
+	if (systemPromptAppend === undefined) {
+		return [];
+	}
+
+	return ["--config", `developer_instructions=${JSON.stringify(systemPromptAppend)}`];
+}
+
 export function codexThreadRuntimeOptions(
 	env: Record<string, string | undefined> | undefined,
-): Pick<CodexThreadOptions, "approvalPolicy" | "sandboxMode"> {
+	additionalDirectories: readonly string[] = [],
+): Pick<CodexThreadOptions, "additionalDirectories" | "approvalPolicy" | "sandboxMode"> {
 	const sandboxMode = codexEnvOption("PROSE_CODEX_SANDBOX_MODE", CODEX_SANDBOX_MODES, env);
 	const approvalPolicy = codexEnvOption("PROSE_CODEX_APPROVAL_POLICY", CODEX_APPROVAL_POLICIES, env);
 
 	return {
 		...(sandboxMode === undefined ? {} : { sandboxMode }),
 		...(approvalPolicy === undefined ? {} : { approvalPolicy }),
+		...(additionalDirectories.length === 0 ? {} : { additionalDirectories: [...additionalDirectories] }),
 	};
+}
+
+export function codexClientConfig(systemPromptAppend: string | undefined = undefined) {
+	if (systemPromptAppend === undefined) {
+		return undefined;
+	}
+
+	return { developer_instructions: systemPromptAppend };
 }
 
 function codexEnvOption<const T extends readonly string[]>(

--- a/cli/src/harnesses/codex-sdk.ts
+++ b/cli/src/harnesses/codex-sdk.ts
@@ -1,4 +1,4 @@
-import { codexThreadRuntimeOptions } from "./codex-options.js";
+import { codexClientConfig, codexThreadRuntimeOptions } from "./codex-options.js";
 import { writeLine } from "./streams.js";
 import type { CodexSdkClientOptions, CodexSdkFactory, CodexThreadEvent, CodexThreadItem, Harness } from "./types.js";
 
@@ -19,8 +19,10 @@ export function createCodexSdkHarness(options: CodexSdkHarnessOptions = {}): Har
 		async run(prompt, runOptions) {
 			try {
 				const env = definedEnv(runOptions.env);
-				const codex = await factory(codexClientOptions(env));
-				const thread = codex.startThread(codexThreadOptions(runOptions.cwd, env));
+				const codex = await factory(codexClientOptions(env, runOptions.systemPromptAppend));
+				const thread = codex.startThread(
+					codexThreadOptions(runOptions.cwd, env, runOptions.additionalDirectories),
+				);
 				const { events } = await thread.runStreamed(
 					prompt,
 					runOptions.signal === undefined ? undefined : { signal: runOptions.signal },
@@ -42,8 +44,12 @@ export function createCodexSdkHarness(options: CodexSdkHarnessOptions = {}): Har
 	};
 }
 
-function codexThreadOptions(cwd: string | undefined, env: Record<string, string> | undefined) {
-	const runtimeOptions = codexThreadRuntimeOptions(env);
+function codexThreadOptions(
+	cwd: string | undefined,
+	env: Record<string, string> | undefined,
+	additionalDirectories: readonly string[] | undefined,
+) {
+	const runtimeOptions = codexThreadRuntimeOptions(env, additionalDirectories);
 	const options = {
 		...(cwd === undefined ? {} : { workingDirectory: cwd }),
 		...runtimeOptions,
@@ -52,14 +58,16 @@ function codexThreadOptions(cwd: string | undefined, env: Record<string, string>
 	return Object.keys(options).length === 0 ? undefined : options;
 }
 
-function codexClientOptions(env: Record<string, string> | undefined) {
+function codexClientOptions(env: Record<string, string> | undefined, systemPromptAppend: string | undefined) {
 	const apiKey = env?.CODEX_API_KEY ?? env?.OPENAI_API_KEY ?? process.env.CODEX_API_KEY ?? process.env.OPENAI_API_KEY;
-	if (env === undefined && apiKey === undefined) {
+	if (env === undefined && apiKey === undefined && systemPromptAppend === undefined) {
 		return undefined;
 	}
+	const config = codexClientConfig(systemPromptAppend);
 
 	return {
 		...(apiKey === undefined ? {} : { apiKey }),
+		...(config === undefined ? {} : { config }),
 		...(env === undefined ? {} : { env }),
 	};
 }

--- a/cli/src/harnesses/types.ts
+++ b/cli/src/harnesses/types.ts
@@ -15,9 +15,11 @@ export interface WritableStreamLike {
 }
 
 export interface HarnessRunOptions {
+	additionalDirectories?: string[];
 	cwd?: string;
 	env?: Record<string, string | undefined>;
 	signal?: AbortSignal;
+	systemPromptAppend?: string;
 	stdout: WritableStreamLike;
 	stderr: WritableStreamLike;
 }
@@ -45,7 +47,7 @@ export type ProcessRunner = (
 ) => Promise<ProcessRunResult>;
 
 export type CodexThreadOptions = ThreadOptions;
-export type CodexSdkClientOptions = Pick<CodexOptions, "apiKey" | "env">;
+export type CodexSdkClientOptions = Pick<CodexOptions, "apiKey" | "config" | "env">;
 
 export interface CodexThread {
 	runStreamed(prompt: CodexInput, options?: TurnOptions): Promise<RunStreamedResult>;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,9 +11,12 @@ export { supportedCommands, canonicalPrompt, CommandModelError, usageFor } from 
 export { createHarness, HARNESS_NAMES } from "./harnesses/index.js";
 export {
 	buildOpenProseSkillInstallCommand,
+	buildOpenProseSkillBootstrapPrompt,
 	checkOpenProseSkill,
 	ensureOpenProseSkill,
 	installOpenProseSkill,
+	loadOpenProseSkillBootstrap,
+	resolveOpenProseSkill,
 	skillAgentsForHarness,
 } from "./skills/open-prose.js";
 

--- a/cli/src/skills/open-prose.ts
+++ b/cli/src/skills/open-prose.ts
@@ -57,6 +57,19 @@ export interface EnsureOpenProseSkillResult {
 	statuses: SkillStatus[];
 }
 
+export interface OpenProseSkillBootstrap {
+	additionalDirectories: string[];
+	skillPath: string;
+	skillRoot: string;
+	systemPromptAppend: string;
+}
+
+export interface LoadOpenProseSkillBootstrapOptions {
+	harness: string;
+	cwd: string;
+	env: Readonly<Record<string, string | undefined>>;
+}
+
 export function skillAgentsForHarness(harness: string): SkillAgent[] {
 	switch (harness as HarnessName) {
 		case "codex":
@@ -69,6 +82,78 @@ export function skillAgentsForHarness(harness: string): SkillAgent[] {
 		default:
 			return [];
 	}
+}
+
+export async function loadOpenProseSkillBootstrap(
+	options: LoadOpenProseSkillBootstrapOptions,
+): Promise<OpenProseSkillBootstrap | undefined> {
+	const resolved = await resolveOpenProseSkill(options);
+	if (resolved === undefined) {
+		return undefined;
+	}
+
+	const skillText = await readFile(resolved.path, "utf8");
+	const skillRoot = dirname(resolved.path);
+	return {
+		additionalDirectories: [skillRoot],
+		skillPath: resolved.path,
+		skillRoot,
+		systemPromptAppend: buildOpenProseSkillBootstrapPrompt({
+			skillPath: resolved.path,
+			skillRoot,
+			skillText,
+		}),
+	};
+}
+
+export function buildOpenProseSkillBootstrapPrompt(options: {
+	skillPath: string;
+	skillRoot: string;
+	skillText: string;
+}): string {
+	return [
+		"<open-prose-introduction>",
+		"You are running inside the Prose CLI harness.",
+		"The OpenProse skill is preloaded below and must be treated as active for this run.",
+		`OpenProse skill root: ${options.skillRoot}`,
+		`OpenProse SKILL.md path: ${options.skillPath}`,
+		"Resolve every file referenced by this SKILL.md relative to the OpenProse skill root.",
+		"When additional OpenProse skill files are needed, read them from that skill root.",
+		"Do not invoke the `prose`, `npx prose`, or `@openprose/prose-cli` shell command; that would recursively call this wrapper.",
+		"</open-prose-introduction>",
+		"",
+		"<open-prose-skill>",
+		options.skillText.trimEnd(),
+		"</open-prose-skill>",
+	].join("\n");
+}
+
+export async function resolveOpenProseSkill(
+	options: LoadOpenProseSkillBootstrapOptions,
+): Promise<SkillLocation | undefined> {
+	const agents = skillAgentsForHarness(options.harness);
+	if (agents.length === 0) {
+		return undefined;
+	}
+
+	const home = homeFromEnv(options.env);
+	const sharedSkillPath = join(home, ".agents", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md");
+	const sharedSkill = {
+		agent: "codex" as const,
+		scope: "user" as const,
+		path: sharedSkillPath,
+		...(await inspectSkill(sharedSkillPath)),
+	};
+	if (sharedSkill.valid) {
+		return sharedSkill;
+	}
+
+	const statuses = await checkOpenProseSkill({
+		agents,
+		cwd: options.cwd,
+		env: options.env,
+	});
+	return statuses.flatMap((status) => status.locations).find((location) => location.valid);
 }
 
 export async function checkOpenProseSkill(options: CheckOpenProseSkillOptions): Promise<SkillStatus[]> {

--- a/cli/tests/cli/cli.test.ts
+++ b/cli/tests/cli/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -120,6 +120,64 @@ describe("runForwardedProseCommand", () => {
 		expect(io.stderr).toBe("err");
 	});
 
+	it("loads OpenProse skill bootstrap after preflight and passes it to the harness", async () => {
+		const home = mkdtempSync(join(tmpdir(), "prose-home-"));
+		const cwd = mkdtempSync(join(tmpdir(), "prose-cwd-"));
+		const io = memoryStreams();
+		const skillRoot = join(home, ".agents", "skills", "open-prose");
+		const seen: Array<{
+			additionalDirectories: string[] | undefined;
+			systemPromptAppend: string | undefined;
+			prompt: string;
+		}> = [];
+
+		try {
+			mkdirSync(skillRoot, { recursive: true });
+			writeFileSync(
+				join(skillRoot, "SKILL.md"),
+				`---
+name: open-prose
+description: Test skill
+---
+
+# OpenProse
+
+FORWARDED_BOOTSTRAP_SENTINEL
+`,
+			);
+
+			await runForwardedProseCommand({
+				command: "run",
+				argv: ["flow.md", "--harness", "codex-sdk"],
+				cwd,
+				env: { HOME: home },
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillPreflight: async () => undefined,
+				harnessFactory: () => ({
+					name: "codex-sdk",
+					async run(prompt, options) {
+						seen.push({
+							additionalDirectories: options.additionalDirectories,
+							systemPromptAppend: options.systemPromptAppend,
+							prompt,
+						});
+						return 0;
+					},
+				}),
+			});
+
+			expect(seen).toHaveLength(1);
+			expect(seen[0]?.prompt).toContain("prose run flow.md");
+			expect(seen[0]?.additionalDirectories).toEqual([skillRoot]);
+			expect(seen[0]?.systemPromptAppend).toContain("FORWARDED_BOOTSTRAP_SENTINEL");
+			expect(seen[0]?.systemPromptAppend).toContain(`OpenProse skill root: ${skillRoot}`);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("passes abort signals to harnesses", async () => {
 		const io = memoryStreams();
 		const signal = new AbortController().signal;
@@ -156,6 +214,7 @@ describe("runForwardedProseCommand", () => {
 			env: {},
 			stdout: io.streams.stdout,
 			stderr: io.streams.stderr,
+			skillBootstrap: false,
 			skillPreflight: async ({ harness, cwd }) => void calls.push(`preflight:${harness}:${cwd}`),
 			harnessFactory: () => ({
 				name: "mock",
@@ -181,6 +240,7 @@ describe("runForwardedProseCommand", () => {
 				env: {},
 				stdout: io.streams.stdout,
 				stderr: io.streams.stderr,
+				skillBootstrap: false,
 				skillPreflight: async () => void (preflightCalled = true),
 				harnessFactory: () => ({
 					name: "mock",

--- a/cli/tests/harnesses/harnesses.test.ts
+++ b/cli/tests/harnesses/harnesses.test.ts
@@ -44,6 +44,16 @@ async function* events(items: CodexThreadEvent[]): AsyncGenerator<CodexThreadEve
 	}
 }
 
+async function waitFor(predicate: () => boolean): Promise<void> {
+	const deadline = Date.now() + 1000;
+	while (!predicate()) {
+		if (Date.now() > deadline) {
+			throw new Error("Timed out waiting for condition.");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 describe("process harnesses", () => {
 	test("claude preserves prompt as a single -p argument and streams output", async () => {
 		const calls: Array<{ command: string; args: string[] }> = [];
@@ -59,6 +69,33 @@ describe("process harnesses", () => {
 		expect(io.stderr).toBe("tool err");
 	});
 
+	test("claude appends OpenProse bootstrap as system prompt context", async () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const io = memoryStreams();
+		const prompt = "prose run inspector.md";
+		const harness = createHarness("claude", { runner: recordingRunner(calls) });
+
+		await harness.run(prompt, {
+			...io.options,
+			additionalDirectories: ["/skills/open-prose"],
+			systemPromptAppend: "OPEN_PROSE_BOOTSTRAP",
+		});
+
+		expect(calls).toEqual([
+			{
+				command: "claude",
+				args: [
+					"--add-dir",
+					"/skills/open-prose",
+					"--append-system-prompt",
+					"OPEN_PROSE_BOOTSTRAP",
+					"-p",
+					prompt,
+				],
+			},
+		]);
+	});
+
 	test("codex CLI builds codex exec with the exact prompt", async () => {
 		const calls: Array<{ command: string; args: string[] }> = [];
 		const io = memoryStreams();
@@ -67,8 +104,43 @@ describe("process harnesses", () => {
 
 		await harness.run(prompt, { ...io.options });
 
-		expect(calls).toEqual([{ command: "codex", args: ["exec", prompt] }]);
+		expect(calls).toEqual([
+			{
+				command: "codex",
+				args: ["exec", "--ephemeral", prompt],
+			},
+		]);
 	});
+
+	test("codex CLI injects OpenProse bootstrap as developer instructions", async () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const io = memoryStreams();
+		const prompt = "prose run inspector.md";
+		const bootstrap = "OPEN_PROSE_BOOTSTRAP\nwith newline";
+		const harness = createHarness("codex", { runner: recordingRunner(calls) });
+
+		await harness.run(prompt, {
+			...io.options,
+			additionalDirectories: ["/skills/open-prose"],
+			env: { HOME: "/home/prose" },
+			systemPromptAppend: bootstrap,
+		});
+
+			expect(calls).toEqual([
+				{
+					command: "codex",
+					args: [
+						"exec",
+						"--ephemeral",
+						"--add-dir",
+						"/skills/open-prose",
+						"--config",
+						`developer_instructions=${JSON.stringify(bootstrap)}`,
+						prompt,
+					],
+				},
+			]);
+		});
 
 	test("codex CLI maps OPENAI_API_KEY to CODEX_API_KEY", async () => {
 		let env: Record<string, string | undefined> | undefined;
@@ -101,13 +173,21 @@ describe("process harnesses", () => {
 			},
 		});
 
-		expect(calls).toEqual([
-			{
-				command: "codex",
-				args: ["exec", "--sandbox", "danger-full-access", "--config", 'approval_policy="never"', prompt],
-			},
-		]);
-	});
+			expect(calls).toEqual([
+				{
+					command: "codex",
+					args: [
+						"exec",
+						"--ephemeral",
+						"--sandbox",
+						"danger-full-access",
+						"--config",
+						'approval_policy="never"',
+						prompt,
+					],
+				},
+			]);
+		});
 
 	test("node runner streams stdout/stderr and reports signal exits", async () => {
 		const io = memoryStreams();
@@ -128,7 +208,7 @@ describe("process harnesses", () => {
 			{ ...io.options, signal: controller.signal },
 		);
 
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await waitFor(() => io.stdout.includes("started"));
 		controller.abort("SIGTERM");
 
 		const result = await resultPromise;
@@ -194,6 +274,50 @@ describe("codex-sdk harness", () => {
 		expect(factoryOptions).toEqual([{ apiKey: "test", env: { OPENAI_API_KEY: "test" } }]);
 	});
 
+	test("injects OpenProse bootstrap into Codex SDK client and thread options", async () => {
+		const io = memoryStreams();
+		const starts: unknown[] = [];
+		const factoryOptions: unknown[] = [];
+		const bootstrap = "OPEN_PROSE_BOOTSTRAP";
+		const factory: CodexSdkFactory = (options) => {
+			factoryOptions.push(options);
+			return {
+				startThread: (options) => {
+					starts.push(options);
+					return {
+						runStreamed: async () => ({
+							events: events([
+								{ type: "item.completed", item: { id: "item-1", type: "agent_message", text: "sdk output" } },
+							]),
+						}),
+					};
+				},
+			};
+		};
+
+		await createCodexSdkHarness({ factory }).run("prose run inspector.md", {
+			...io.options,
+			additionalDirectories: ["/skills/open-prose"],
+			env: { OPENAI_API_KEY: "test", HOME: "/home/prose" },
+			systemPromptAppend: bootstrap,
+		});
+
+		expect(starts).toEqual([
+			{
+				additionalDirectories: ["/skills/open-prose"],
+			},
+		]);
+		expect(factoryOptions).toEqual([
+			{
+				apiKey: "test",
+				config: {
+					developer_instructions: bootstrap,
+				},
+				env: { OPENAI_API_KEY: "test", HOME: "/home/prose" },
+			},
+		]);
+	});
+
 	test("forwards requested sandbox and approval settings to Codex SDK threads", async () => {
 		const io = memoryStreams();
 		const starts: unknown[] = [];
@@ -240,6 +364,48 @@ describe("codex-sdk harness", () => {
 });
 
 describe("claude-sdk harness", () => {
+	test("injects OpenProse bootstrap as Claude Code system prompt append", async () => {
+		const io = memoryStreams();
+		const calls: unknown[] = [];
+		const bootstrap = "OPEN_PROSE_BOOTSTRAP";
+		const harness = createClaudeSdkHarness({
+			query: async (args) => {
+				calls.push(args);
+				return {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "result", subtype: "success", result: "ok", is_error: false };
+					},
+					close() {},
+				} as never;
+			},
+		});
+
+		const exitCode = await harness.run("prose run inspector.md", {
+			...io.options,
+			additionalDirectories: ["/skills/open-prose"],
+			cwd: "/repo",
+			env: { A: "B" },
+			systemPromptAppend: bootstrap,
+		});
+
+		expect(exitCode).toBe(0);
+		expect(calls).toEqual([
+			{
+				prompt: "prose run inspector.md",
+				options: expect.objectContaining({
+					additionalDirectories: ["/skills/open-prose"],
+					cwd: "/repo",
+					env: { A: "B" },
+					systemPrompt: {
+						type: "preset",
+						preset: "claude_code",
+						append: bootstrap,
+					},
+				}),
+			},
+		]);
+	});
+
 	test("streams text deltas without duplicating final result", async () => {
 		const io = memoryStreams();
 		const abortControllers: AbortController[] = [];

--- a/cli/tests/skills/open-prose.test.ts
+++ b/cli/tests/skills/open-prose.test.ts
@@ -4,10 +4,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ProcessRunner } from "../../src/harnesses/index.js";
 import {
+	buildOpenProseSkillBootstrapPrompt,
 	buildOpenProseSkillInstallCommand,
 	checkOpenProseSkill,
 	ensureOpenProseSkill,
 	installOpenProseSkill,
+	loadOpenProseSkillBootstrap,
+	resolveOpenProseSkill,
 } from "../../src/skills/open-prose.js";
 
 function tempDir(): string {
@@ -28,6 +31,22 @@ description: Test skill
 	);
 }
 
+function writeSentinelSkill(path: string, sentinel: string): void {
+	mkdirSync(path, { recursive: true });
+	writeFileSync(
+		join(path, "SKILL.md"),
+		`---
+name: open-prose
+description: Test skill
+---
+
+# OpenProse
+
+${sentinel}
+`,
+	);
+}
+
 function memoryStream() {
 	let output = "";
 	return {
@@ -39,6 +58,70 @@ function memoryStream() {
 }
 
 describe("OpenProse skill checks", () => {
+	it("builds a bootstrap prompt with the full skill text and skill root instructions", () => {
+		const bootstrap = buildOpenProseSkillBootstrapPrompt({
+			skillPath: "/home/prose/.agents/skills/open-prose/SKILL.md",
+			skillRoot: "/home/prose/.agents/skills/open-prose",
+			skillText: "---\nname: open-prose\n---\n\n# Skill\nBOOTSTRAP_SENTINEL\n",
+		});
+
+		expect(bootstrap).toContain("BOOTSTRAP_SENTINEL");
+		expect(bootstrap).toContain("OpenProse skill root: /home/prose/.agents/skills/open-prose");
+		expect(bootstrap).toContain("OpenProse SKILL.md path: /home/prose/.agents/skills/open-prose/SKILL.md");
+		expect(bootstrap).toContain("Resolve every file referenced by this SKILL.md relative to the OpenProse skill root.");
+		expect(bootstrap).toContain("Do not invoke the `prose`, `npx prose`, or `@openprose/prose-cli` shell command");
+		expect(bootstrap).toContain("<open-prose-introduction>");
+		expect(bootstrap).toContain("</open-prose-introduction>");
+		expect(bootstrap).toContain("<open-prose-skill>");
+		expect(bootstrap).toContain("</open-prose-skill>");
+	});
+
+	it("loads the shared installed skill into a harness bootstrap", async () => {
+		const home = tempDir();
+		const cwd = tempDir();
+		const skillRoot = join(home, ".agents", "skills", "open-prose");
+
+		try {
+			writeSentinelSkill(skillRoot, "SHARED_BOOTSTRAP_SENTINEL");
+
+			const bootstrap = await loadOpenProseSkillBootstrap({
+				harness: "claude-sdk",
+				cwd,
+				env: { HOME: home },
+			});
+
+			expect(bootstrap?.skillRoot).toBe(skillRoot);
+			expect(bootstrap?.skillPath).toBe(join(skillRoot, "SKILL.md"));
+			expect(bootstrap?.additionalDirectories).toEqual([skillRoot]);
+			expect(bootstrap?.systemPromptAppend).toContain("SHARED_BOOTSTRAP_SENTINEL");
+			expect(bootstrap?.systemPromptAppend).toContain(`OpenProse skill root: ${skillRoot}`);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to provider-specific installed skill locations", async () => {
+		const home = tempDir();
+		const cwd = tempDir();
+		const skillRoot = join(home, ".claude", "skills", "open-prose");
+
+		try {
+			writeSentinelSkill(skillRoot, "CLAUDE_BOOTSTRAP_SENTINEL");
+
+			const resolved = await resolveOpenProseSkill({
+				harness: "claude",
+				cwd,
+				env: { HOME: home },
+			});
+
+			expect(resolved?.path).toBe(join(skillRoot, "SKILL.md"));
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("detects Codex user skills without treating them as Claude skills", async () => {
 		const home = tempDir();
 		const cwd = tempDir();


### PR DESCRIPTION
## Summary
- load the installed OpenProse `SKILL.md` before forwarded CLI runs and append it to each supported harness prompt surface
- pass the resolved skill root as an additional readable directory for Claude/Codex CLI and SDK harnesses
- add focused unit coverage plus a shared real-harness smoke script for release-gated CI
- make Codex CLI runs ephemeral so successful smokes do not emit session-recording warnings

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`
- `node --check cli/scripts/smoke-harness.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/cli-real-harness-smoke.yml .github/workflows/cli-release-check.yml`
- `npm run smoke:harness -- --harness all --timeout 240000`

No `skills/**` files are included in this branch.
