### PR TITLE
[codex] clean up responsibility runtime playtest warts

### DIFF
--- a/.github/scripts/openprose-smoke/run.ts
+++ b/.github/scripts/openprose-smoke/run.ts
@@ -789,20 +789,21 @@ async function classifyLiveCase(
   exitCode: number | null,
   timedOut: boolean,
 ): Promise<{ status: SmokeStatus; reasons: string[]; foundOutputs: string[] }> {
-  const reasons: string[] = [];
+  const artifactReasons: string[] = [];
+  const processReasons: string[] = [];
   const expectedOutputs = smokeCase.expectedOutputs ?? [];
 
   if (timedOut) {
-    reasons.push(`Claude CLI timed out after ${smokeCase.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds.`);
+    processReasons.push(`Claude CLI timed out after ${smokeCase.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds.`);
   }
   if (exitCode !== 0) {
-    reasons.push(`Claude CLI exited with code ${exitCode === null ? "null" : exitCode}.`);
+    processReasons.push(`Claude CLI exited with code ${exitCode === null ? "null" : exitCode}.`);
   }
 
   const runsDir = path.join(workspace, ...RUNS_DIR_SEGMENTS);
   const hasRunsDir = await pathExists(runsDir);
   if (!hasRunsDir) {
-    reasons.push("No <openprose-root>/runs directory was created.");
+    artifactReasons.push("No <openprose-root>/runs directory was created.");
   }
 
   const markerTexts = [
@@ -812,30 +813,30 @@ async function classifyLiveCase(
   ];
 
   if (markerTexts.some((text) => hasLineStarting(text, "---error"))) {
-    reasons.push("Found a line starting ---error in stdout, stderr, or run artifacts.");
+    artifactReasons.push("Found a line starting ---error in stdout, stderr, or run artifacts.");
   }
   if (markerTexts.some((text) => hasLineStarting(text, "---test FAIL"))) {
-    reasons.push("Found a line starting ---test FAIL in stdout, stderr, or run artifacts.");
+    artifactReasons.push("Found a line starting ---test FAIL in stdout, stderr, or run artifacts.");
   }
   if (smokeCase.command === "test" && !markerTexts.some((text) => hasLineStarting(text, "---test PASS"))) {
-    reasons.push("Test smoke case did not emit a line starting ---test PASS.");
+    artifactReasons.push("Test smoke case did not emit a line starting ---test PASS.");
   }
 
   const foundOutputs: string[] = [];
   const latestRunDir = hasRunsDir ? await findLatestRunDir(runsDir) : undefined;
   if (hasRunsDir && !latestRunDir) {
-    reasons.push("No run directory was created under <openprose-root>/runs.");
+    artifactReasons.push("No run directory was created under <openprose-root>/runs.");
   }
   if (latestRunDir) {
     for (const artifactName of ["forme.manifest.json", "root.prose.md", "vm.log.md"]) {
       const artifactPath = path.join(latestRunDir, artifactName);
       const artifactStat = await statIfExists(artifactPath);
       if (!artifactStat?.isFile()) {
-        reasons.push(`Missing required run artifact: ${artifactName}`);
+        artifactReasons.push(`Missing required run artifact: ${artifactName}`);
         continue;
       }
       if ((await readTextIfExists(artifactPath)).trim().length === 0) {
-        reasons.push(`Empty required run artifact: ${artifactName}`);
+        artifactReasons.push(`Empty required run artifact: ${artifactName}`);
       }
     }
   }
@@ -846,9 +847,12 @@ async function classifyLiveCase(
     if (bindingPath && (await readTextIfExists(bindingPath)).trim().length > 0) {
       foundOutputs.push(output);
     } else {
-      reasons.push(`Missing or empty expected output binding: ${output}`);
+      artifactReasons.push(`Missing or empty expected output binding: ${output}`);
     }
   }
+
+  const reasons =
+    timedOut || artifactReasons.length > 0 ? [...processReasons, ...artifactReasons] : [];
 
   return {
     status: reasons.length > 0 ? "fail" : "pass",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Serve shutdown logging** — In-flight activations interrupted by `prose serve`
+  shutdown now log as shutdown cancellations instead of generic trigger
+  failures.
+- **Status wording** — `prose status` now describes absent responsibility state
+  as `no runtime status yet` instead of `missing`.
+- **Compiler discipline** — The bundled compiler program now returns after
+  writing `manifest.next.json` and leaves deterministic validation to the CLI.
+- **Smoke postconditions** — OpenProse smoke checks now trust verified run
+  artifacts when a model exits nonzero after satisfying the fixture contract.
+
 ## [0.13.1] - 2026-05-05
 
 ### Fixed

--- a/skills/open-prose/compiler/index.prose.md
+++ b/skills/open-prose/compiler/index.prose.md
@@ -51,6 +51,9 @@ to keep each lowering step on a narrow context budget.
 - Prefer warnings over silent assumptions when timing, fulfillment, or Forme
   wiring is ambiguous.
 - Write `manifest.next.json` only after validation accepts the manifest.
+- After writing `manifest.next.json`, return the result. Do not run optional
+  `jq`, `sed`, shell summaries, or environment-maintenance commands; the host
+  CLI performs deterministic validation after the compiler program exits.
 
 ### Execution
 

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -164,6 +164,8 @@ override that local listener. The listener always exposes
 `/_openprose/health`, including cron-only manifests. Trigger routes respond
 with `202 Accepted` after the event is accepted; judge and fulfillment
 activations continue in the background and log failures to the serve process.
+During shutdown, in-flight activations interrupted by the serve process signal
+are reported as shutdown cancellations instead of trigger failures.
 
 ## Development
 

--- a/tools/cli/src/prose/repository-serve-daemon.ts
+++ b/tools/cli/src/prose/repository-serve-daemon.ts
@@ -70,6 +70,7 @@ export async function startRepositoryServeDaemon(
 	const timerRegistrations = summary.registrations.filter((registration) => registration.adapter === "timer");
 	let httpServer: ServerType | undefined;
 	let closed = false;
+	let signalDrivenShutdown = false;
 	let cleanupSignal = () => {};
 
 	const dispatchEvent = async (event: RepositoryServeEvent): Promise<RepositoryServeDispatchResult> => {
@@ -97,6 +98,7 @@ export async function startRepositoryServeDaemon(
 			timers.push(
 				startCronTimer({
 					dispatchEvent,
+					isSignalDrivenShutdown: () => signalDrivenShutdown,
 					now,
 					registration,
 					scheduler: timerScheduler,
@@ -108,9 +110,11 @@ export async function startRepositoryServeDaemon(
 
 		const app = buildHttpApp({
 			dispatchEvent,
+			isSignalDrivenShutdown: () => signalDrivenShutdown,
 			now,
 			registrations: httpRegistrations,
 			stderr: options.stderr,
+			stdout: options.stdout,
 		});
 		const started = await startHttpServer(app, host, port);
 		httpServer = started.server;
@@ -154,9 +158,11 @@ export async function startRepositoryServeDaemon(
 	};
 
 	if (options.signal?.aborted) {
+		signalDrivenShutdown = true;
 		await stop();
 	} else if (options.signal !== undefined) {
 		const onAbort = () => {
+			signalDrivenShutdown = true;
 			void stop();
 		};
 		options.signal.addEventListener("abort", onAbort, { once: true });
@@ -178,6 +184,7 @@ export { millisecondsUntilNextCron, nextCronDate };
 
 function startCronTimer(options: {
 	dispatchEvent(event: RepositoryServeEvent): Promise<RepositoryServeDispatchResult>;
+	isSignalDrivenShutdown(): boolean;
 	now: () => Date;
 	registration: RepositoryServeTriggerRegistration;
 	scheduler: RepositoryServeTimerScheduler;
@@ -222,6 +229,10 @@ function startCronTimer(options: {
 				});
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
+				if (options.isSignalDrivenShutdown() && isShutdownCancellationMessage(message)) {
+					options.stdout.write(`Trigger ${registration.triggerId} cancelled during shutdown: ${message}\n`);
+					return;
+				}
 				options.stderr.write(`Trigger ${registration.triggerId} failed: ${message}\n`);
 			}
 
@@ -245,9 +256,11 @@ function startCronTimer(options: {
 
 function buildHttpApp(options: {
 	dispatchEvent(event: RepositoryServeEvent): Promise<RepositoryServeDispatchResult>;
+	isSignalDrivenShutdown(): boolean;
 	now: () => Date;
 	registrations: RepositoryServeTriggerRegistration[];
 	stderr: WritableStreamLike;
+	stdout: WritableStreamLike;
 }): Hono {
 	const app = new Hono();
 	const routes = new Map<string, RepositoryServeTriggerRegistration[]>();
@@ -275,7 +288,13 @@ function buildHttpApp(options: {
 					})
 					.catch((error) => {
 						const message = error instanceof Error ? error.message : String(error);
-						options.stderr.write(`HTTP trigger ${key} failed: ${message}\n`);
+						if (options.isSignalDrivenShutdown() && isShutdownCancellationMessage(message)) {
+							options.stdout.write(
+								`HTTP trigger ${registration.triggerId} [${key}] cancelled during shutdown: ${message}\n`,
+							);
+							return;
+						}
+						options.stderr.write(`HTTP trigger ${registration.triggerId} [${key}] failed: ${message}\n`);
 					});
 
 				return {
@@ -379,6 +398,10 @@ async function closeHttpServer(server: ServerType): Promise<void> {
 function closeIdleHttpConnections(server: ServerType): void {
 	const closeIdleConnections = (server as { closeIdleConnections?: () => void }).closeIdleConnections;
 	closeIdleConnections?.call(server);
+}
+
+function isShutdownCancellationMessage(message: string): boolean {
+	return /\bexited with code (130|143)\b/.test(message);
 }
 
 function track<T>(promise: Promise<T>, inflight: Set<Promise<unknown>>): void {

--- a/tools/cli/src/prose/repository-status.ts
+++ b/tools/cli/src/prose/repository-status.ts
@@ -388,7 +388,7 @@ function appendRuns(lines: string[], runs: RepositoryStatusRun[]): void {
 
 function formatLatestStatus(status: RepositoryStatusLatestStatus): string {
 	if (status.state === "missing") {
-		return "missing";
+		return "no runtime status yet";
 	}
 	if (status.state === "invalid") {
 		return `invalid (${status.error ?? "unknown error"})`;

--- a/tools/cli/tests/prose/repository-serve.test.ts
+++ b/tools/cli/tests/prose/repository-serve.test.ts
@@ -730,6 +730,173 @@ describe("repository serve core", () => {
 		}
 	}, 10_000);
 
+	it("logs shutdown-cancelled HTTP activations as cancellations", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-serve-http-shutdown-"));
+		const io = memoryStreams();
+		const controller = new AbortController();
+		let resolveJudgeStarted!: () => void;
+		const judgeStarted = new Promise<void>((resolve) => {
+			resolveJudgeStarted = resolve;
+		});
+
+		try {
+			writeActiveManifest(temp);
+			const daemon = await startRepositoryServeDaemon({
+				cwd: temp,
+				env: {},
+				host: "127.0.0.1",
+				port: 0,
+				signal: controller.signal,
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				commandRunner: async (options) => {
+					if (options.env.PROSE_ACTIVATION_ID === "high-intent-stargazer-outreach.judge") {
+						resolveJudgeStarted();
+						await new Promise<void>((resolve) => {
+							options.signal?.addEventListener("abort", () => resolve(), { once: true });
+						});
+						return 143;
+					}
+					return 0;
+				},
+			});
+
+			expect(daemon.address).toBeDefined();
+			const response = await fetch(`${daemon.address!.url}/webhooks/github/stars`, {
+				method: "POST",
+				body: JSON.stringify({ repository: "openprose/prose", starred_by: "alice" }),
+				headers: { "content-type": "application/json" },
+			});
+			expect(response.status).toBe(202);
+			await judgeStarted;
+
+			controller.abort("SIGTERM");
+			await daemon.closed;
+
+			expect(io.stdout).toContain(
+				"HTTP trigger high-intent-stargazer-outreach.evidence-change [POST /webhooks/github/stars] cancelled during shutdown: Activation 'high-intent-stargazer-outreach.judge' exited with code 143.",
+			);
+			expect(io.stderr).not.toContain("HTTP trigger high-intent-stargazer-outreach.evidence-change");
+		} finally {
+			controller.abort("SIGTERM");
+			rmSync(temp, { recursive: true, force: true });
+		}
+	}, 10_000);
+
+	it("does not classify manual stop exit 143 as signal-driven cancellation", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-serve-http-manual-stop-"));
+		const io = memoryStreams();
+		let resolveJudgeStarted!: () => void;
+		let releaseJudge!: () => void;
+		const judgeStarted = new Promise<void>((resolve) => {
+			resolveJudgeStarted = resolve;
+		});
+		const allowJudgeExit = new Promise<void>((resolve) => {
+			releaseJudge = resolve;
+		});
+
+		try {
+			writeActiveManifest(temp);
+			const daemon = await startRepositoryServeDaemon({
+				cwd: temp,
+				env: {},
+				host: "127.0.0.1",
+				port: 0,
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				commandRunner: async (options) => {
+					if (options.env.PROSE_ACTIVATION_ID === "high-intent-stargazer-outreach.judge") {
+						resolveJudgeStarted();
+						await allowJudgeExit;
+						return 143;
+					}
+					return 0;
+				},
+			});
+
+			expect(daemon.address).toBeDefined();
+			const response = await fetch(`${daemon.address!.url}/webhooks/github/stars`, {
+				method: "POST",
+				body: JSON.stringify({ repository: "openprose/prose", starred_by: "alice" }),
+				headers: { "content-type": "application/json" },
+			});
+			expect(response.status).toBe(202);
+			await judgeStarted;
+
+			const stopped = daemon.stop();
+			releaseJudge();
+			await stopped;
+
+			expect(io.stderr).toContain(
+				"HTTP trigger high-intent-stargazer-outreach.evidence-change [POST /webhooks/github/stars] failed: Activation 'high-intent-stargazer-outreach.judge' exited with code 143.",
+			);
+			expect(io.stdout).not.toContain("cancelled during shutdown");
+		} finally {
+			releaseJudge?.();
+			rmSync(temp, { recursive: true, force: true });
+		}
+	}, 10_000);
+
+	it("logs shutdown-cancelled cron activations as cancellations", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-serve-cron-shutdown-"));
+		const io = memoryStreams();
+		const controller = new AbortController();
+		let current = new Date(2026, 0, 1, 0, 0, 30);
+		const scheduled: Array<{ callback: () => void | Promise<void>; delayMs: number }> = [];
+		const scheduler: RepositoryServeTimerScheduler = {
+			setTimeout(callback, delayMs) {
+				scheduled.push({ callback, delayMs });
+				return { cancel() {} };
+			},
+		};
+		let resolveJudgeStarted!: () => void;
+		const judgeStarted = new Promise<void>((resolve) => {
+			resolveJudgeStarted = resolve;
+		});
+
+		try {
+			writeActiveManifestObject(temp, timerOnlyManifest());
+			const daemon = await startRepositoryServeDaemon({
+				cwd: temp,
+				env: {},
+				host: "127.0.0.1",
+				port: 0,
+				now: () => current,
+				signal: controller.signal,
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				timerScheduler: scheduler,
+				commandRunner: async (options) => {
+					if (options.env.PROSE_ACTIVATION_ID === "high-intent-stargazer-outreach.judge") {
+						resolveJudgeStarted();
+						await new Promise<void>((resolve) => {
+							options.signal?.addEventListener("abort", () => resolve(), { once: true });
+						});
+						return 143;
+					}
+					return 0;
+				},
+			});
+
+			expect(scheduled[0]?.delayMs).toBe(30_000);
+			current = new Date(2026, 0, 1, 0, 1, 0);
+			const fired = scheduled[0]!.callback();
+			await judgeStarted;
+
+			controller.abort("SIGTERM");
+			await daemon.closed;
+			await fired;
+
+			expect(io.stdout).toContain(
+				"Trigger high-intent-stargazer-outreach.periodic-check cancelled during shutdown: Activation 'high-intent-stargazer-outreach.judge' exited with code 143.",
+			);
+			expect(io.stderr).not.toContain("Trigger high-intent-stargazer-outreach.periodic-check failed");
+		} finally {
+			controller.abort("SIGTERM");
+			rmSync(temp, { recursive: true, force: true });
+		}
+	}, 10_000);
+
 	it("keeps an HTTP health endpoint for cron-only manifests", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-serve-cron-health-"));
 		const io = memoryStreams();

--- a/tools/cli/tests/prose/repository-status.test.ts
+++ b/tools/cli/tests/prose/repository-status.test.ts
@@ -80,7 +80,7 @@ describe("repository status", () => {
 				Responsibilities:
 				- high-intent-stargazer-outreach
 				  source: tests/open-prose/responsibility-runtime/01-stargazer-responsibility.prose.md
-				  status: missing
+				  status: no runtime status yet
 				  pressure: none
 
 				Runs:


### PR DESCRIPTION
## Summary

This PR applies the follow-ups from the released `0.13.1` example playtest across the bundled OpenProse Native Repository examples.

- Clarifies fresh responsibility status as `no runtime status yet` instead of `missing`.
- Logs signal-aborted in-flight `prose serve` activations as shutdown cancellations instead of generic HTTP/cron trigger failures.
- Tightens the bundled compiler program so it returns after writing `manifest.next.json` and lets the CLI perform deterministic validation.
- Makes OpenProse smoke checks artifact-driven when a model exits nonzero after satisfying all verified fixture postconditions.
- Documents the serve shutdown logging behavior in the CLI README.

## Playtest Context

The post-release pass used `/opt/homebrew/bin/prose@0.13.1` and global `open-prose` skill `0.13.1` across all eight examples. Compile/status/serve/health passed across the set, and HTTP examples returned `202 Accepted`. The main recurring wart was that short smoke-test shutdowns made accepted background activations log as failed with exit code `143`.

Planning synthesis: `/Users/sl/code/openprose/planning/plans/2026-05-01-responsibility-primitive/examples-rewrite/released-0.13.1-feedback/synthesis/00-summary.md`

## Validation

- `node --check .github/scripts/openprose-smoke/run.ts`
- `tools/cli/node_modules/.bin/tsx .github/scripts/openprose-smoke/run.ts --dry-run --force --case kind-test --results-dir /tmp/openprose-smoke-dry-results --workspace-root /tmp/openprose-smoke-dry --changed-files skills/open-prose/compiler/index.prose.md`
- `npm test -- tests/prose/repository-status.test.ts tests/prose/repository-serve.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
