### PR TITLE
chore(repo): gitignore Claude and Codex local override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ dist/prose/
 
 # OpenProse smoke runner output
 openprose-smoke-results/
+
+# Local agent overrides — never checked in
+AGENTS.override.md
+CLAUDE.local.md


### PR DESCRIPTION
Add AGENTS.override.md and CLAUDE.local.md under a clearly labeled "Local agent overrides" group so personal agent instruction files cannot accidentally be committed.