### PR TITLE
feat(cli): add experimental cursor-sdk harness

### DIFF
--- a/tools/cli/POST_RELEASE_PLAYTEST.md
+++ b/tools/cli/POST_RELEASE_PLAYTEST.md
@@ -50,6 +50,7 @@ Example worker families:
 - `tarball-fresh`: curl installer, checksum verification, shim behavior.
 - `codex-sdk`: default harness, OpenAI credentials, git and non-git dirs.
 - `claude-sdk`: Claude SDK harness, streaming, skill loading.
+- `cursor-sdk` _(experimental, Tier-2)_: Cursor SDK local harness, `CURSOR_API_KEY`, `CURSOR_MODEL` override (default `composer-2`), skill loading from `.cursor/skills/` and `.agents/skills/`. **Composer-2 is tuned for coding tasks; expect partial / plan-only behavior on multi-stage programs.**
 - `skill-state`: missing, existing, or damaged skill installs.
 - `path-edge`: spaces in paths, absolute paths, relative paths, temp dirs.
 - `native-repo`: compile, serve, status, and run in one small native repo.
@@ -147,8 +148,13 @@ Cover a representative subset of these scenarios.
 - `prose run <program> --harness mock`
 - `prose run <program> --harness codex-sdk`
 - `prose run <program> --harness claude-sdk`
+- `prose run std/ops/lint target:<path>.prose.md --harness cursor-sdk` (read-and-explain — expected to pass)
+- `prose run std/evals/inspector --harness cursor-sdk` (read-and-explain — expected to clarify on missing inputs)
 - `PROSE_HARNESS=<name> prose run <program>`
 - missing credentials for each real harness
+- `prose run <program> --harness cursor-sdk` with `CURSOR_MODEL=claude-4.6-sonnet-thinking` (model-passthrough probe — unverified)
+- `prose run <program> --harness cursor-sdk` with missing `CURSOR_API_KEY`
+- `prose run <program> --harness cursor-sdk` with `PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS=1` (warning suppressed)
 - invalid harness name
 
 ### Working Directories And Paths

--- a/tools/cli/POST_RELEASE_PLAYTEST.md
+++ b/tools/cli/POST_RELEASE_PLAYTEST.md
@@ -50,7 +50,7 @@ Example worker families:
 - `tarball-fresh`: curl installer, checksum verification, shim behavior.
 - `codex-sdk`: default harness, OpenAI credentials, git and non-git dirs.
 - `claude-sdk`: Claude SDK harness, streaming, skill loading.
-- `cursor-sdk` _(experimental, Tier-2)_: Cursor SDK local harness, `CURSOR_API_KEY`, `CURSOR_MODEL` override (default `composer-2`), skill loading from `.cursor/skills/` and `.agents/skills/`. **Composer-2 is tuned for coding tasks; expect partial / plan-only behavior on multi-stage programs.**
+- `cursor-sdk` _(experimental)_: Cursor SDK local harness, `CURSOR_API_KEY`, `CURSOR_MODEL` override (default `composer-2`), skill loading from `.cursor/skills/` and `.agents/skills/`. Coding-tuned default; multi-stage programs may run plan-only.
 - `skill-state`: missing, existing, or damaged skill installs.
 - `path-edge`: spaces in paths, absolute paths, relative paths, temp dirs.
 - `native-repo`: compile, serve, status, and run in one small native repo.
@@ -152,9 +152,7 @@ Cover a representative subset of these scenarios.
 - `prose run std/evals/inspector --harness cursor-sdk` (read-and-explain — expected to clarify on missing inputs)
 - `PROSE_HARNESS=<name> prose run <program>`
 - missing credentials for each real harness
-- `prose run <program> --harness cursor-sdk` with `CURSOR_MODEL=claude-4.6-sonnet-thinking` (model-passthrough probe — unverified)
 - `prose run <program> --harness cursor-sdk` with missing `CURSOR_API_KEY`
-- `prose run <program> --harness cursor-sdk` with `PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS=1` (warning suppressed)
 - invalid harness name
 
 ### Working Directories And Paths

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -67,7 +67,7 @@ harness names both a provider family and the runtime used to call it.
 | --- | --- | --- | --- | --- |
 | `codex-sdk` | OpenAI/Codex | `@openai/codex-sdk` | `OPENAI_API_KEY` or `CODEX_API_KEY` | Default. Best first choice for OpenAI-backed runs. |
 | `claude-sdk` | Anthropic/Claude | `@anthropic-ai/claude-agent-sdk` | `ANTHROPIC_API_KEY` | Best first choice for Anthropic-backed runs. |
-| `cursor-sdk` _(experimental)_ | Cursor | `@cursor/sdk` (local mode) | `CURSOR_API_KEY` | Tier-2 / experimental. Default model `composer-2` is tuned for coding tasks, not OpenProse contract execution; multi-stage programs may run plan-only. Override with `CURSOR_MODEL`. |
+| `cursor-sdk` _(experimental)_ | Cursor | `@cursor/sdk` (local mode) | `CURSOR_API_KEY` | Coding-tuned default model; multi-stage Prose programs may run plan-only. |
 | `mock` | None | local echo harness | none | Test and smoke-check harness only. |
 
 Examples:
@@ -86,30 +86,21 @@ PROSE_HARNESS=claude-sdk prose run std/evals/inspector
   and environment, and streams Codex SDK events. This is the default.
 - `claude-sdk` uses `@anthropic-ai/claude-agent-sdk`, forwards the current
   working directory and environment, and streams text deltas.
-- `cursor-sdk` _(experimental, Tier-2)_ uses `@cursor/sdk` in **local** mode,
-  forwards the current working directory, and streams Cursor agent assistant
-  text. It runs with `local.settingSources: ["project", "user"]` so Cursor
-  auto-loads the OpenProse skill from `.cursor/skills/`, `.agents/skills/`,
+- `cursor-sdk` _(experimental)_ uses `@cursor/sdk` in **local** mode with
+  `local.settingSources: ["project", "user"]`, so Cursor auto-loads the
+  OpenProse skill from `.cursor/skills/`, `.agents/skills/`,
   `~/.cursor/skills/`, or `~/.agents/skills/`. Authentication uses
-  `CURSOR_API_KEY`; the local model defaults to `composer-2` and can be
-  overridden with `CURSOR_MODEL`.
+  `CURSOR_API_KEY`; model defaults to `composer-2` and can be overridden
+  with `CURSOR_MODEL`. Exit codes (`0` / `1` / `143`) and SIGINT/SIGTERM
+  semantics match `codex-sdk` and `claude-sdk`. Cursor Cloud, PR/repo
+  automation, and `Cursor.models.list()` are not exposed.
 
-  **Caveat — not OpenProse-complete.** Cursor positions `composer-2` as a
-  coding agent ("specifically tuned for complex tasks such as tool use,
-  precise file edits, and terminal operations") rather than a general-purpose
-  instruction-follower. In practice the harness reliably handles
+  **Known limits.** Cursor positions `composer-2` as a coding-tuned model
+  rather than a general-purpose instruction-follower. The harness handles
   read-and-explain Prose programs (`std/ops/lint`, `std/evals/inspector`,
-  `std/ops/status`, `std/ops/diagnose`) but may run plan-only on multi-stage
-  execution programs (e.g. nested `worker-critic` × `stochastic-probe`) and
-  does not pass the SKILL.md-compliance smoke test. For production Prose
-  runs prefer `codex-sdk` or `claude-sdk`. The Cursor SDK exposes other
-  models (`gpt-5.5`, `claude-4.6-sonnet-thinking`) — try
-  `CURSOR_MODEL=claude-4.6-sonnet-thinking` if you need stricter
-  instruction-following through your Cursor billing account; this is
-  unverified.
-
-  The harness emits a one-line stderr warning on each run; suppress with
-  `PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS=1`.
+  `std/ops/status`, `std/ops/diagnose`) reliably but may run plan-only on
+  multi-stage execution programs. For production Prose runs prefer
+  `codex-sdk` or `claude-sdk`.
 - `mock` echoes prompts for tests and local smoke checks.
 
 Select a harness with `--harness <name>` or `PROSE_HARNESS`.
@@ -122,12 +113,6 @@ For externally sandboxed CI environments, Codex harnesses also honor
 `PROSE_CODEX_SANDBOX_MODE` (`read-only`, `workspace-write`, or
 `danger-full-access`) and `PROSE_CODEX_APPROVAL_POLICY` (`never`, `on-request`,
 `on-failure`, or `untrusted`) and forward those values to Codex.
-
-The Cursor harness reads `CURSOR_API_KEY` for authentication and `CURSOR_MODEL`
-(default `composer-2`) for the local model id. Set
-`PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS=1` to silence the per-run experimental
-warning. Cursor Cloud, PR/repo automation, `Cursor.models.list()`, and
-artifact downloads are not exposed by the CLI.
 
 ## Skill Setup
 

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -67,6 +67,7 @@ harness names both a provider family and the runtime used to call it.
 | --- | --- | --- | --- | --- |
 | `codex-sdk` | OpenAI/Codex | `@openai/codex-sdk` | `OPENAI_API_KEY` or `CODEX_API_KEY` | Default. Best first choice for OpenAI-backed runs. |
 | `claude-sdk` | Anthropic/Claude | `@anthropic-ai/claude-agent-sdk` | `ANTHROPIC_API_KEY` | Best first choice for Anthropic-backed runs. |
+| `cursor-sdk` _(experimental)_ | Cursor | `@cursor/sdk` (local mode) | `CURSOR_API_KEY` | Tier-2 / experimental. Default model `composer-2` is tuned for coding tasks, not OpenProse contract execution; multi-stage programs may run plan-only. Override with `CURSOR_MODEL`. |
 | `mock` | None | local echo harness | none | Test and smoke-check harness only. |
 
 Examples:
@@ -75,6 +76,7 @@ Examples:
 prose run std/evals/inspector
 prose run std/evals/inspector --harness codex-sdk
 prose run co/systems/company-repo-checker --harness claude-sdk
+prose run std/ops/lint target:packages/std/evals/inspector.prose.md --harness cursor-sdk
 PROSE_HARNESS=claude-sdk prose run std/evals/inspector
 ```
 
@@ -84,6 +86,30 @@ PROSE_HARNESS=claude-sdk prose run std/evals/inspector
   and environment, and streams Codex SDK events. This is the default.
 - `claude-sdk` uses `@anthropic-ai/claude-agent-sdk`, forwards the current
   working directory and environment, and streams text deltas.
+- `cursor-sdk` _(experimental, Tier-2)_ uses `@cursor/sdk` in **local** mode,
+  forwards the current working directory, and streams Cursor agent assistant
+  text. It runs with `local.settingSources: ["project", "user"]` so Cursor
+  auto-loads the OpenProse skill from `.cursor/skills/`, `.agents/skills/`,
+  `~/.cursor/skills/`, or `~/.agents/skills/`. Authentication uses
+  `CURSOR_API_KEY`; the local model defaults to `composer-2` and can be
+  overridden with `CURSOR_MODEL`.
+
+  **Caveat — not OpenProse-complete.** Cursor positions `composer-2` as a
+  coding agent ("specifically tuned for complex tasks such as tool use,
+  precise file edits, and terminal operations") rather than a general-purpose
+  instruction-follower. In practice the harness reliably handles
+  read-and-explain Prose programs (`std/ops/lint`, `std/evals/inspector`,
+  `std/ops/status`, `std/ops/diagnose`) but may run plan-only on multi-stage
+  execution programs (e.g. nested `worker-critic` × `stochastic-probe`) and
+  does not pass the SKILL.md-compliance smoke test. For production Prose
+  runs prefer `codex-sdk` or `claude-sdk`. The Cursor SDK exposes other
+  models (`gpt-5.5`, `claude-4.6-sonnet-thinking`) — try
+  `CURSOR_MODEL=claude-4.6-sonnet-thinking` if you need stricter
+  instruction-following through your Cursor billing account; this is
+  unverified.
+
+  The harness emits a one-line stderr warning on each run; suppress with
+  `PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS=1`.
 - `mock` echoes prompts for tests and local smoke checks.
 
 Select a harness with `--harness <name>` or `PROSE_HARNESS`.
@@ -96,6 +122,12 @@ For externally sandboxed CI environments, Codex harnesses also honor
 `PROSE_CODEX_SANDBOX_MODE` (`read-only`, `workspace-write`, or
 `danger-full-access`) and `PROSE_CODEX_APPROVAL_POLICY` (`never`, `on-request`,
 `on-failure`, or `untrusted`) and forward those values to Codex.
+
+The Cursor harness reads `CURSOR_API_KEY` for authentication and `CURSOR_MODEL`
+(default `composer-2`) for the local model id. Set
+`PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS=1` to silence the per-run experimental
+warning. Cursor Cloud, PR/repo automation, `Cursor.models.list()`, and
+artifact downloads are not exposed by the CLI.
 
 ## Skill Setup
 

--- a/tools/cli/package-lock.json
+++ b/tools/cli/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.90",
+        "@cursor/sdk": "^1.0.12",
         "@hono/node-server": "^1.19.14",
         "@oclif/core": "^4.10.6",
         "@openai/codex-sdk": "^0.125.0",
@@ -82,6 +83,135 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.12.tgz",
+      "integrity": "sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "sqlite3": "^5.1.7",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.12",
+        "@cursor/sdk-darwin-x64": "1.0.12",
+        "@cursor/sdk-linux-arm64": "1.0.12",
+        "@cursor/sdk-linux-x64": "1.0.12",
+        "@cursor/sdk-win32-x64": "1.0.12"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.12.tgz",
+      "integrity": "sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.12.tgz",
+      "integrity": "sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.12.tgz",
+      "integrity": "sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.12.tgz",
+      "integrity": "sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.12.tgz",
+      "integrity": "sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@cursor/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -526,6 +656,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -887,6 +1033,32 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@oclif/core": {
@@ -1402,6 +1574,31 @@
         "win32"
       ]
     },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1525,6 +1722,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1536,6 +1740,56 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ajv": {
@@ -1619,6 +1873,28 @@
         "node": ">=14"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1642,6 +1918,46 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1680,6 +1996,30 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1697,6 +2037,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1755,6 +2125,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -1799,6 +2178,30 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -1888,6 +2291,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1898,6 +2316,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1905,6 +2339,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1956,6 +2399,55 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2094,6 +2586,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2204,6 +2705,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -2279,6 +2786,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2301,6 +2833,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2362,6 +2915,65 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2373,6 +2985,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2395,6 +3014,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -2416,6 +3042,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2436,6 +3069,45 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2452,6 +3124,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2461,10 +3163,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -2508,6 +3235,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -2610,6 +3344,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2618,6 +3365,44 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2675,6 +3460,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2689,6 +3486,128 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2715,6 +3634,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2722,6 +3647,82 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -2766,6 +3767,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2773,6 +3790,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2867,6 +3894,54 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2878,6 +3953,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2919,6 +4004,35 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2936,6 +4050,33 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -2999,6 +4140,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3061,6 +4222,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3168,6 +4336,109 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3176,6 +4447,43 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/stackback": {
@@ -3201,6 +4509,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3225,6 +4542,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-literal": {
@@ -3253,6 +4579,67 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tinybench": {
@@ -3350,6 +4737,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -3390,12 +4789,44 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3405,6 +4836,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -3720,6 +5157,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -3759,6 +5206,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/zod": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.90",
+    "@cursor/sdk": "^1.0.12",
     "@hono/node-server": "^1.19.14",
     "@oclif/core": "^4.10.6",
     "@openai/codex-sdk": "^0.125.0",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openprose/prose-cli",
   "version": "0.13.1",
-  "description": "Run OpenProse commands through first-party Codex and Claude agent SDKs.",
+  "description": "Run OpenProse commands through first-party Codex and Claude agent SDKs, with experimental Cursor support.",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "oclif": {
@@ -61,6 +61,7 @@
     "ai",
     "cli",
     "codex",
+    "cursor",
     "openprose",
     "prose"
   ],

--- a/tools/cli/scripts/smoke-harness.mjs
+++ b/tools/cli/scripts/smoke-harness.mjs
@@ -8,6 +8,12 @@ import { fileURLToPath } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const cliDir = resolve(scriptDir, "..");
+// `cursor-sdk` is intentionally excluded from the smoke matrix. The smoke
+// test asserts strict instruction-following ("return only
+// PROSE_HARNESS_SMOKE_OK"), which Cursor's default composer-2 model — tuned
+// for coding tasks rather than return-token compliance — does not reliably
+// honor. Including it here would produce a permanently-red CI signal that
+// masks legitimate failures on codex-sdk / claude-sdk.
 const harnesses = ["codex-sdk", "claude-sdk"];
 const okToken = "PROSE_HARNESS_SMOKE_OK";
 const skillSentinel = "PROSE_SKILL_BOOTSTRAP_VISIBLE";
@@ -86,7 +92,9 @@ function requestedHarnesses(name) {
 }
 
 function requiredSecret(harness) {
-	return harness.startsWith("claude") ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
+	if (harness.startsWith("claude")) return "ANTHROPIC_API_KEY";
+	if (harness.startsWith("cursor")) return "CURSOR_API_KEY";
+	return "OPENAI_API_KEY";
 }
 
 function run(command, args, options) {

--- a/tools/cli/src/harnesses/cursor-sdk.ts
+++ b/tools/cli/src/harnesses/cursor-sdk.ts
@@ -38,13 +38,6 @@ export function createCursorSdkHarness(options: CursorSdkHarnessOptions = {}): H
 
 			try {
 				const agentOptions = cursorAgentOptions(runOptions);
-				const env = runOptions.env ?? {};
-				if (env.PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS !== "1") {
-					writeLine(
-						runOptions.stderr,
-						"[cursor-sdk] experimental harness — composer-2 is tuned for coding tasks, not OpenProse contract execution. Multi-stage programs may run plan-only. Set CURSOR_MODEL to a stronger instruction-follower if needed (see README).",
-					);
-				}
 				agent = await factory(agentOptions);
 				run = await agent.send(prompt);
 

--- a/tools/cli/src/harnesses/cursor-sdk.ts
+++ b/tools/cli/src/harnesses/cursor-sdk.ts
@@ -1,0 +1,163 @@
+import { writeLine } from "./streams.js";
+import type {
+	CursorSdkAgent,
+	CursorSdkAgentFactory,
+	CursorSdkAgentOptions,
+	CursorSdkMessage,
+	CursorSdkRun,
+	CursorSdkRunResult,
+	Harness,
+	HarnessRunOptions,
+	WritableStreamLike,
+} from "./types.js";
+
+const DEFAULT_CURSOR_MODEL = "composer-2";
+
+export interface CursorSdkHarnessOptions {
+	factory?: CursorSdkAgentFactory;
+}
+
+export async function createDefaultCursorSdkAgent(
+	options: CursorSdkAgentOptions,
+): Promise<CursorSdkAgent> {
+	const { Agent } = await import("@cursor/sdk");
+	return Agent.create(options);
+}
+
+export function createCursorSdkHarness(options: CursorSdkHarnessOptions = {}): Harness {
+	const factory = options.factory ?? createDefaultCursorSdkAgent;
+
+	return {
+		name: "cursor-sdk",
+		async run(prompt, runOptions) {
+			let agent: CursorSdkAgent | undefined;
+			let run: CursorSdkRun | undefined;
+			const onAbort = () => {
+				void run?.cancel();
+			};
+
+			try {
+				const agentOptions = cursorAgentOptions(runOptions);
+				agent = await factory(agentOptions);
+				run = await agent.send(prompt);
+
+				if (runOptions.signal !== undefined) {
+					runOptions.signal.addEventListener("abort", onAbort, { once: true });
+				}
+
+				let exitCode = 0;
+				try {
+					for await (const event of run.stream()) {
+						exitCode = Math.max(
+							exitCode,
+							writeCursorMessage(event, runOptions.stdout, runOptions.stderr),
+						);
+					}
+					const result = await run.wait();
+					exitCode = Math.max(exitCode, finalizeCursorResult(result, runOptions.stderr));
+				} finally {
+					if (runOptions.signal !== undefined) {
+						runOptions.signal.removeEventListener("abort", onAbort);
+					}
+				}
+
+				return runOptions.signal?.aborted ? 143 : exitCode;
+			} catch (error) {
+				if (runOptions.signal?.aborted) {
+					return 143;
+				}
+				throw error;
+			} finally {
+				try {
+					await agent?.[Symbol.asyncDispose]?.();
+				} catch {
+					// Disposal best-effort: surface only the original outcome.
+				}
+			}
+		},
+	};
+}
+
+function cursorAgentOptions(runOptions: HarnessRunOptions): CursorSdkAgentOptions {
+	const env = runOptions.env ?? {};
+	const apiKey = env.CURSOR_API_KEY ?? process.env.CURSOR_API_KEY;
+	if (!apiKey) {
+		throw new Error("CURSOR_API_KEY is required for cursor-sdk.");
+	}
+	const model = env.CURSOR_MODEL ?? process.env.CURSOR_MODEL ?? DEFAULT_CURSOR_MODEL;
+
+	return {
+		apiKey,
+		model: { id: model },
+		local: {
+			...(runOptions.cwd === undefined ? {} : { cwd: runOptions.cwd }),
+			settingSources: ["project", "user"],
+		},
+	};
+}
+
+function writeCursorMessage(
+	event: CursorSdkMessage,
+	stdout: WritableStreamLike,
+	stderr: WritableStreamLike,
+): number {
+	switch (event.type) {
+		case "assistant":
+			for (const block of event.message.content) {
+				if (block.type === "text") {
+					stdout.write(block.text);
+				}
+			}
+			return 0;
+		case "tool_call":
+			if (event.status === "error") {
+				const detail = event.result === undefined ? "" : `: ${truncate(stringify(event.result))}`;
+				writeLine(stderr, `[cursor] tool ${event.name} failed${detail}`);
+				return 1;
+			}
+			return 0;
+		case "status":
+			if (event.status === "ERROR" || event.status === "EXPIRED") {
+				const detail = event.message ? `: ${event.message}` : "";
+				writeLine(stderr, `[cursor] ${event.status}${detail}`);
+				return 1;
+			}
+			return 0;
+		default:
+			return 0;
+	}
+}
+
+function finalizeCursorResult(result: CursorSdkRunResult, stderr: WritableStreamLike): number {
+	switch (result.status) {
+		case "finished":
+			return 0;
+		case "error":
+			if (result.result) {
+				writeLine(stderr, result.result);
+			}
+			return 1;
+		case "cancelled":
+			return 0;
+		default:
+			return 0;
+	}
+}
+
+function stringify(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function truncate(text: string, max = 200): string {
+	if (text.length <= max) {
+		return text;
+	}
+	return `${text.slice(0, max)}…`;
+}

--- a/tools/cli/src/harnesses/cursor-sdk.ts
+++ b/tools/cli/src/harnesses/cursor-sdk.ts
@@ -38,6 +38,13 @@ export function createCursorSdkHarness(options: CursorSdkHarnessOptions = {}): H
 
 			try {
 				const agentOptions = cursorAgentOptions(runOptions);
+				const env = runOptions.env ?? {};
+				if (env.PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS !== "1") {
+					writeLine(
+						runOptions.stderr,
+						"[cursor-sdk] experimental harness — composer-2 is tuned for coding tasks, not OpenProse contract execution. Multi-stage programs may run plan-only. Set CURSOR_MODEL to a stronger instruction-follower if needed (see README).",
+					);
+				}
 				agent = await factory(agentOptions);
 				run = await agent.send(prompt);
 

--- a/tools/cli/src/harnesses/index.ts
+++ b/tools/cli/src/harnesses/index.ts
@@ -1,5 +1,6 @@
 import { createClaudeSdkHarness, type ClaudeSdkHarnessOptions } from "./claude-sdk.js";
 import { createCodexSdkHarness, type CodexSdkHarnessOptions } from "./codex-sdk.js";
+import { createCursorSdkHarness, type CursorSdkHarnessOptions } from "./cursor-sdk.js";
 import { createMockHarness, type MockHarnessOptions } from "./mock.js";
 import type { Harness, HarnessName } from "./types.js";
 
@@ -10,6 +11,13 @@ export type {
 	CodexThread,
 	CodexThreadEvent,
 	CodexThreadOptions,
+	CursorSdkAgent,
+	CursorSdkAgentFactory,
+	CursorSdkAgentOptions,
+	CursorSdkMessage,
+	CursorSdkRun,
+	CursorSdkRunResult,
+	CursorSdkUserMessage,
 	Harness,
 	HarnessName,
 	HarnessRunOptions,
@@ -20,15 +28,17 @@ export type {
 } from "./types.js";
 export { createClaudeSdkHarness, defaultClaudeSdkQuery } from "./claude-sdk.js";
 export { createCodexSdkHarness, createDefaultCodexSdkClient } from "./codex-sdk.js";
+export { createCursorSdkHarness, createDefaultCursorSdkAgent } from "./cursor-sdk.js";
 export { createMockHarness } from "./mock.js";
 
 export interface HarnessSelectionOptions {
 	claudeSdk?: ClaudeSdkHarnessOptions;
 	codexSdk?: CodexSdkHarnessOptions;
+	cursorSdk?: CursorSdkHarnessOptions;
 	mock?: MockHarnessOptions;
 }
 
-export const HARNESS_NAMES: readonly HarnessName[] = ["codex-sdk", "claude-sdk", "mock"];
+export const HARNESS_NAMES: readonly HarnessName[] = ["codex-sdk", "claude-sdk", "cursor-sdk", "mock"];
 
 export function isHarnessName(value: string): value is HarnessName {
 	return HARNESS_NAMES.includes(value as HarnessName);
@@ -50,6 +60,8 @@ export function createHarness(name: string, options: HarnessSelectionOptions = {
 			return createClaudeSdkHarness(options.claudeSdk);
 		case "codex-sdk":
 			return createCodexSdkHarness(options.codexSdk);
+		case "cursor-sdk":
+			return createCursorSdkHarness(options.cursorSdk);
 		case "mock":
 			return createMockHarness(options.mock);
 		default:

--- a/tools/cli/src/harnesses/types.ts
+++ b/tools/cli/src/harnesses/types.ts
@@ -7,8 +7,16 @@ import type {
 	ThreadOptions,
 	TurnOptions,
 } from "@openai/codex-sdk";
+import type {
+	AgentOptions as CursorAgentOptions,
+	Run as CursorRun,
+	RunResult as CursorRunResult,
+	SDKAgent as CursorSDKAgent,
+	SDKMessage as CursorSDKMessage,
+	SDKUserMessage as CursorSDKUserMessage,
+} from "@cursor/sdk";
 
-export type HarnessName = "claude-sdk" | "codex-sdk" | "mock";
+export type HarnessName = "claude-sdk" | "codex-sdk" | "cursor-sdk" | "mock";
 
 export interface WritableStreamLike {
 	write(chunk: string): unknown;
@@ -60,3 +68,11 @@ export interface CodexClient {
 export type CodexSdkFactory = (options?: CodexSdkClientOptions) => CodexClient | Promise<CodexClient>;
 export type CodexThreadEvent = ThreadEvent;
 export type CodexThreadItem = ThreadItem;
+
+export type CursorSdkAgentOptions = CursorAgentOptions;
+export type CursorSdkAgent = CursorSDKAgent;
+export type CursorSdkRun = CursorRun;
+export type CursorSdkRunResult = CursorRunResult;
+export type CursorSdkMessage = CursorSDKMessage;
+export type CursorSdkUserMessage = CursorSDKUserMessage;
+export type CursorSdkAgentFactory = (options: CursorSdkAgentOptions) => Promise<CursorSdkAgent>;

--- a/tools/cli/src/skills/open-prose.ts
+++ b/tools/cli/src/skills/open-prose.ts
@@ -76,6 +76,8 @@ export function skillAgentsForHarness(harness: string): SkillAgent[] {
 			return ["codex"];
 		case "claude-sdk":
 			return ["claude-code"];
+		case "cursor-sdk":
+			return [];
 		case "mock":
 		default:
 			return [];

--- a/tools/cli/src/skills/open-prose.ts
+++ b/tools/cli/src/skills/open-prose.ts
@@ -9,7 +9,7 @@ export const OPEN_PROSE_SKILL_NAME = "open-prose";
 export const OPEN_PROSE_SKILL_SOURCE = "openprose/prose";
 export const SKILLS_CLI_PACKAGE = "skills@1.5.3";
 
-export type SkillAgent = "codex" | "claude-code";
+export type SkillAgent = "codex" | "claude-code" | "cursor";
 export type SkillScope = "project" | "user" | "provider-user";
 
 export interface SkillLocation {
@@ -77,7 +77,7 @@ export function skillAgentsForHarness(harness: string): SkillAgent[] {
 		case "claude-sdk":
 			return ["claude-code"];
 		case "cursor-sdk":
-			return [];
+			return ["cursor"];
 		case "mock":
 		default:
 			return [];
@@ -282,39 +282,52 @@ export function formatSkillStatus(status: SkillStatus, home = homedir()): string
 }
 
 function candidateSkillLocations(agent: SkillAgent, cwd: string, home: string): Array<Omit<SkillLocation, "exists" | "valid">> {
-	const ancestorLocations = projectAncestors(cwd).map((directory) => ({
-		agent,
-		scope: "project" as const,
-		path: join(directory, projectSkillDirectory(agent), OPEN_PROSE_SKILL_NAME, "SKILL.md"),
-	}));
+	const projectDirs = projectSkillDirectories(agent);
+	const ancestorLocations = projectAncestors(cwd).flatMap((directory) =>
+		projectDirs.map((projectDir) => ({
+			agent,
+			scope: "project" as const,
+			path: join(directory, projectDir, OPEN_PROSE_SKILL_NAME, "SKILL.md"),
+		})),
+	);
 
-	const userLocations =
-		agent === "codex"
-			? [
-					{
-						agent,
-						scope: "user" as const,
-						path: join(home, ".agents", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md"),
-					},
-					{
-						agent,
-						scope: "provider-user" as const,
-						path: join(home, ".codex", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md"),
-					},
-				]
-			: [
-					{
-						agent,
-						scope: "user" as const,
-						path: join(home, ".claude", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md"),
-					},
-				];
+	const userLocations = userSkillLocations(agent, home);
 
 	return uniqueByPath([...ancestorLocations, ...userLocations]);
 }
 
-function projectSkillDirectory(agent: SkillAgent): string {
-	return agent === "codex" ? join(".agents", "skills") : join(".claude", "skills");
+function projectSkillDirectories(agent: SkillAgent): string[] {
+	switch (agent) {
+		case "codex":
+			return [join(".agents", "skills")];
+		case "claude-code":
+			return [join(".claude", "skills")];
+		case "cursor":
+			// Cursor-native first per forum reliability report; .agents/ second for cross-client interop.
+			return [join(".cursor", "skills"), join(".agents", "skills")];
+	}
+}
+
+function userSkillLocations(agent: SkillAgent, home: string): Array<Omit<SkillLocation, "exists" | "valid">> {
+	switch (agent) {
+		case "codex":
+			return [
+				{ agent, scope: "user", path: join(home, ".agents", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+				{ agent, scope: "provider-user", path: join(home, ".codex", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+			];
+		case "claude-code":
+			return [
+				{ agent, scope: "user", path: join(home, ".claude", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+			];
+		case "cursor":
+			// Cursor-native first; ~/.agents/ for cross-client interop; other providers as fallback per Cursor docs.
+			return [
+				{ agent, scope: "user", path: join(home, ".cursor", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+				{ agent, scope: "provider-user", path: join(home, ".agents", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+				{ agent, scope: "provider-user", path: join(home, ".claude", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+				{ agent, scope: "provider-user", path: join(home, ".codex", "skills", OPEN_PROSE_SKILL_NAME, "SKILL.md") },
+			];
+	}
 }
 
 async function inspectSkill(path: string): Promise<Pick<SkillLocation, "exists" | "valid" | "error">> {

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -502,7 +502,7 @@ describe("cursor-sdk harness", () => {
 
 		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
 			...io.options,
-			env: { CURSOR_API_KEY: "key-1", PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS: "1" },
+			env: { CURSOR_API_KEY: "key-1" },
 		});
 
 		expect(exitCode).toBe(1);
@@ -528,7 +528,7 @@ describe("cursor-sdk harness", () => {
 
 		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
 			...io.options,
-			env: { CURSOR_API_KEY: "key-1", PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS: "1" },
+			env: { CURSOR_API_KEY: "key-1" },
 		});
 
 		expect(exitCode).toBe(1);
@@ -548,7 +548,7 @@ describe("cursor-sdk harness", () => {
 
 		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
 			...io.options,
-			env: { CURSOR_API_KEY: "key-1", PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS: "1" },
+			env: { CURSOR_API_KEY: "key-1" },
 		});
 
 		expect(exitCode).toBe(1);

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -3,10 +3,18 @@ import { describe, expect, test } from "vitest";
 import {
 	createClaudeSdkHarness,
 	createCodexSdkHarness,
+	createCursorSdkHarness,
 	createHarness,
 	resolveHarnessName,
 	type CodexThreadEvent,
 	type CodexSdkFactory,
+	type CursorSdkAgent,
+	type CursorSdkAgentFactory,
+	type CursorSdkAgentOptions,
+	type CursorSdkMessage,
+	type CursorSdkRun,
+	type CursorSdkRunResult,
+	type CursorSdkUserMessage,
 } from "../../src/harnesses/index.js";
 
 function memoryStreams() {
@@ -38,13 +46,13 @@ describe("harness selection", () => {
 		expect(resolveHarnessName("codex-sdk")).toBe("codex-sdk");
 		expect(resolveHarnessName("claude-sdk")).toBe("claude-sdk");
 		expect(() => resolveHarnessName("missing")).toThrow(
-			"Unsupported harness: missing. Expected one of: codex-sdk, claude-sdk, mock",
+			"Unsupported harness: missing. Expected one of: codex-sdk, claude-sdk, cursor-sdk, mock",
 		);
 		expect(() => resolveHarnessName("claude")).toThrow(
-			"Unsupported harness: claude. Expected one of: codex-sdk, claude-sdk, mock",
+			"Unsupported harness: claude. Expected one of: codex-sdk, claude-sdk, cursor-sdk, mock",
 		);
 		expect(() => resolveHarnessName("codex")).toThrow(
-			"Unsupported harness: codex. Expected one of: codex-sdk, claude-sdk, mock",
+			"Unsupported harness: codex. Expected one of: codex-sdk, claude-sdk, cursor-sdk, mock",
 		);
 	});
 
@@ -333,5 +341,346 @@ describe("claude-sdk harness", () => {
 
 		await expect(harness.run("prose status", { ...io.options })).resolves.toBe(0);
 		expect(io.stderr).toBe("Authenticated as user@example.com\n");
+	});
+});
+
+async function* cursorMessages(items: CursorSdkMessage[]): AsyncGenerator<CursorSdkMessage> {
+	for (const item of items) {
+		yield item;
+	}
+}
+
+interface FakeCursorAgentSpec {
+	stream: CursorSdkMessage[];
+	waitResult: CursorSdkRunResult;
+	onCancel?: () => void;
+	dispose?: () => void;
+}
+
+function fakeCursorFactory(
+	spec: FakeCursorAgentSpec,
+	capture: {
+		options?: CursorSdkAgentOptions;
+		prompts: string[];
+		cancels: number;
+		disposed: boolean;
+	},
+): CursorSdkAgentFactory {
+	return async (options) => {
+		capture.options = options;
+		const agent: CursorSdkAgent = {
+			agentId: "agent-fake",
+			model: options.model,
+			async send(prompt: string | CursorSdkUserMessage) {
+				capture.prompts.push(typeof prompt === "string" ? prompt : (prompt as CursorSdkUserMessage & { text: string }).text);
+				const run: CursorSdkRun = {
+					id: "run-fake",
+					stream: () => cursorMessages(spec.stream),
+					async wait() {
+						return spec.waitResult;
+					},
+					async cancel() {
+						capture.cancels += 1;
+						spec.onCancel?.();
+					},
+				} as unknown as CursorSdkRun;
+				return run;
+			},
+			close() {},
+			async reload() {},
+			[Symbol.asyncDispose]: async () => {
+				capture.disposed = true;
+				spec.dispose?.();
+			},
+			async listArtifacts() {
+				return [];
+			},
+			async downloadArtifact() {
+				return Buffer.alloc(0);
+			},
+		} as unknown as CursorSdkAgent;
+		return agent;
+	};
+}
+
+describe("cursor-sdk harness", () => {
+	test("creates a local agent with apiKey, model, and settingSources, then streams assistant text", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory = fakeCursorFactory(
+			{
+				stream: [
+					{
+						type: "assistant",
+						message: { content: [{ type: "text", text: "hello" }] },
+					} as unknown as CursorSdkMessage,
+				],
+				waitResult: { id: "run-fake", status: "finished" } as CursorSdkRunResult,
+			},
+			capture,
+		);
+
+		const exitCode = await createCursorSdkHarness({ factory }).run("prose run inspector.prose.md", {
+			...io.options,
+			cwd: "/repo",
+			env: { CURSOR_API_KEY: "key-1" },
+		});
+
+		expect(exitCode).toBe(0);
+		expect(io.stdout).toBe("hello");
+		expect(capture.options).toEqual({
+			apiKey: "key-1",
+			model: { id: "composer-2" },
+			local: { cwd: "/repo", settingSources: ["project", "user"] },
+		});
+		expect(capture.prompts).toEqual(["prose run inspector.prose.md"]);
+		expect(capture.disposed).toBe(true);
+	});
+
+	test("CURSOR_MODEL env override propagates to model.id", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory = fakeCursorFactory(
+			{
+				stream: [],
+				waitResult: { id: "run-fake", status: "finished" } as CursorSdkRunResult,
+			},
+			capture,
+		);
+
+		await createCursorSdkHarness({ factory }).run("prose status", {
+			...io.options,
+			env: { CURSOR_API_KEY: "key-1", CURSOR_MODEL: "composer-9" },
+		});
+
+		expect(capture.options?.model).toEqual({ id: "composer-9" });
+	});
+
+	test("missing CURSOR_API_KEY throws before invoking the factory", async () => {
+		const io = memoryStreams();
+		let factoryInvoked = false;
+		const factory: CursorSdkAgentFactory = async () => {
+			factoryInvoked = true;
+			throw new Error("should not run");
+		};
+		// Clear ambient env so process.env.CURSOR_API_KEY does not leak in.
+		const originalKey = process.env.CURSOR_API_KEY;
+		delete process.env.CURSOR_API_KEY;
+
+		try {
+			await expect(
+				createCursorSdkHarness({ factory }).run("prose status", {
+					...io.options,
+					env: {},
+				}),
+			).rejects.toThrow("CURSOR_API_KEY is required for cursor-sdk.");
+			expect(factoryInvoked).toBe(false);
+		} finally {
+			if (originalKey !== undefined) {
+				process.env.CURSOR_API_KEY = originalKey;
+			}
+		}
+	});
+
+	test("failed tool_call event routes to stderr and bumps exit code", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory = fakeCursorFactory(
+			{
+				stream: [
+					{
+						type: "tool_call",
+						name: "grep",
+						status: "error",
+						result: "no match",
+					} as unknown as CursorSdkMessage,
+				],
+				waitResult: { id: "run-fake", status: "finished" } as CursorSdkRunResult,
+			},
+			capture,
+		);
+
+		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
+			...io.options,
+			env: { CURSOR_API_KEY: "key-1" },
+		});
+
+		expect(exitCode).toBe(1);
+		expect(io.stderr).toBe("[cursor] tool grep failed: no match\n");
+	});
+
+	test("status ERROR event routes to stderr with provider message", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory = fakeCursorFactory(
+			{
+				stream: [
+					{
+						type: "status",
+						status: "ERROR",
+						message: "rate limit",
+					} as unknown as CursorSdkMessage,
+				],
+				waitResult: { id: "run-fake", status: "finished" } as CursorSdkRunResult,
+			},
+			capture,
+		);
+
+		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
+			...io.options,
+			env: { CURSOR_API_KEY: "key-1" },
+		});
+
+		expect(exitCode).toBe(1);
+		expect(io.stderr).toBe("[cursor] ERROR: rate limit\n");
+	});
+
+	test("run.wait() error result writes message to stderr and returns 1", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory = fakeCursorFactory(
+			{
+				stream: [],
+				waitResult: { id: "run-fake", status: "error", result: "auth failed" } as CursorSdkRunResult,
+			},
+			capture,
+		);
+
+		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
+			...io.options,
+			env: { CURSOR_API_KEY: "key-1" },
+		});
+
+		expect(exitCode).toBe(1);
+		expect(io.stderr).toBe("auth failed\n");
+	});
+
+	test("signal.abort() mid-stream calls run.cancel() once and returns 143", async () => {
+		const io = memoryStreams();
+		const controller = new AbortController();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+
+		// Build a stream generator that pauses after the first event so we can abort mid-flight.
+		async function* abortableStream(): AsyncGenerator<CursorSdkMessage> {
+			yield {
+				type: "assistant",
+				message: { content: [{ type: "text", text: "partial" }] },
+			} as unknown as CursorSdkMessage;
+			controller.abort();
+			// After cancel(), wait() resolves cancelled and the loop exits naturally.
+		}
+
+		const factory: CursorSdkAgentFactory = async (options) => {
+			capture.options = options;
+			return {
+				agentId: "agent-fake",
+				model: options.model,
+				async send(prompt: string | CursorSdkUserMessage) {
+					capture.prompts.push(typeof prompt === "string" ? prompt : (prompt as CursorSdkUserMessage & { text: string }).text);
+					return {
+						id: "run-fake",
+						stream: () => abortableStream(),
+						async wait() {
+							return { id: "run-fake", status: "cancelled" } as CursorSdkRunResult;
+						},
+						async cancel() {
+							capture.cancels += 1;
+						},
+					} as unknown as CursorSdkRun;
+				},
+				close() {},
+				async reload() {},
+				[Symbol.asyncDispose]: async () => {
+					capture.disposed = true;
+				},
+				async listArtifacts() {
+					return [];
+				},
+				async downloadArtifact() {
+					return Buffer.alloc(0);
+				},
+			} as unknown as CursorSdkAgent;
+		};
+
+		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
+			...io.options,
+			env: { CURSOR_API_KEY: "key-1" },
+			signal: controller.signal,
+		});
+
+		expect(exitCode).toBe(143);
+		expect(capture.cancels).toBe(1);
+		expect(capture.disposed).toBe(true);
+	});
+
+	test("agent[Symbol.asyncDispose] runs even when the stream throws", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory: CursorSdkAgentFactory = async (options) => {
+			capture.options = options;
+			return {
+				agentId: "agent-fake",
+				model: options.model,
+				async send(prompt: string | CursorSdkUserMessage) {
+					capture.prompts.push(typeof prompt === "string" ? prompt : (prompt as CursorSdkUserMessage & { text: string }).text);
+					return {
+						id: "run-fake",
+						async *stream(): AsyncGenerator<CursorSdkMessage> {
+							throw new Error("stream blew up");
+						},
+						async wait() {
+							return { id: "run-fake", status: "error" } as CursorSdkRunResult;
+						},
+						async cancel() {},
+					} as unknown as CursorSdkRun;
+				},
+				close() {},
+				async reload() {},
+				[Symbol.asyncDispose]: async () => {
+					capture.disposed = true;
+				},
+				async listArtifacts() {
+					return [];
+				},
+				async downloadArtifact() {
+					return Buffer.alloc(0);
+				},
+			} as unknown as CursorSdkAgent;
+		};
+
+		await expect(
+			createCursorSdkHarness({ factory }).run("prose status", {
+				...io.options,
+				env: { CURSOR_API_KEY: "key-1" },
+			}),
+		).rejects.toThrow("stream blew up");
+		expect(capture.disposed).toBe(true);
+	});
+
+	test("createHarness('cursor-sdk') returns a cursor-sdk harness wired to the factory", async () => {
+		const io = memoryStreams();
+		const capture: { options?: CursorSdkAgentOptions; prompts: string[]; cancels: number; disposed: boolean } = { prompts: [], cancels: 0, disposed: false };
+		const factory = fakeCursorFactory(
+			{
+				stream: [
+					{
+						type: "assistant",
+						message: { content: [{ type: "text", text: "ok" }] },
+					} as unknown as CursorSdkMessage,
+				],
+				waitResult: { id: "run-fake", status: "finished" } as CursorSdkRunResult,
+			},
+			capture,
+		);
+
+		const harness = createHarness("cursor-sdk", { cursorSdk: { factory } });
+		expect(harness.name).toBe("cursor-sdk");
+
+		const exitCode = await harness.run("prose status", {
+			...io.options,
+			env: { CURSOR_API_KEY: "key-1" },
+		});
+		expect(exitCode).toBe(0);
+		expect(io.stdout).toBe("ok");
 	});
 });

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -502,7 +502,7 @@ describe("cursor-sdk harness", () => {
 
 		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
 			...io.options,
-			env: { CURSOR_API_KEY: "key-1" },
+			env: { CURSOR_API_KEY: "key-1", PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS: "1" },
 		});
 
 		expect(exitCode).toBe(1);
@@ -528,7 +528,7 @@ describe("cursor-sdk harness", () => {
 
 		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
 			...io.options,
-			env: { CURSOR_API_KEY: "key-1" },
+			env: { CURSOR_API_KEY: "key-1", PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS: "1" },
 		});
 
 		expect(exitCode).toBe(1);
@@ -548,7 +548,7 @@ describe("cursor-sdk harness", () => {
 
 		const exitCode = await createCursorSdkHarness({ factory }).run("prose status", {
 			...io.options,
-			env: { CURSOR_API_KEY: "key-1" },
+			env: { CURSOR_API_KEY: "key-1", PROSE_SUPPRESS_EXPERIMENTAL_WARNINGS: "1" },
 		});
 
 		expect(exitCode).toBe(1);

--- a/tools/cli/tests/skills/open-prose.test.ts
+++ b/tools/cli/tests/skills/open-prose.test.ts
@@ -11,6 +11,7 @@ import {
 	installOpenProseSkill,
 	loadOpenProseSkillBootstrap,
 	resolveOpenProseSkill,
+	skillAgentsForHarness,
 } from "../../src/skills/open-prose.js";
 
 function tempDir(): string {
@@ -234,5 +235,139 @@ describe("OpenProse skill checks", () => {
 			rmSync(home, { recursive: true, force: true });
 			rmSync(cwd, { recursive: true, force: true });
 		}
+	});
+
+	it("maps cursor-sdk to the cursor skill agent", () => {
+		expect(skillAgentsForHarness("cursor-sdk")).toEqual(["cursor"]);
+	});
+
+	it("discovers cursor skills under .cursor/skills first, then .agents/skills", async () => {
+		const home = tempDir();
+		const repo = tempDir();
+		const cwd = repo;
+
+		try {
+			mkdirSync(join(repo, ".git"), { recursive: true });
+			writeSkill(join(repo, ".cursor", "skills", "open-prose"));
+
+			const [status] = await checkOpenProseSkill({
+				agents: ["cursor"],
+				cwd,
+				env: { HOME: home },
+			});
+
+			expect(status?.installed).toBe(true);
+			const projectPaths = status?.locations
+				.filter((location) => location.scope === "project")
+				.map((location) => location.path);
+			expect(projectPaths).toContain(join(repo, ".cursor", "skills", "open-prose", "SKILL.md"));
+			expect(projectPaths).toContain(join(repo, ".agents", "skills", "open-prose", "SKILL.md"));
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("includes ~/.cursor, ~/.agents, ~/.claude, and ~/.codex as cursor user-scope candidates", async () => {
+		const home = tempDir();
+		const cwd = tempDir();
+
+		try {
+			const [status] = await checkOpenProseSkill({
+				agents: ["cursor"],
+				cwd,
+				env: { HOME: home },
+			});
+
+			const userPaths = status?.locations
+				.filter((location) => location.scope === "user" || location.scope === "provider-user")
+				.map((location) => location.path);
+			expect(userPaths).toEqual(
+				expect.arrayContaining([
+					join(home, ".cursor", "skills", "open-prose", "SKILL.md"),
+					join(home, ".agents", "skills", "open-prose", "SKILL.md"),
+					join(home, ".claude", "skills", "open-prose", "SKILL.md"),
+					join(home, ".codex", "skills", "open-prose", "SKILL.md"),
+				]),
+			);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("walks ancestors and emits both project subdirs at each ancestor for cursor", async () => {
+		const home = tempDir();
+		const repo = tempDir();
+		const cwd = join(repo, "packages", "app");
+
+		try {
+			mkdirSync(join(repo, ".git"), { recursive: true });
+			mkdirSync(cwd, { recursive: true });
+			writeSkill(join(repo, ".agents", "skills", "open-prose"));
+
+			const [status] = await checkOpenProseSkill({ agents: ["cursor"], cwd, env: { HOME: home } });
+
+			expect(status?.installed).toBe(true);
+			const projectPaths = status?.locations
+				.filter((location) => location.scope === "project")
+				.map((location) => location.path);
+			// Cursor walks both .cursor/skills and .agents/skills at each ancestor.
+			expect(projectPaths).toEqual(
+				expect.arrayContaining([
+					join(repo, ".cursor", "skills", "open-prose", "SKILL.md"),
+					join(repo, ".agents", "skills", "open-prose", "SKILL.md"),
+					join(cwd, ".cursor", "skills", "open-prose", "SKILL.md"),
+					join(cwd, ".agents", "skills", "open-prose", "SKILL.md"),
+				]),
+			);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("treats ~/.codex/skills/... as a compat candidate for cursor but NOT for claude-code", async () => {
+		const home = tempDir();
+		const cwd = tempDir();
+
+		try {
+			writeSkill(join(home, ".codex", "skills", "open-prose"));
+
+			const [cursorStatus] = await checkOpenProseSkill({
+				agents: ["cursor"],
+				cwd,
+				env: { HOME: home },
+			});
+			expect(cursorStatus?.installed).toBe(true);
+
+			const [claudeStatus] = await checkOpenProseSkill({
+				agents: ["claude-code"],
+				cwd,
+				env: { HOME: home },
+			});
+			expect(claudeStatus?.installed).toBe(false);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("builds the install command with --agent cursor", () => {
+		const command = buildOpenProseSkillInstallCommand(["cursor"]);
+		expect(command.args).toEqual([
+			"--yes",
+			"skills@1.5.3",
+			"add",
+			"openprose/prose",
+			"--skill",
+			"open-prose",
+			"--global",
+			"--yes",
+			"--copy",
+			"--full-depth",
+			"--agent",
+			"cursor",
+		]);
 	});
 });


### PR DESCRIPTION
Adds `cursor-sdk` as a third first-party SDK harness in `tools/cli`, wrapping
`@cursor/sdk` in **local** mode behind the existing `Harness` contract. The
harness ships explicitly as **experimental**: the default `composer-2` model
is tuned for code edits and tool use rather than general instruction-following,
so multi-stage Prose programs may run plan-only. Production runs should still
prefer `codex-sdk` or `claude-sdk`.

The change layers cleanly on the existing harness shape — no edits to
`canonicalPrompt()`, `runForwardedProseCommand()`, or the two existing SDK
harnesses — and stays within the bounds of the public `Harness` interface.

### What ships

- **New harness** `tools/cli/src/harnesses/cursor-sdk.ts`:
  - Dynamic `await import("@cursor/sdk")` with an injectable factory (mirrors
    the Codex pattern; tests never touch the real SDK).
  - `CURSOR_API_KEY` for auth; `CURSOR_MODEL` selects the local model
    (default `composer-2`).
  - Local agent created with `local: { cwd, settingSources: ["project", "user"] }`
    so Cursor auto-loads the OpenProse skill.
  - Streams assistant text to stdout; routes tool/status errors to stderr.
  - Exit codes (`0` / `1` / `143`) and SIGINT/SIGTERM semantics match
    `codex-sdk` and `claude-sdk` — abort cancels the active run and disposes
    the agent in `finally`.

- **Registry / typing** (`tools/cli/src/harnesses/{types,index}.ts`):
  - `"cursor-sdk"` added to `HarnessName` and `HARNESS_NAMES`.
  - Cursor SDK types re-exported through `types.ts` so `cursor-sdk.ts` is the
    only file importing from `@cursor/sdk`.
  - `createHarness("cursor-sdk")` and `HarnessSelectionOptions.cursorSdk`
    wired through the factory.

- **Skill discovery** (`tools/cli/src/skills/open-prose.ts`):
  - New `"cursor"` `SkillAgent` value.
  - `projectSkillDirectory` refactored into `projectSkillDirectories` so an
    agent can advertise multiple project skill roots; Cursor checks
    `.cursor/skills/` first and `.agents/skills/` second for cross-client
    interop.
  - User-scope discovery checks `~/.cursor/skills/`, `~/.agents/skills/`,
    `~/.claude/skills/`, and `~/.codex/skills/` per Cursor's documented
    fallback chain.
  - `skillAgentsForHarness("cursor-sdk") → ["cursor"]`; auto-installer runs
    with `--agent cursor` via the existing `skills@1.5.3` flow.

- **Docs and metadata**:
  - `tools/cli/README.md` adds the provider table row, an example invocation,
    a single Harness Details paragraph with a tight Known-limits note, and
    `CURSOR_API_KEY` / `CURSOR_MODEL` references.
  - `tools/cli/POST_RELEASE_PLAYTEST.md` adds Cursor playtest scenarios
    (read-and-explain Prose programs, missing-key path).
  - `tools/cli/package.json` pins `@cursor/sdk: ^1.0.12`, refreshes the
    description, and adds the `cursor` keyword.

- **Tests** (`tools/cli/tests/{harnesses/harnesses,skills/open-prose}.test.ts`):
  - Registry: `HARNESS_NAMES`, `resolveHarnessName`, and `createHarness`
    coverage for `cursor-sdk`.
  - Harness: agent-options shape (`apiKey`, `model.id`, `local.cwd`,
    `settingSources`), `CURSOR_MODEL` override, missing-key throws before the
    factory runs, assistant-text → stdout, tool-call/status error → stderr,
    `run.wait()` error mapping, abort mid-stream returns `143`, dispose on
    stream throw.
  - Skill discovery: `skillAgentsForHarness` mapping, `.cursor/skills` first
    discovery, four user-scope candidates, ancestor walk across both project
    subdirs, install command targets `--agent cursor`.