### PR TITLE
[codex] Tighten compile validation and serve trigger acknowledgements

### DIFF
--- a/.github/scripts/openprose-smoke/run.ts
+++ b/.github/scripts/openprose-smoke/run.ts
@@ -13,6 +13,7 @@ type SmokeCase = {
   tier: SmokeTier;
   command: SmokeCommand;
   source: string;
+  workspaceSources?: string[];
   inputs?: Record<string, string>;
   expectedOutputs?: string[];
   timeoutSeconds?: number;
@@ -458,10 +459,12 @@ async function loadManifest(manifestPath: string): Promise<SmokeManifest> {
 
 async function assertSourceFilesExist(cases: SmokeCase[], manifestDir: string): Promise<void> {
   for (const smokeCase of cases) {
-    const sourcePath = path.join(manifestDir, smokeCase.source);
-    const sourceStat = await statIfExists(sourcePath);
-    if (!sourceStat?.isFile()) {
-      throw new Error(`Smoke case ${smokeCase.id} source does not exist: ${smokeCase.source}`);
+    for (const source of workspaceSourcesForCase(smokeCase)) {
+      const sourcePath = path.join(manifestDir, source);
+      const sourceStat = await statIfExists(sourcePath);
+      if (!sourceStat?.isFile()) {
+        throw new Error(`Smoke case ${smokeCase.id} source does not exist: ${source}`);
+      }
     }
   }
 }
@@ -491,6 +494,15 @@ function validateCase(entry: any, index: number): SmokeCase {
   if (entry.expectedOutputs !== undefined && !isStringArray(entry.expectedOutputs)) {
     throw new Error(`Smoke case ${entry.id} expectedOutputs must be a string array`);
   }
+  if (entry.workspaceSources !== undefined && !isStringArray(entry.workspaceSources)) {
+    throw new Error(`Smoke case ${entry.id} workspaceSources must be a string array`);
+  }
+  const workspaceSources = unique([entry.source, ...(entry.workspaceSources ?? [])]);
+  for (const source of workspaceSources) {
+    if (!source.endsWith(".prose.md") || path.basename(source) !== source) {
+      throw new Error(`Smoke case ${entry.id} workspaceSources entries must be .prose.md filenames`);
+    }
+  }
   if (entry.timeoutSeconds !== undefined && !isPositiveInteger(entry.timeoutSeconds)) {
     throw new Error(`Smoke case ${entry.id} timeoutSeconds must be a positive integer`);
   }
@@ -503,6 +515,7 @@ function validateCase(entry: any, index: number): SmokeCase {
     tier: entry.tier,
     command: entry.command,
     source: entry.source,
+    workspaceSources,
     inputs: entry.inputs,
     expectedOutputs: entry.expectedOutputs ?? [],
     timeoutSeconds: entry.timeoutSeconds,
@@ -559,7 +572,7 @@ async function runCase(
   await resetDirectory(caseResultsDir);
   assertSafeDirectoryTarget(workspace, `workspace for ${smokeCase.id}`);
   await resetDirectory(workspace);
-  await setupWorkspace(workspace, manifestDir);
+  await setupWorkspace(workspace, manifestDir, smokeCase);
   await copyFixtureArtifacts(manifestDir, path.join(caseResultsDir, "fixture"));
 
   const prompt = buildPrompt(smokeCase);
@@ -628,13 +641,13 @@ async function runCase(
   return result;
 }
 
-async function setupWorkspace(workspace: string, manifestDir: string): Promise<void> {
+async function setupWorkspace(workspace: string, manifestDir: string, smokeCase: SmokeCase): Promise<void> {
   await fs.mkdir(workspace, { recursive: true });
   const skillSource = path.join(REPO_ROOT, "skills", "open-prose");
   const skillTarget = path.join(workspace, ".claude", "skills", "open-prose");
   await fs.mkdir(path.dirname(skillTarget), { recursive: true });
   await fs.cp(skillSource, skillTarget, { recursive: true, force: true });
-  await copyFixtureMarkdownFiles(manifestDir, workspace);
+  await copyWorkspaceMarkdownFiles(manifestDir, workspace, workspaceSourcesForCase(smokeCase));
 }
 
 async function copyFixtureArtifacts(manifestDir: string, artifactDir: string): Promise<void> {
@@ -653,9 +666,28 @@ async function copyFixtureMarkdownFiles(sourceDir: string, targetDir: string): P
   }
 }
 
+async function copyWorkspaceMarkdownFiles(sourceDir: string, targetDir: string, sources: string[]): Promise<void> {
+  await fs.mkdir(targetDir, { recursive: true });
+  for (const source of sources) {
+    await fs.copyFile(path.join(sourceDir, source), path.join(targetDir, source));
+  }
+}
+
+function workspaceSourcesForCase(smokeCase: SmokeCase): string[] {
+  return smokeCase.workspaceSources ?? [smokeCase.source];
+}
+
 function buildPrompt(smokeCase: SmokeCase): string {
   const command = `prose ${smokeCase.command} ${smokeCase.source}`;
   const inputs = Object.entries(smokeCase.inputs ?? {});
+  const commandGuidance =
+    smokeCase.command === "test"
+      ? [
+          "For prose test: bind fixtures from the test file, resolve and execute the frontmatter subject as the program under test, evaluate ### Expects and ### Expects Not against bindings, and write ---test PASS or ---test FAIL to vm.log.md.",
+          "Write a compact forme.manifest.json before execution; for a test it must name the subject, fixtures, expected outputs, and assertions.",
+          "A test fixture is self-contained; do not prompt for inputs and do not inspect unrelated programs after resolving the subject.",
+        ]
+      : [];
   const inputBlock =
     inputs.length > 0
       ? inputs.map(([name, value]) => `- ${name}: ${value}`).join("\n")
@@ -679,12 +711,15 @@ function buildPrompt(smokeCase: SmokeCase): string {
     inputBlock,
     "Do not ask the user for input.",
     "Bind caller inputs if the source requires them.",
+    ...commandGuidance,
     "Use the default filesystem state backend unless the source explicitly requests another backend.",
     "Satisfy the open-prose Run State Gate before reporting success.",
+    "The run must create runs/<run-id>/root.prose.md, runs/<run-id>/forme.manifest.json, and runs/<run-id>/vm.log.md.",
     "The smoke runner checks real files, not stdout. Before replying, ensure each declared output is published as a non-empty binding file:",
     artifactBlock,
     "If a binding is missing, create it under the correct service binding directory before reporting success.",
     "Keep all reads and writes inside this workspace.",
+    "As soon as the required run artifacts, log markers, and declared bindings exist, stop and print the summary without further refinement.",
     `Print a concise result summary with the run id and declared output names: ${outputs}.`,
   ].join("\n");
 }

--- a/skills/open-prose/compiler/index.prose.md
+++ b/skills/open-prose/compiler/index.prose.md
@@ -46,6 +46,8 @@ to keep each lowering step on a narrow context budget.
   when the source graph makes the relationship clear.
 - Do not invent connector routes, queue names, provider payloads, secrets, or
   provider subscription setup.
+- Stay inside `source_root`; do not inspect sibling examples, parent
+  repositories, or unrelated source trees.
 - Prefer warnings over silent assumptions when timing, fulfillment, or Forme
   wiring is ambiguous.
 - Write `manifest.next.json` only after validation accepts the manifest.
@@ -59,6 +61,8 @@ agent source_discoverer:
   prompt: """
   Discover OpenProse source files under source_root.
   Load contract-markdown.md only.
+  Treat source_root as a hard boundary. Do not read parent directories or
+  sibling repositories while discovering source.
   Return root-relative source records with path, kind, and optional name.
   Recognize responsibility, gateway, system, service, test, pattern, and unknown.
   Ignore dist/, runs/, state/, deps/, and generated output.

--- a/skills/open-prose/responsibility-runtime.md
+++ b/skills/open-prose/responsibility-runtime.md
@@ -62,7 +62,7 @@ Default compiler output lives under `<openprose-root>/dist/`:
 
 - validate the active manifest
 - register concrete cron and HTTP triggers
-- resolve events to activations
+- accept HTTP trigger events quickly, then resolve events to activations
 - launch normal bounded `prose run` sessions
 - record operational metadata
 
@@ -142,6 +142,10 @@ launched as a normal bounded fulfillment, retry, or escalation activation.
 `prose status` is deterministic local inspection. It does not run the VM,
 register adapters, or infer new semantics; it reads compiled IR and runtime
 receipts so a developer can see what the runtime believes is active.
+
+HTTP trigger adapters acknowledge accepted events before the downstream judge or
+fulfillment run completes. Long-running AI work should not hold webhook callers
+open; activation failures belong in serve logs and run/status state.
 
 ## Responsibilities
 

--- a/tests/open-prose/smoke/manifest.json
+++ b/tests/open-prose/smoke/manifest.json
@@ -75,6 +75,7 @@
       "tier": "required",
       "command": "test",
       "source": "08-kind-test.prose.md",
+      "workspaceSources": ["08-kind-test.prose.md", "02-caller-input.prose.md"],
       "expectedOutputs": ["echo"],
       "timeoutSeconds": 480,
       "maxTurns": 24
@@ -84,6 +85,7 @@
       "tier": "required",
       "command": "run",
       "source": "09-local-pattern.prose.md",
+      "workspaceSources": ["09-local-pattern.prose.md", "worker-critic.prose.md"],
       "inputs": {
         "task": "produce a one sentence smoke result",
         "quality-bar": "The output contains local-pattern-smoke-pass and is under 80 words."

--- a/tools/cli/POST_RELEASE_PLAYTEST.md
+++ b/tools/cli/POST_RELEASE_PLAYTEST.md
@@ -67,6 +67,9 @@ Start with the released version and record it:
 version="0.13.0"
 npm view @openprose/prose-cli@"$version" version dist-tags.latest
 gh release view "v$version" --repo openprose/prose
+command -v prose || true
+which -a prose || true
+prose --version || true
 ```
 
 For each worker, create an isolated root:

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -152,13 +152,18 @@ prose status
 ```
 
 `prose compile` returns success only after the emitted `manifest.next.json`
-passes deterministic IR validation.
+passes deterministic IR validation with no error diagnostics. If an agent
+harness reports a stray nonzero status after writing a valid manifest, the CLI
+warns and accepts the validated artifact. Abort and signal exits are preserved.
 
 `prose serve` loads and validates `dist/manifest.active.json` under the active
 OpenProse root, registers local cron and HTTP trigger adapters, and launches
 ordinary bounded `prose run` activations when those triggers fire. HTTP
 adapters bind to `127.0.0.1:7331` by default; use `--host` and `--port` to
-override that local listener.
+override that local listener. The listener always exposes
+`/_openprose/health`, including cron-only manifests. Trigger routes respond
+with `202 Accepted` after the event is accepted; judge and fulfillment
+activations continue in the background and log failures to the serve process.
 
 ## Development
 

--- a/tools/cli/src/commands/compile.ts
+++ b/tools/cli/src/commands/compile.ts
@@ -101,6 +101,12 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 		...(options.skillPreflight === undefined ? {} : { skillPreflight: options.skillPreflight }),
 	});
 	if (exitCode !== 0) {
+		if (await shouldAcceptNonzeroCompiledManifest(exitCode, options, target)) {
+			options.stderr.write(
+				`Compiler harness exited with code ${exitCode} after writing valid repository IR; accepting ${target.manifestPath}.\n`,
+			);
+			return 0;
+		}
 		return exitCode;
 	}
 
@@ -111,6 +117,36 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 		...target,
 	});
 	return 0;
+}
+
+async function shouldAcceptNonzeroCompiledManifest(
+	exitCode: number,
+	options: RunCompileCommandOptions,
+	target: { absoluteManifestPath: string; manifestPath: string },
+): Promise<boolean> {
+	if (options.signal?.aborted || isSignalExitCode(exitCode)) {
+		return false;
+	}
+	return validCompiledRepositoryIrExists({ ...options, ...target });
+}
+
+async function validCompiledRepositoryIrExists(options: {
+	argv: readonly string[];
+	cwd: string;
+	env: Readonly<Record<string, string | undefined>>;
+	absoluteManifestPath: string;
+	manifestPath: string;
+}): Promise<boolean> {
+	try {
+		await validateCompiledRepositoryIr(options);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function isSignalExitCode(exitCode: number): boolean {
+	return Number.isInteger(exitCode) && exitCode > 128 && exitCode <= 192;
 }
 
 export async function validateCompiledRepositoryIr(options: {

--- a/tools/cli/src/prose/repository-ir.ts
+++ b/tools/cli/src/prose/repository-ir.ts
@@ -1018,6 +1018,8 @@ function validateDiagnostics(value: unknown, sourcePaths: Set<string>, errors: s
 		}
 		if (!diagnosticSeverities.includes(diagnostic.severity as RepositoryIrDiagnosticSeverity)) {
 			errors.push(`diagnostics[${index}].severity must be info, warning, or error`);
+		} else if (diagnostic.severity === "error") {
+			errors.push(`diagnostics[${index}].severity must not be error in a written manifest`);
 		}
 		if (!isNonEmptyString(diagnostic.message)) {
 			errors.push(`diagnostics[${index}].message must be a non-empty string`);

--- a/tools/cli/src/prose/repository-serve-daemon.ts
+++ b/tools/cli/src/prose/repository-serve-daemon.ts
@@ -106,18 +106,16 @@ export async function startRepositoryServeDaemon(
 			);
 		}
 
-		if (httpRegistrations.length > 0) {
-			const app = buildHttpApp({
-				dispatchEvent,
-				now,
-				registrations: httpRegistrations,
-				stderr: options.stderr,
-			});
-			const started = await startHttpServer(app, host, port);
-			httpServer = started.server;
-			address = started.address;
-			options.stdout.write(`HTTP listening on ${address.url}\n`);
-		}
+		const app = buildHttpApp({
+			dispatchEvent,
+			now,
+			registrations: httpRegistrations,
+			stderr: options.stderr,
+		});
+		const started = await startHttpServer(app, host, port);
+		httpServer = started.server;
+		address = started.address;
+		options.stdout.write(`HTTP listening on ${address.url}\n`);
 	} catch (error) {
 		for (const timer of timers) {
 			timer.cancel();
@@ -268,29 +266,32 @@ function buildHttpApp(options: {
 		const [method, path] = splitRouteKey(key);
 		app.on(method, path, async (context) => {
 			const payload = await buildHttpEventPayload(context.req.raw, options.now());
-			const results: RepositoryServeDispatchResult[] = [];
-			try {
-				for (const registration of registrations) {
-					results.push(
-						await options.dispatchEvent({
-							triggerId: registration.triggerId,
-							payload,
-						}),
-					);
-				}
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				options.stderr.write(`HTTP trigger ${key} failed: ${message}\n`);
-				return context.json({ ok: false, error: message }, 500);
-			}
+			const acceptedAt = options.now().toISOString();
+			const accepted = registrations.map((registration) => {
+				void options
+					.dispatchEvent({
+						triggerId: registration.triggerId,
+						payload,
+					})
+					.catch((error) => {
+						const message = error instanceof Error ? error.message : String(error);
+						options.stderr.write(`HTTP trigger ${key} failed: ${message}\n`);
+					});
 
-			return context.json({
-				ok: true,
-				results: results.map((result) => ({
-					triggerId: result.triggerId,
-					activations: result.activationResults,
-				})),
+				return {
+					triggerId: registration.triggerId,
+					activations: registration.activationIds,
+				};
 			});
+
+			return context.json(
+				{
+					ok: true,
+					acceptedAt,
+					accepted,
+				},
+				202,
+			);
 		});
 	}
 
@@ -371,7 +372,13 @@ async function closeHttpServer(server: ServerType): Promise<void> {
 			}
 			resolve();
 		});
+		closeIdleHttpConnections(server);
 	});
+}
+
+function closeIdleHttpConnections(server: ServerType): void {
+	const closeIdleConnections = (server as { closeIdleConnections?: () => void }).closeIdleConnections;
+	closeIdleConnections?.call(server);
 }
 
 function track<T>(promise: Promise<T>, inflight: Set<Promise<unknown>>): void {

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -32,6 +32,12 @@ function memoryStreams() {
 			return stderr;
 		},
 	};
+}
+
+function writeManifestWithErrorDiagnostic(path: string): void {
+	const manifest = JSON.parse(readFileSync(stargazerFixture, "utf8")) as { diagnostics: Array<{ severity: string }> };
+	manifest.diagnostics[0]!.severity = "error";
+	writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 describe("Oclif entrypoint helpers", () => {
@@ -318,6 +324,99 @@ describe("runCompileCommand", () => {
 			});
 
 			expect(exitCode).toBe(0);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts a valid manifest when the compiler harness exits nonzero after writing it", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-valid-nonzero-"));
+		const io = memoryStreams();
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run() {
+						mkdirSync(join(temp, "dist"), { recursive: true });
+						copyFileSync(stargazerFixture, join(temp, "dist/manifest.next.json"));
+						return 1;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(0);
+			expect(io.stderr).toContain("Compiler harness exited with code 1 after writing valid repository IR");
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves nonzero compiler exits when the manifest has error diagnostics", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-error-diagnostic-"));
+		const io = memoryStreams();
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run() {
+						mkdirSync(join(temp, "dist"), { recursive: true });
+						writeManifestWithErrorDiagnostic(join(temp, "dist/manifest.next.json"));
+						return 1;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(1);
+			expect(io.stderr).not.toContain("accepting dist/manifest.next.json");
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves abort exits after the compiler writes a valid manifest", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-abort-"));
+		const io = memoryStreams();
+		const controller = new AbortController();
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				signal: controller.signal,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run() {
+						mkdirSync(join(temp, "dist"), { recursive: true });
+						copyFileSync(stargazerFixture, join(temp, "dist/manifest.next.json"));
+						controller.abort("SIGTERM");
+						return 143;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(143);
+			expect(io.stderr).not.toContain("accepting dist/manifest.next.json");
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}

--- a/tools/cli/tests/prose/repository-ir.test.ts
+++ b/tools/cli/tests/prose/repository-ir.test.ts
@@ -303,4 +303,14 @@ describe("repository IR v0", () => {
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain("diagnostics[0].sourcePath must reference a discovered source path");
 	});
+
+	it("rejects error diagnostics in written manifests", () => {
+		const manifest = cloneFixture("tests/open-prose/compiler/expected/stargazer.manifest.next.json");
+		manifest.diagnostics[0].severity = "error";
+
+		const result = validateRepositoryIr(manifest);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("diagnostics[0].severity must not be error in a written manifest");
+	});
 });

--- a/tools/cli/tests/prose/repository-serve.test.ts
+++ b/tools/cli/tests/prose/repository-serve.test.ts
@@ -658,10 +658,18 @@ describe("repository serve core", () => {
 		}
 	});
 
-	it("serves HTTP trigger registrations and launches matched activations", async () => {
+	it("acknowledges HTTP trigger registrations before matched activations finish", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-serve-http-"));
 		const io = memoryStreams();
 		const calls: string[] = [];
+		let releaseJudge: () => void = () => {};
+		let resolveJudgeStarted!: () => void;
+		const judgeStarted = new Promise<void>((resolve) => {
+			resolveJudgeStarted = resolve;
+		});
+		const allowJudge = new Promise<void>((resolve) => {
+			releaseJudge = resolve;
+		});
 
 		try {
 			writeActiveManifest(temp);
@@ -675,6 +683,8 @@ describe("repository serve core", () => {
 				commandRunner: async (options) => {
 					calls.push(options.env.PROSE_ACTIVATION_ID ?? "");
 					if (options.env.PROSE_ACTIVATION_ID === "high-intent-stargazer-outreach.judge") {
+						resolveJudgeStarted();
+						await allowJudge;
 						writeStatusFromRunEnv(options.env, "down");
 					}
 					return 0;
@@ -690,26 +700,64 @@ describe("repository serve core", () => {
 				});
 				const body = await response.json();
 
-				expect(response.status).toBe(200);
+				expect(response.status).toBe(202);
 				expect(body).toMatchObject({
 					ok: true,
-					results: [
+					accepted: [
 						{
 							triggerId: "high-intent-stargazer-outreach.evidence-change",
+							activations: [
+								"high-intent-stargazer-outreach.judge",
+								"high-intent-stargazer-outreach.fulfillment",
+							],
 						},
 					],
 				});
+				await judgeStarted;
+				expect(calls).toEqual(["high-intent-stargazer-outreach.judge"]);
+				releaseJudge();
+				await waitFor(() => calls.includes("high-intent-stargazer-outreach.fulfillment"));
 				expect(calls).toEqual([
 					"high-intent-stargazer-outreach.judge",
 					"high-intent-stargazer-outreach.fulfillment",
 				]);
 			} finally {
+				releaseJudge();
 				await daemon.stop();
 			}
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}
 	}, 10_000);
+
+	it("keeps an HTTP health endpoint for cron-only manifests", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-serve-cron-health-"));
+		const io = memoryStreams();
+
+		try {
+			writeActiveManifestObject(temp, timerOnlyManifest());
+			const daemon = await startRepositoryServeDaemon({
+				cwd: temp,
+				env: {},
+				host: "127.0.0.1",
+				port: 0,
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				commandRunner: async () => 0,
+			});
+
+			try {
+				expect(daemon.address).toBeDefined();
+				const response = await fetch(`${daemon.address!.url}/_openprose/health`);
+				expect(response.status).toBe(200);
+				expect(await response.json()).toEqual({ ok: true });
+			} finally {
+				await daemon.stop();
+			}
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
 
 	it("restores trigger registrations when serve restarts", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-serve-restart-"));
@@ -769,6 +817,8 @@ describe("repository serve core", () => {
 			const daemon = await startRepositoryServeDaemon({
 				cwd: temp,
 				env: {},
+				host: "127.0.0.1",
+				port: 0,
 				now: () => current,
 				stdout: io.streams.stdout,
 				stderr: io.streams.stderr,
@@ -916,4 +966,14 @@ function writeStatusFromRunEnv(
 
 	mkdirSync(dirname(latestPath), { recursive: true });
 	writeFileSync(latestPath, `${JSON.stringify(record, null, 2)}\n`);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("Timed out waiting for condition.");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
 }


### PR DESCRIPTION
## Summary

- accept a valid `manifest.next.json` when the compiler harness exits nonzero after writing it
- keep `prose serve` HTTP health available for cron-only manifests
- make HTTP trigger routes return `202 Accepted` immediately while activations continue in the background
- tighten compiler docs around staying inside `source_root` and capture the release playtest PATH check

## Context

The released `0.13.0` example pass showed that compile now usually emits serve-valid IR, but one compile returned nonzero after producing a valid manifest because of an incidental agent-side command failure. The same pass showed all HTTP-backed examples timing out at the webhook edge because serve waited for judge activation completion before responding.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`
- local serve smoke with compiled fixture: health returned `200`, HTTP trigger returned `202 Accepted`
