### PR TITLE
chore: prepare CLI 0.2.0 release

### DIFF
--- a/.github/workflows/cli-release-check.yml
+++ b/.github/workflows/cli-release-check.yml
@@ -100,7 +100,7 @@ jobs:
           node dist/index.js --help
           node dist/index.js help
           node dist/index.js run hello.prose.md --harness mock
-          PROSE_HARNESS=mock node dist/index.js status --graph
+          PROSE_HARNESS=mock node dist/index.js status
 
   npm-package-smoke:
     name: npm package smoke

--- a/tools/cli/install.sh
+++ b/tools/cli/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Installs the Node-based Prose CLI from a verified release tarball.
-DEFAULT_VERSION="0.1.4"
+DEFAULT_VERSION="0.2.0"
 DEFAULT_REPO_URL="https://github.com/openprose/prose"
 
 log() {

--- a/tools/cli/package-lock.json
+++ b/tools/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openprose/prose-cli",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.90",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Run OpenProse commands through Codex, Claude, or SDK-backed agent harnesses.",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/tools/cli/tests/prose/repository-serve.test.ts
+++ b/tools/cli/tests/prose/repository-serve.test.ts
@@ -709,7 +709,7 @@ describe("repository serve core", () => {
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}
-	});
+	}, 10_000);
 
 	it("restores trigger registrations when serve restarts", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-serve-restart-"));


### PR DESCRIPTION
## Summary

- Bump @openprose/prose-cli to 0.2.0
- Update package-lock metadata
- Update install.sh default release version

## Verification

- npm run typecheck
- npm test
- npm run build
- npm run release:tarball
