### PR TITLE
Prepare CLI 0.1.2 release

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Installs the Node-based Prose CLI from a verified release tarball.
-DEFAULT_VERSION="0.1.1"
+DEFAULT_VERSION="0.1.2"
 DEFAULT_REPO_URL="https://github.com/openprose/prose"
 
 log() {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openprose/prose-cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.90",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Run OpenProse commands through Codex, Claude, or SDK-backed agent harnesses.",
   "type": "module",
   "packageManager": "npm@10.9.2",


### PR DESCRIPTION
## Summary
- bump `@openprose/prose-cli` from `0.1.1` to `0.1.2`
- update the npm lockfile root package version
- update the tarball installer default version to `0.1.2`

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`
- confirmed `@openprose/prose-cli@0.1.2` is not currently published on npm

This is the release-prep PR from `cli/RELEASE.md`. After merge, run the manual `CLI Publish` workflow from `main` first with `dry_run=true`, then with `dry_run=false` if the dry run passes.
