### PR TITLE
[codex] harden Sonnet compile flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke postconditions** — OpenProse smoke checks now trust verified run
   artifacts when a model exits nonzero after satisfying the fixture contract.
 - **Sonnet compile path** — Pathless `prose compile` now forwards `src` to the
-  compiler, and the Claude SDK harness defaults to non-interactive edit
-  acceptance so declared compile artifacts can be written without approval
-  prompts. If the harness returns a valid marked manifest instead of writing it
-  directly, the CLI validates and writes the artifact.
+  compiler, and SDK harnesses default to permissive non-interactive filesystem
+  access so declared artifacts can be written without approval prompts.
 
 ## [0.13.1] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   writing `manifest.next.json` and leaves deterministic validation to the CLI.
 - **Smoke postconditions** — OpenProse smoke checks now trust verified run
   artifacts when a model exits nonzero after satisfying the fixture contract.
+- **Sonnet compile path** — Pathless `prose compile` now forwards `src` to the
+  compiler, and the Claude SDK harness defaults to non-interactive edit
+  acceptance so declared compile artifacts can be written without approval
+  prompts. If the harness returns a valid marked manifest instead of writing it
+  directly, the CLI validates and writes the artifact.
 
 ## [0.13.1] - 2026-05-05
 

--- a/skills/open-prose/compiler/index.prose.md
+++ b/skills/open-prose/compiler/index.prose.md
@@ -173,12 +173,6 @@ agent manifest_writer:
   command and the host CLI validates the result immediately after the write.
   Use the host filesystem write primitive immediately. The compile command
   itself is the user's approval to write the declared manifest artifact.
-  If the harness cannot write the file directly, do not ask for approval and do
-  not return a summary as a substitute. Instead, return the complete validated
-  manifest JSON between these exact markers and then stop:
-  <openprose-compiled-manifest>
-  { ...complete repository IR JSON... }
-  </openprose-compiled-manifest>
   Report the written path and byte count.
   """
   shape:

--- a/skills/open-prose/compiler/index.prose.md
+++ b/skills/open-prose/compiler/index.prose.md
@@ -44,6 +44,9 @@ to keep each lowering step on a narrow context budget.
   instinct, `ir-v0.md` wins.
 - Infer responsibilities, concrete trigger registrations, and fulfillment only
   when the source graph makes the relationship clear.
+- When `source_root` is a directory, compile the repository graph under that
+  directory. Do not ask the user to choose one `.prose.md` file; infer roots,
+  wire reachable source, and emit diagnostics for ambiguity.
 - Do not invent connector routes, queue names, provider payloads, secrets, or
   provider subscription setup.
 - Stay inside `source_root`; do not inspect sibling examples, parent
@@ -166,6 +169,16 @@ agent manifest_writer:
   Write the already validated manifest JSON to output_dir/manifest.next.json.
   Create output_dir if needed.
   Do not change, pretty-print creatively, summarize, or repair the manifest.
+  Do not ask for approval before writing; `prose compile` is a non-interactive
+  command and the host CLI validates the result immediately after the write.
+  Use the host filesystem write primitive immediately. The compile command
+  itself is the user's approval to write the declared manifest artifact.
+  If the harness cannot write the file directly, do not ask for approval and do
+  not return a summary as a substitute. Instead, return the complete validated
+  manifest JSON between these exact markers and then stop:
+  <openprose-compiled-manifest>
+  { ...complete repository IR JSON... }
+  </openprose-compiled-manifest>
   Report the written path and byte count.
   """
   shape:

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -81,27 +81,30 @@ PROSE_HARNESS=claude-sdk prose run std/evals/inspector
 ## Harness Details
 
 - `codex-sdk` uses `@openai/codex-sdk`, forwards the current working directory
-  and environment, and streams Codex SDK events. This is the default.
+  and environment, streams Codex SDK events, and defaults to
+  `danger-full-access` with approval policy `never` so non-interactive commands
+  can write declared artifacts inside the caller's sandbox. This is the
+  default harness.
 - `claude-sdk` uses `@anthropic-ai/claude-agent-sdk`, forwards the current
   working directory and environment, streams text deltas, and defaults to
-  `acceptEdits` with basic filesystem tools auto-allowed so non-interactive
-  commands can write declared artifacts.
+  `bypassPermissions` with basic filesystem tools auto-allowed for the same
+  non-interactive artifact-writing contract.
 - `mock` echoes prompts for tests and local smoke checks.
 
 Select a harness with `--harness <name>` or `PROSE_HARNESS`.
 
-OpenProse commands are allowed to run from non-git directories. Codex SDK
-harness runs leave Codex sandbox and approval policy controls to Codex and the
-environment settings below.
+OpenProse commands are allowed to run from non-git directories. SDK harnesses
+assume the caller runs them inside the desired external sandbox, so their local
+permission defaults are intentionally permissive and non-interactive.
 
-For externally sandboxed CI environments, Codex harnesses also honor
+Codex harnesses honor
 `PROSE_CODEX_SANDBOX_MODE` (`read-only`, `workspace-write`, or
 `danger-full-access`) and `PROSE_CODEX_APPROVAL_POLICY` (`never`, `on-request`,
-`on-failure`, or `untrusted`) and forward those values to Codex.
+`on-failure`, or `untrusted`) when callers need to override those defaults.
 
 Claude harnesses honor `ANTHROPIC_MODEL` or `PROSE_CLAUDE_MODEL` for model
 selection, plus `PROSE_CLAUDE_PERMISSION_MODE` when callers need to override
-the default `acceptEdits` permission mode.
+the default `bypassPermissions` permission mode.
 
 ## Skill Setup
 
@@ -161,8 +164,6 @@ prose status
 passes deterministic IR validation with no error diagnostics. If an agent
 harness reports a stray nonzero status after writing a valid manifest, the CLI
 warns and accepts the validated artifact. Abort and signal exits are preserved.
-If a harness cannot directly write the artifact but returns a valid manifest in
-the compiler's marked output block, the CLI validates and writes it.
 When no source path is supplied, the CLI forwards `src` as the compiler source
 root; this keeps repository compiles non-interactive while preserving the
 documented default.

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -83,7 +83,9 @@ PROSE_HARNESS=claude-sdk prose run std/evals/inspector
 - `codex-sdk` uses `@openai/codex-sdk`, forwards the current working directory
   and environment, and streams Codex SDK events. This is the default.
 - `claude-sdk` uses `@anthropic-ai/claude-agent-sdk`, forwards the current
-  working directory and environment, and streams text deltas.
+  working directory and environment, streams text deltas, and defaults to
+  `acceptEdits` with basic filesystem tools auto-allowed so non-interactive
+  commands can write declared artifacts.
 - `mock` echoes prompts for tests and local smoke checks.
 
 Select a harness with `--harness <name>` or `PROSE_HARNESS`.
@@ -96,6 +98,10 @@ For externally sandboxed CI environments, Codex harnesses also honor
 `PROSE_CODEX_SANDBOX_MODE` (`read-only`, `workspace-write`, or
 `danger-full-access`) and `PROSE_CODEX_APPROVAL_POLICY` (`never`, `on-request`,
 `on-failure`, or `untrusted`) and forward those values to Codex.
+
+Claude harnesses honor `ANTHROPIC_MODEL` or `PROSE_CLAUDE_MODEL` for model
+selection, plus `PROSE_CLAUDE_PERMISSION_MODE` when callers need to override
+the default `acceptEdits` permission mode.
 
 ## Skill Setup
 
@@ -155,6 +161,11 @@ prose status
 passes deterministic IR validation with no error diagnostics. If an agent
 harness reports a stray nonzero status after writing a valid manifest, the CLI
 warns and accepts the validated artifact. Abort and signal exits are preserved.
+If a harness cannot directly write the artifact but returns a valid manifest in
+the compiler's marked output block, the CLI validates and writes it.
+When no source path is supplied, the CLI forwards `src` as the compiler source
+root; this keeps repository compiles non-interactive while preserving the
+documented default.
 
 `prose serve` loads and validates `dist/manifest.active.json` under the active
 OpenProse root, registers local cron and HTTP trigger adapters, and launches

--- a/tools/cli/src/commands/compile.ts
+++ b/tools/cli/src/commands/compile.ts
@@ -105,7 +105,10 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 		...(options.skillBootstrap === undefined ? {} : { skillBootstrap: options.skillBootstrap }),
 		...(options.skillPreflight === undefined ? {} : { skillPreflight: options.skillPreflight }),
 	});
-	await writeReturnedCompiledManifest(stdoutCapture.text(), target, options.stderr);
+	if (exitCode !== 0 && (options.signal?.aborted || isSignalExitCode(exitCode))) {
+		return exitCode;
+	}
+	await writeReturnedCompiledManifest(stdoutCapture.text(), target, options.stderr, { strict: exitCode === 0 });
 	if (exitCode !== 0) {
 		if (await shouldAcceptNonzeroCompiledManifest(exitCode, options, target)) {
 			options.stderr.write(
@@ -142,8 +145,13 @@ async function writeReturnedCompiledManifest(
 	stdout: string,
 	target: { absoluteManifestPath: string; manifestPath: string },
 	stderr: WritableStreamLike,
+	options: { strict: boolean },
 ): Promise<void> {
-	const returnedManifest = parseReturnedCompiledManifest(stdout);
+	if (await compiledManifestFileExists(target.absoluteManifestPath)) {
+		return;
+	}
+
+	const returnedManifest = parseReturnedCompiledManifest(stdout, options);
 	if (returnedManifest === undefined) {
 		return;
 	}
@@ -153,7 +161,20 @@ async function writeReturnedCompiledManifest(
 	stderr.write(`Compiler returned valid repository IR; wrote ${target.manifestPath}.\n`);
 }
 
-function parseReturnedCompiledManifest(stdout: string): unknown | undefined {
+async function compiledManifestFileExists(path: string): Promise<boolean> {
+	try {
+		await readFile(path, "utf8");
+		return true;
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return false;
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		throw new CompileValidationError("Unable to inspect compiled repository IR after compile.", [message]);
+	}
+}
+
+function parseReturnedCompiledManifest(stdout: string, options: { strict: boolean }): unknown | undefined {
 	const start = stdout.lastIndexOf(RETURNED_MANIFEST_START);
 	if (start === -1) {
 		return undefined;
@@ -161,6 +182,9 @@ function parseReturnedCompiledManifest(stdout: string): unknown | undefined {
 	const contentStart = start + RETURNED_MANIFEST_START.length;
 	const end = stdout.indexOf(RETURNED_MANIFEST_END, contentStart);
 	if (end === -1) {
+		if (!options.strict) {
+			return undefined;
+		}
 		throw new CompileValidationError("Compiler returned repository IR without a closing manifest marker.", [
 			`missing ${RETURNED_MANIFEST_END}`,
 		]);
@@ -170,12 +194,18 @@ function parseReturnedCompiledManifest(stdout: string): unknown | undefined {
 	try {
 		parsed = JSON.parse(stdout.slice(contentStart, end).trim());
 	} catch (error) {
+		if (!options.strict) {
+			return undefined;
+		}
 		const message = error instanceof Error ? error.message : String(error);
 		throw new CompileValidationError("Compiler returned repository IR is not valid JSON.", [message]);
 	}
 
 	const validation = validateRepositoryIr(parsed);
 	if (!validation.valid) {
+		if (!options.strict) {
+			return undefined;
+		}
 		throw new CompileValidationError("Compiler returned repository IR is invalid.", validation.errors);
 	}
 

--- a/tools/cli/src/commands/compile.ts
+++ b/tools/cli/src/commands/compile.ts
@@ -1,6 +1,6 @@
 import { Command } from "@oclif/core";
-import { readFile, unlink } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import type { Harness, WritableStreamLike } from "../harnesses/types.js";
 import {
 	CommandModelError,
@@ -26,6 +26,9 @@ export class CompileValidationError extends Error {
 		this.details = [...details];
 	}
 }
+
+const RETURNED_MANIFEST_START = "<openprose-compiled-manifest>";
+const RETURNED_MANIFEST_END = "</openprose-compiled-manifest>";
 
 export interface RunCompileCommandOptions {
 	argv: readonly string[];
@@ -81,25 +84,28 @@ export default class Compile extends Command {
 }
 
 export async function runCompileCommand(options: RunCompileCommandOptions): Promise<number> {
+	const argv = withDefaultCompileSource(options.argv, options.env);
 	const target = await resolveCompiledManifestTarget({
-		argv: options.argv,
+		argv,
 		cwd: options.cwd,
 		env: options.env,
 	});
 	await removePreviousCompiledManifest(target.absoluteManifestPath);
+	const stdoutCapture = createStdoutCapture(options.stdout);
 
 	const exitCode = await runForwardedProseCommand({
 		command: "compile",
-		argv: options.argv,
+		argv,
 		cwd: options.cwd,
 		env: options.env,
-		stdout: options.stdout,
+		stdout: stdoutCapture.stream,
 		stderr: options.stderr,
 		...(options.signal === undefined ? {} : { signal: options.signal }),
 		...(options.harnessFactory === undefined ? {} : { harnessFactory: options.harnessFactory }),
 		...(options.skillBootstrap === undefined ? {} : { skillBootstrap: options.skillBootstrap }),
 		...(options.skillPreflight === undefined ? {} : { skillPreflight: options.skillPreflight }),
 	});
+	await writeReturnedCompiledManifest(stdoutCapture.text(), target, options.stderr);
 	if (exitCode !== 0) {
 		if (await shouldAcceptNonzeroCompiledManifest(exitCode, options, target)) {
 			options.stderr.write(
@@ -111,12 +117,97 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 	}
 
 	await validateCompiledRepositoryIr({
-		argv: options.argv,
+		argv,
 		cwd: options.cwd,
 		env: options.env,
 		...target,
 	});
 	return 0;
+}
+
+function createStdoutCapture(stdout: WritableStreamLike): { stream: WritableStreamLike; text: () => string } {
+	let captured = "";
+	return {
+		stream: {
+			write(chunk: string) {
+				captured += chunk;
+				return stdout.write(chunk);
+			},
+		},
+		text: () => captured,
+	};
+}
+
+async function writeReturnedCompiledManifest(
+	stdout: string,
+	target: { absoluteManifestPath: string; manifestPath: string },
+	stderr: WritableStreamLike,
+): Promise<void> {
+	const returnedManifest = parseReturnedCompiledManifest(stdout);
+	if (returnedManifest === undefined) {
+		return;
+	}
+
+	await mkdir(dirname(target.absoluteManifestPath), { recursive: true });
+	await writeFile(target.absoluteManifestPath, `${JSON.stringify(returnedManifest, null, 2)}\n`, "utf8");
+	stderr.write(`Compiler returned valid repository IR; wrote ${target.manifestPath}.\n`);
+}
+
+function parseReturnedCompiledManifest(stdout: string): unknown | undefined {
+	const start = stdout.lastIndexOf(RETURNED_MANIFEST_START);
+	if (start === -1) {
+		return undefined;
+	}
+	const contentStart = start + RETURNED_MANIFEST_START.length;
+	const end = stdout.indexOf(RETURNED_MANIFEST_END, contentStart);
+	if (end === -1) {
+		throw new CompileValidationError("Compiler returned repository IR without a closing manifest marker.", [
+			`missing ${RETURNED_MANIFEST_END}`,
+		]);
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout.slice(contentStart, end).trim());
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new CompileValidationError("Compiler returned repository IR is not valid JSON.", [message]);
+	}
+
+	const validation = validateRepositoryIr(parsed);
+	if (!validation.valid) {
+		throw new CompileValidationError("Compiler returned repository IR is invalid.", validation.errors);
+	}
+
+	return parsed;
+}
+
+function withDefaultCompileSource(
+	argv: readonly string[],
+	env: Readonly<Record<string, string | undefined>>,
+): string[] {
+	const { args } = splitHarnessArgs(argv, env, "compile");
+	return compileArgsHaveSource(args) ? [...argv] : ["src", ...argv];
+}
+
+function compileArgsHaveSource(args: readonly string[]): boolean {
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === undefined) {
+			continue;
+		}
+		if (arg === "--out") {
+			index += 1;
+			continue;
+		}
+		if (arg.startsWith("--out=")) {
+			continue;
+		}
+		if (!arg.startsWith("-")) {
+			return true;
+		}
+	}
+	return false;
 }
 
 async function shouldAcceptNonzeroCompiledManifest(

--- a/tools/cli/src/commands/compile.ts
+++ b/tools/cli/src/commands/compile.ts
@@ -1,6 +1,6 @@
 import { Command } from "@oclif/core";
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { readFile, unlink } from "node:fs/promises";
+import { resolve } from "node:path";
 import type { Harness, WritableStreamLike } from "../harnesses/types.js";
 import {
 	CommandModelError,
@@ -26,9 +26,6 @@ export class CompileValidationError extends Error {
 		this.details = [...details];
 	}
 }
-
-const RETURNED_MANIFEST_START = "<openprose-compiled-manifest>";
-const RETURNED_MANIFEST_END = "</openprose-compiled-manifest>";
 
 export interface RunCompileCommandOptions {
 	argv: readonly string[];
@@ -91,24 +88,19 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 		env: options.env,
 	});
 	await removePreviousCompiledManifest(target.absoluteManifestPath);
-	const stdoutCapture = createStdoutCapture(options.stdout);
 
 	const exitCode = await runForwardedProseCommand({
 		command: "compile",
 		argv,
 		cwd: options.cwd,
 		env: options.env,
-		stdout: stdoutCapture.stream,
+		stdout: options.stdout,
 		stderr: options.stderr,
 		...(options.signal === undefined ? {} : { signal: options.signal }),
 		...(options.harnessFactory === undefined ? {} : { harnessFactory: options.harnessFactory }),
 		...(options.skillBootstrap === undefined ? {} : { skillBootstrap: options.skillBootstrap }),
 		...(options.skillPreflight === undefined ? {} : { skillPreflight: options.skillPreflight }),
 	});
-	if (exitCode !== 0 && (options.signal?.aborted || isSignalExitCode(exitCode))) {
-		return exitCode;
-	}
-	await writeReturnedCompiledManifest(stdoutCapture.text(), target, options.stderr, { strict: exitCode === 0 });
 	if (exitCode !== 0) {
 		if (await shouldAcceptNonzeroCompiledManifest(exitCode, options, target)) {
 			options.stderr.write(
@@ -126,90 +118,6 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 		...target,
 	});
 	return 0;
-}
-
-function createStdoutCapture(stdout: WritableStreamLike): { stream: WritableStreamLike; text: () => string } {
-	let captured = "";
-	return {
-		stream: {
-			write(chunk: string) {
-				captured += chunk;
-				return stdout.write(chunk);
-			},
-		},
-		text: () => captured,
-	};
-}
-
-async function writeReturnedCompiledManifest(
-	stdout: string,
-	target: { absoluteManifestPath: string; manifestPath: string },
-	stderr: WritableStreamLike,
-	options: { strict: boolean },
-): Promise<void> {
-	if (await compiledManifestFileExists(target.absoluteManifestPath)) {
-		return;
-	}
-
-	const returnedManifest = parseReturnedCompiledManifest(stdout, options);
-	if (returnedManifest === undefined) {
-		return;
-	}
-
-	await mkdir(dirname(target.absoluteManifestPath), { recursive: true });
-	await writeFile(target.absoluteManifestPath, `${JSON.stringify(returnedManifest, null, 2)}\n`, "utf8");
-	stderr.write(`Compiler returned valid repository IR; wrote ${target.manifestPath}.\n`);
-}
-
-async function compiledManifestFileExists(path: string): Promise<boolean> {
-	try {
-		await readFile(path, "utf8");
-		return true;
-	} catch (error) {
-		if (isNodeError(error) && error.code === "ENOENT") {
-			return false;
-		}
-		const message = error instanceof Error ? error.message : String(error);
-		throw new CompileValidationError("Unable to inspect compiled repository IR after compile.", [message]);
-	}
-}
-
-function parseReturnedCompiledManifest(stdout: string, options: { strict: boolean }): unknown | undefined {
-	const start = stdout.lastIndexOf(RETURNED_MANIFEST_START);
-	if (start === -1) {
-		return undefined;
-	}
-	const contentStart = start + RETURNED_MANIFEST_START.length;
-	const end = stdout.indexOf(RETURNED_MANIFEST_END, contentStart);
-	if (end === -1) {
-		if (!options.strict) {
-			return undefined;
-		}
-		throw new CompileValidationError("Compiler returned repository IR without a closing manifest marker.", [
-			`missing ${RETURNED_MANIFEST_END}`,
-		]);
-	}
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(stdout.slice(contentStart, end).trim());
-	} catch (error) {
-		if (!options.strict) {
-			return undefined;
-		}
-		const message = error instanceof Error ? error.message : String(error);
-		throw new CompileValidationError("Compiler returned repository IR is not valid JSON.", [message]);
-	}
-
-	const validation = validateRepositoryIr(parsed);
-	if (!validation.valid) {
-		if (!options.strict) {
-			return undefined;
-		}
-		throw new CompileValidationError("Compiler returned repository IR is invalid.", validation.errors);
-	}
-
-	return parsed;
 }
 
 function withDefaultCompileSource(

--- a/tools/cli/src/harnesses/claude-sdk.ts
+++ b/tools/cli/src/harnesses/claude-sdk.ts
@@ -27,7 +27,8 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 		async run(prompt, runOptions) {
 			const abortController = bridgeAbortController(runOptions.signal);
 			const model = claudeModel(runOptions.env);
-			const permissionMode = claudePermissionMode(runOptions.env);
+			const isCompile = isCompilePrompt(prompt);
+			const permissionMode = claudePermissionMode(runOptions.env, isCompile ? "acceptEdits" : undefined);
 			const stream = await Promise.resolve(
 				query({
 					prompt,
@@ -39,15 +40,19 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 						...(runOptions.cwd === undefined ? {} : { cwd: runOptions.cwd }),
 						...(runOptions.env === undefined ? {} : { env: runOptions.env }),
 						includePartialMessages: true,
-						allowedTools: [...CLAUDE_AUTO_ALLOW_RULES],
 						...(model === undefined ? {} : { model }),
-						permissionMode,
-						settings: {
-							permissions: {
-								allow: [...CLAUDE_AUTO_ALLOW_RULES],
-								defaultMode: permissionMode,
-							},
-						},
+						...(isCompile
+							? {
+									allowedTools: [...CLAUDE_AUTO_ALLOW_RULES],
+									settings: {
+										permissions: {
+											allow: [...CLAUDE_AUTO_ALLOW_RULES],
+											defaultMode: permissionMode ?? "acceptEdits",
+										},
+									},
+								}
+							: {}),
+						...(permissionMode === undefined ? {} : { permissionMode }),
 						...(permissionMode === "bypassPermissions" ? { allowDangerouslySkipPermissions: true } : {}),
 						stderr: (chunk: string) => runOptions.stderr.write(chunk),
 						...(runOptions.systemPromptAppend === undefined
@@ -103,6 +108,10 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 	};
 }
 
+function isCompilePrompt(prompt: string): boolean {
+	return prompt === "prose compile" || prompt.startsWith("prose compile ");
+}
+
 function claudeModel(env: Readonly<Record<string, string | undefined>> | undefined): string | undefined {
 	const value = env?.PROSE_CLAUDE_MODEL ?? env?.ANTHROPIC_MODEL ?? process.env.PROSE_CLAUDE_MODEL ?? process.env.ANTHROPIC_MODEL;
 	if (value === undefined || value.trim() === "") {
@@ -111,10 +120,13 @@ function claudeModel(env: Readonly<Record<string, string | undefined>> | undefin
 	return value;
 }
 
-function claudePermissionMode(env: Readonly<Record<string, string | undefined>> | undefined): ClaudePermissionMode {
+function claudePermissionMode(
+	env: Readonly<Record<string, string | undefined>> | undefined,
+	fallback: ClaudePermissionMode | undefined,
+): ClaudePermissionMode | undefined {
 	const value = env?.PROSE_CLAUDE_PERMISSION_MODE ?? process.env.PROSE_CLAUDE_PERMISSION_MODE;
 	if (value === undefined || value === "") {
-		return "acceptEdits";
+		return fallback;
 	}
 	if (CLAUDE_PERMISSION_MODES.includes(value as ClaudePermissionMode)) {
 		return value as ClaudePermissionMode;

--- a/tools/cli/src/harnesses/claude-sdk.ts
+++ b/tools/cli/src/harnesses/claude-sdk.ts
@@ -9,6 +9,7 @@ type ClaudePermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "p
 
 const CLAUDE_PERMISSION_MODES = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
 const CLAUDE_AUTO_ALLOW_RULES = ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"] as const;
+const DEFAULT_CLAUDE_PERMISSION_MODE = "bypassPermissions";
 
 export interface ClaudeSdkHarnessOptions {
 	query?: ClaudeSdkQueryLike;
@@ -27,8 +28,7 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 		async run(prompt, runOptions) {
 			const abortController = bridgeAbortController(runOptions.signal);
 			const model = claudeModel(runOptions.env);
-			const isCompile = isCompilePrompt(prompt);
-			const permissionMode = claudePermissionMode(runOptions.env, isCompile ? "acceptEdits" : undefined);
+			const permissionMode = claudePermissionMode(runOptions.env);
 			const stream = await Promise.resolve(
 				query({
 					prompt,
@@ -41,18 +41,14 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 						...(runOptions.env === undefined ? {} : { env: runOptions.env }),
 						includePartialMessages: true,
 						...(model === undefined ? {} : { model }),
-						...(isCompile
-							? {
-									allowedTools: [...CLAUDE_AUTO_ALLOW_RULES],
-									settings: {
-										permissions: {
-											allow: [...CLAUDE_AUTO_ALLOW_RULES],
-											defaultMode: permissionMode ?? "acceptEdits",
-										},
-									},
-								}
-							: {}),
-						...(permissionMode === undefined ? {} : { permissionMode }),
+						allowedTools: [...CLAUDE_AUTO_ALLOW_RULES],
+						permissionMode,
+						settings: {
+							permissions: {
+								allow: [...CLAUDE_AUTO_ALLOW_RULES],
+								defaultMode: permissionMode,
+							},
+						},
 						...(permissionMode === "bypassPermissions" ? { allowDangerouslySkipPermissions: true } : {}),
 						stderr: (chunk: string) => runOptions.stderr.write(chunk),
 						...(runOptions.systemPromptAppend === undefined
@@ -108,10 +104,6 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 	};
 }
 
-function isCompilePrompt(prompt: string): boolean {
-	return prompt === "prose compile" || prompt.startsWith("prose compile ");
-}
-
 function claudeModel(env: Readonly<Record<string, string | undefined>> | undefined): string | undefined {
 	const value = env?.PROSE_CLAUDE_MODEL ?? env?.ANTHROPIC_MODEL ?? process.env.PROSE_CLAUDE_MODEL ?? process.env.ANTHROPIC_MODEL;
 	if (value === undefined || value.trim() === "") {
@@ -120,13 +112,10 @@ function claudeModel(env: Readonly<Record<string, string | undefined>> | undefin
 	return value;
 }
 
-function claudePermissionMode(
-	env: Readonly<Record<string, string | undefined>> | undefined,
-	fallback: ClaudePermissionMode | undefined,
-): ClaudePermissionMode | undefined {
+function claudePermissionMode(env: Readonly<Record<string, string | undefined>> | undefined): ClaudePermissionMode {
 	const value = env?.PROSE_CLAUDE_PERMISSION_MODE ?? process.env.PROSE_CLAUDE_PERMISSION_MODE;
 	if (value === undefined || value === "") {
-		return fallback;
+		return DEFAULT_CLAUDE_PERMISSION_MODE;
 	}
 	if (CLAUDE_PERMISSION_MODES.includes(value as ClaudePermissionMode)) {
 		return value as ClaudePermissionMode;

--- a/tools/cli/src/harnesses/claude-sdk.ts
+++ b/tools/cli/src/harnesses/claude-sdk.ts
@@ -5,6 +5,10 @@ export type ClaudeSdkQuery = typeof import("@anthropic-ai/claude-agent-sdk").que
 export type ClaudeSdkQueryResult = ReturnType<ClaudeSdkQuery>;
 export type ClaudeSdkMessage = ClaudeSdkQueryResult extends AsyncIterable<infer Message> ? Message : never;
 export type ClaudeSdkQueryLike = (...args: Parameters<ClaudeSdkQuery>) => ClaudeSdkQueryResult | Promise<ClaudeSdkQueryResult>;
+type ClaudePermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk";
+
+const CLAUDE_PERMISSION_MODES = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
+const CLAUDE_AUTO_ALLOW_RULES = ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"] as const;
 
 export interface ClaudeSdkHarnessOptions {
 	query?: ClaudeSdkQueryLike;
@@ -22,6 +26,8 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 		name: "claude-sdk",
 		async run(prompt, runOptions) {
 			const abortController = bridgeAbortController(runOptions.signal);
+			const model = claudeModel(runOptions.env);
+			const permissionMode = claudePermissionMode(runOptions.env);
 			const stream = await Promise.resolve(
 				query({
 					prompt,
@@ -33,6 +39,16 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 						...(runOptions.cwd === undefined ? {} : { cwd: runOptions.cwd }),
 						...(runOptions.env === undefined ? {} : { env: runOptions.env }),
 						includePartialMessages: true,
+						allowedTools: [...CLAUDE_AUTO_ALLOW_RULES],
+						...(model === undefined ? {} : { model }),
+						permissionMode,
+						settings: {
+							permissions: {
+								allow: [...CLAUDE_AUTO_ALLOW_RULES],
+								defaultMode: permissionMode,
+							},
+						},
+						...(permissionMode === "bypassPermissions" ? { allowDangerouslySkipPermissions: true } : {}),
 						stderr: (chunk: string) => runOptions.stderr.write(chunk),
 						...(runOptions.systemPromptAppend === undefined
 							? {}
@@ -85,6 +101,25 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 			return runOptions.signal?.aborted ? 143 : exitCode;
 		},
 	};
+}
+
+function claudeModel(env: Readonly<Record<string, string | undefined>> | undefined): string | undefined {
+	const value = env?.PROSE_CLAUDE_MODEL ?? env?.ANTHROPIC_MODEL ?? process.env.PROSE_CLAUDE_MODEL ?? process.env.ANTHROPIC_MODEL;
+	if (value === undefined || value.trim() === "") {
+		return undefined;
+	}
+	return value;
+}
+
+function claudePermissionMode(env: Readonly<Record<string, string | undefined>> | undefined): ClaudePermissionMode {
+	const value = env?.PROSE_CLAUDE_PERMISSION_MODE ?? process.env.PROSE_CLAUDE_PERMISSION_MODE;
+	if (value === undefined || value === "") {
+		return "acceptEdits";
+	}
+	if (CLAUDE_PERMISSION_MODES.includes(value as ClaudePermissionMode)) {
+		return value as ClaudePermissionMode;
+	}
+	throw new Error(`PROSE_CLAUDE_PERMISSION_MODE must be one of: ${CLAUDE_PERMISSION_MODES.join(", ")}`);
 }
 
 function writeClaudeMessage(

--- a/tools/cli/src/harnesses/codex-options.ts
+++ b/tools/cli/src/harnesses/codex-options.ts
@@ -2,6 +2,8 @@ import type { CodexThreadOptions } from "./types.js";
 
 const CODEX_SANDBOX_MODES = ["read-only", "workspace-write", "danger-full-access"] as const;
 const CODEX_APPROVAL_POLICIES = ["never", "on-request", "on-failure", "untrusted"] as const;
+const DEFAULT_CODEX_SANDBOX_MODE = "danger-full-access";
+const DEFAULT_CODEX_APPROVAL_POLICY = "never";
 
 export function codexThreadRuntimeOptions(
 	env: Record<string, string | undefined> | undefined,
@@ -12,8 +14,8 @@ export function codexThreadRuntimeOptions(
 
 	return {
 		skipGitRepoCheck: true,
-		...(sandboxMode === undefined ? {} : { sandboxMode }),
-		...(approvalPolicy === undefined ? {} : { approvalPolicy }),
+		sandboxMode: sandboxMode ?? DEFAULT_CODEX_SANDBOX_MODE,
+		approvalPolicy: approvalPolicy ?? DEFAULT_CODEX_APPROVAL_POLICY,
 		...(additionalDirectories.length === 0 ? {} : { additionalDirectories: [...additionalDirectories] }),
 	};
 }

--- a/tools/cli/src/skills/open-prose.ts
+++ b/tools/cli/src/skills/open-prose.ts
@@ -119,7 +119,7 @@ export function buildOpenProseSkillBootstrapPrompt(options: {
 		"When additional OpenProse skill files are needed, read them from that skill root.",
 		"Do not invoke the `prose`, `npx prose`, or `@openprose/prose-cli` shell command; that would recursively call this wrapper.",
 		"CLI runs are non-interactive. Do not ask the user for permission to write declared OpenProse artifacts under the current OpenProse root.",
-		"For `prose compile`, the command itself grants permission to create or replace `dist/manifest.next.json` or the requested `--out` manifest.",
+		"For `prose compile`, the command itself grants permission to create or replace `dist/manifest.next.json` or the requested `--out` directory's `manifest.next.json`.",
 		"</open-prose-introduction>",
 		"",
 		"<open-prose-skill>",

--- a/tools/cli/src/skills/open-prose.ts
+++ b/tools/cli/src/skills/open-prose.ts
@@ -118,6 +118,8 @@ export function buildOpenProseSkillBootstrapPrompt(options: {
 		"Resolve every file referenced by this SKILL.md relative to the OpenProse skill root.",
 		"When additional OpenProse skill files are needed, read them from that skill root.",
 		"Do not invoke the `prose`, `npx prose`, or `@openprose/prose-cli` shell command; that would recursively call this wrapper.",
+		"CLI runs are non-interactive. Do not ask the user for permission to write declared OpenProse artifacts under the current OpenProse root.",
+		"For `prose compile`, the command itself grants permission to create or replace `dist/manifest.next.json` or the requested `--out` manifest.",
 		"</open-prose-introduction>",
 		"",
 		"<open-prose-skill>",

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -300,6 +300,38 @@ FORWARDED_BOOTSTRAP_SENTINEL
 });
 
 describe("runCompileCommand", () => {
+	it("defaults pathless compile commands to the repository src directory", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-default-src-"));
+		const io = memoryStreams();
+		const prompts: string[] = [];
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: ["--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run(prompt) {
+						prompts.push(prompt);
+						mkdirSync(join(temp, "dist"), { recursive: true });
+						copyFileSync(stargazerFixture, join(temp, "dist/manifest.next.json"));
+						return 0;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(0);
+			expect(prompts).toEqual(["prose compile src"]);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
 	it("validates the manifest emitted by the intelligent compiler", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-compile-valid-"));
 		const io = memoryStreams();
@@ -324,6 +356,42 @@ describe("runCompileCommand", () => {
 			});
 
 			expect(exitCode).toBe(0);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("writes a valid manifest returned by the compiler", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-returned-"));
+		const io = memoryStreams();
+		const manifest = readFileSync(stargazerFixture, "utf8").trim();
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run(_prompt, options) {
+						options.stdout.write(
+							`summary\n<openprose-compiled-manifest>\n${manifest}\n</openprose-compiled-manifest>\n`,
+						);
+						return 0;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(0);
+			expect(JSON.parse(readFileSync(join(temp, "dist/manifest.next.json"), "utf8"))).toMatchObject({
+				kind: "openprose.repository-ir",
+				version: 0,
+			});
+			expect(io.stderr).toContain("Compiler returned valid repository IR; wrote dist/manifest.next.json.");
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -361,68 +361,35 @@ describe("runCompileCommand", () => {
 		}
 	});
 
-	it("writes a valid manifest returned by the compiler", async () => {
-		const temp = mkdtempSync(join(tmpdir(), "prose-compile-returned-"));
+	it("does not treat marked stdout as a compile artifact", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-marked-stdout-"));
 		const io = memoryStreams();
 		const manifest = readFileSync(stargazerFixture, "utf8").trim();
 
 		try {
-			const exitCode = await runCompileCommand({
-				argv: [".", "--harness", "mock"],
-				cwd: temp,
-				env: {},
-				stdout: io.streams.stdout,
-				stderr: io.streams.stderr,
-				skillBootstrap: false,
-				skillPreflight: false,
-				harnessFactory: () => ({
-					name: "mock",
-					async run(_prompt, options) {
-						options.stdout.write(
-							`summary\n<openprose-compiled-manifest>\n${manifest}\n</openprose-compiled-manifest>\n`,
-						);
-						return 0;
-					},
+			await expect(
+				runCompileCommand({
+					argv: [".", "--harness", "mock"],
+					cwd: temp,
+					env: {},
+					stdout: io.streams.stdout,
+					stderr: io.streams.stderr,
+					skillBootstrap: false,
+					skillPreflight: false,
+					harnessFactory: () => ({
+						name: "mock",
+						async run(_prompt, options) {
+							options.stdout.write(
+								`summary\n<openprose-compiled-manifest>\n${manifest}\n</openprose-compiled-manifest>\n`,
+							);
+							return 0;
+						},
+					}),
 				}),
+			).rejects.toMatchObject({
+				name: "CompileValidationError",
+				message: "Compiled repository IR was not written to dist/manifest.next.json.",
 			});
-
-			expect(exitCode).toBe(0);
-			expect(JSON.parse(readFileSync(join(temp, "dist/manifest.next.json"), "utf8"))).toMatchObject({
-				kind: "openprose.repository-ir",
-				version: 0,
-			});
-			expect(io.stderr).toContain("Compiler returned valid repository IR; wrote dist/manifest.next.json.");
-		} finally {
-			rmSync(temp, { recursive: true, force: true });
-		}
-	});
-
-	it("prefers a written manifest over marked stdout", async () => {
-		const temp = mkdtempSync(join(tmpdir(), "prose-compile-written-over-returned-"));
-		const io = memoryStreams();
-
-		try {
-			const exitCode = await runCompileCommand({
-				argv: [".", "--harness", "mock"],
-				cwd: temp,
-				env: {},
-				stdout: io.streams.stdout,
-				stderr: io.streams.stderr,
-				skillBootstrap: false,
-				skillPreflight: false,
-				harnessFactory: () => ({
-					name: "mock",
-					async run(_prompt, options) {
-						mkdirSync(join(temp, "dist"), { recursive: true });
-						copyFileSync(stargazerFixture, join(temp, "dist/manifest.next.json"));
-						options.stdout.write("<openprose-compiled-manifest>\nnot json\n</openprose-compiled-manifest>\n");
-						return 0;
-					},
-				}),
-			});
-
-			expect(exitCode).toBe(0);
-			expect(io.stderr).not.toContain("Compiler returned valid repository IR");
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}
@@ -516,37 +483,6 @@ describe("runCompileCommand", () => {
 
 			expect(exitCode).toBe(143);
 			expect(io.stderr).not.toContain("accepting dist/manifest.next.json");
-		} finally {
-			rmSync(temp, { recursive: true, force: true });
-		}
-	});
-
-	it("preserves abort exits after a partial returned manifest", async () => {
-		const temp = mkdtempSync(join(tmpdir(), "prose-compile-abort-partial-return-"));
-		const io = memoryStreams();
-		const controller = new AbortController();
-
-		try {
-			const exitCode = await runCompileCommand({
-				argv: [".", "--harness", "mock"],
-				cwd: temp,
-				env: {},
-				stdout: io.streams.stdout,
-				stderr: io.streams.stderr,
-				signal: controller.signal,
-				skillBootstrap: false,
-				skillPreflight: false,
-				harnessFactory: () => ({
-					name: "mock",
-					async run(_prompt, options) {
-						options.stdout.write("<openprose-compiled-manifest>\n");
-						controller.abort("SIGTERM");
-						return 143;
-					},
-				}),
-			});
-
-			expect(exitCode).toBe(143);
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -397,6 +397,37 @@ describe("runCompileCommand", () => {
 		}
 	});
 
+	it("prefers a written manifest over marked stdout", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-written-over-returned-"));
+		const io = memoryStreams();
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run(_prompt, options) {
+						mkdirSync(join(temp, "dist"), { recursive: true });
+						copyFileSync(stargazerFixture, join(temp, "dist/manifest.next.json"));
+						options.stdout.write("<openprose-compiled-manifest>\nnot json\n</openprose-compiled-manifest>\n");
+						return 0;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(0);
+			expect(io.stderr).not.toContain("Compiler returned valid repository IR");
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
 	it("accepts a valid manifest when the compiler harness exits nonzero after writing it", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-compile-valid-nonzero-"));
 		const io = memoryStreams();
@@ -485,6 +516,37 @@ describe("runCompileCommand", () => {
 
 			expect(exitCode).toBe(143);
 			expect(io.stderr).not.toContain("accepting dist/manifest.next.json");
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves abort exits after a partial returned manifest", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-abort-partial-return-"));
+		const io = memoryStreams();
+		const controller = new AbortController();
+
+		try {
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				signal: controller.signal,
+				skillBootstrap: false,
+				skillPreflight: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run(_prompt, options) {
+						options.stdout.write("<openprose-compiled-manifest>\n");
+						controller.abort("SIGTERM");
+						return 143;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(143);
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -269,6 +269,39 @@ describe("claude-sdk harness", () => {
 		]);
 	});
 
+	test("leaves non-compile Claude SDK runs on default permissions", async () => {
+		const io = memoryStreams();
+		const calls: unknown[] = [];
+		const harness = createClaudeSdkHarness({
+			query: async (args) => {
+				calls.push(args);
+				return {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "result", subtype: "success", result: "ok", is_error: false };
+					},
+					close() {},
+				} as never;
+			},
+		});
+
+		const exitCode = await harness.run("prose status", {
+			...io.options,
+			env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
+		});
+
+		expect(exitCode).toBe(0);
+		expect(calls).toEqual([
+			{
+				prompt: "prose status",
+				options: expect.not.objectContaining({
+					allowedTools: expect.anything(),
+					permissionMode: expect.anything(),
+					settings: expect.anything(),
+				}),
+			},
+		]);
+	});
+
 	test("streams text deltas without duplicating final result", async () => {
 		const io = memoryStreams();
 		const abortControllers: AbortController[] = [];

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -229,6 +229,46 @@ describe("claude-sdk harness", () => {
 		]);
 	});
 
+	test("selects Claude model from env and defaults to non-interactive edit mode", async () => {
+		const io = memoryStreams();
+		const calls: unknown[] = [];
+		const harness = createClaudeSdkHarness({
+			query: async (args) => {
+				calls.push(args);
+				return {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "result", subtype: "success", result: "ok", is_error: false };
+					},
+					close() {},
+				} as never;
+			},
+		});
+
+		const exitCode = await harness.run("prose compile src", {
+			...io.options,
+			env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
+		});
+
+		expect(exitCode).toBe(0);
+		expect(calls).toEqual([
+			{
+				prompt: "prose compile src",
+				options: expect.objectContaining({
+					env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
+					allowedTools: ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"],
+					model: "claude-sonnet-4-6",
+					permissionMode: "acceptEdits",
+					settings: {
+						permissions: {
+							allow: ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"],
+							defaultMode: "acceptEdits",
+						},
+					},
+				}),
+			},
+		]);
+	});
+
 	test("streams text deltas without duplicating final result", async () => {
 		const io = memoryStreams();
 		const abortControllers: AbortController[] = [];

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -92,7 +92,14 @@ describe("codex-sdk harness", () => {
 
 		expect(exitCode).toBe(0);
 		expect(io.stdout).toBe("sdk output\n");
-		expect(starts).toEqual([{ skipGitRepoCheck: true, workingDirectory: "/repo" }]);
+		expect(starts).toEqual([
+			{
+				approvalPolicy: "never",
+				sandboxMode: "danger-full-access",
+				skipGitRepoCheck: true,
+				workingDirectory: "/repo",
+			},
+		]);
 		expect(factoryOptions).toEqual([{ apiKey: "test", env: { OPENAI_API_KEY: "test" } }]);
 	});
 
@@ -127,6 +134,8 @@ describe("codex-sdk harness", () => {
 		expect(starts).toEqual([
 			{
 				additionalDirectories: ["/skills/open-prose"],
+				approvalPolicy: "never",
+				sandboxMode: "danger-full-access",
 				skipGitRepoCheck: true,
 			},
 		]);
@@ -160,13 +169,13 @@ describe("codex-sdk harness", () => {
 		const exitCode = await createCodexSdkHarness({ factory }).run("prose run inspector.prose.md", {
 			...io.options,
 			env: {
-				PROSE_CODEX_APPROVAL_POLICY: "never",
-				PROSE_CODEX_SANDBOX_MODE: "danger-full-access",
+				PROSE_CODEX_APPROVAL_POLICY: "on-request",
+				PROSE_CODEX_SANDBOX_MODE: "workspace-write",
 			},
 		});
 
 		expect(exitCode).toBe(0);
-		expect(starts).toEqual([{ approvalPolicy: "never", sandboxMode: "danger-full-access", skipGitRepoCheck: true }]);
+		expect(starts).toEqual([{ approvalPolicy: "on-request", sandboxMode: "workspace-write", skipGitRepoCheck: true }]);
 	});
 
 	test("maps failed turns to stderr and nonzero exit", async () => {
@@ -229,7 +238,7 @@ describe("claude-sdk harness", () => {
 		]);
 	});
 
-	test("selects Claude model from env and defaults to non-interactive edit mode", async () => {
+	test("selects Claude model from env and defaults to permissive non-interactive mode", async () => {
 		const io = memoryStreams();
 		const calls: unknown[] = [];
 		const harness = createClaudeSdkHarness({
@@ -244,7 +253,7 @@ describe("claude-sdk harness", () => {
 			},
 		});
 
-		const exitCode = await harness.run("prose compile src", {
+		const exitCode = await harness.run("prose run inspector.prose.md", {
 			...io.options,
 			env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
 		});
@@ -252,16 +261,17 @@ describe("claude-sdk harness", () => {
 		expect(exitCode).toBe(0);
 		expect(calls).toEqual([
 			{
-				prompt: "prose compile src",
+				prompt: "prose run inspector.prose.md",
 				options: expect.objectContaining({
 					env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
 					allowedTools: ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"],
 					model: "claude-sonnet-4-6",
-					permissionMode: "acceptEdits",
+					permissionMode: "bypassPermissions",
+					allowDangerouslySkipPermissions: true,
 					settings: {
 						permissions: {
 							allow: ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"],
-							defaultMode: "acceptEdits",
+							defaultMode: "bypassPermissions",
 						},
 					},
 				}),
@@ -269,7 +279,7 @@ describe("claude-sdk harness", () => {
 		]);
 	});
 
-	test("leaves non-compile Claude SDK runs on default permissions", async () => {
+	test("honors Claude permission overrides from env", async () => {
 		const io = memoryStreams();
 		const calls: unknown[] = [];
 		const harness = createClaudeSdkHarness({
@@ -286,17 +296,25 @@ describe("claude-sdk harness", () => {
 
 		const exitCode = await harness.run("prose status", {
 			...io.options,
-			env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
+			env: {
+				ANTHROPIC_MODEL: "claude-sonnet-4-6",
+				PROSE_CLAUDE_PERMISSION_MODE: "acceptEdits",
+			},
 		});
 
 		expect(exitCode).toBe(0);
 		expect(calls).toEqual([
 			{
 				prompt: "prose status",
-				options: expect.not.objectContaining({
-					allowedTools: expect.anything(),
-					permissionMode: expect.anything(),
-					settings: expect.anything(),
+				options: expect.objectContaining({
+					allowedTools: ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"],
+					permissionMode: "acceptEdits",
+					settings: {
+						permissions: {
+							allow: ["Read(*)", "Glob(*)", "Grep(*)", "Write(*)", "Edit(*)", "MultiEdit(*)"],
+							defaultMode: "acceptEdits",
+						},
+					},
 				}),
 			},
 		]);

--- a/tools/cli/tests/skills/open-prose.test.ts
+++ b/tools/cli/tests/skills/open-prose.test.ts
@@ -70,6 +70,8 @@ describe("OpenProse skill checks", () => {
 		expect(bootstrap).toContain("OpenProse SKILL.md path: /home/prose/.agents/skills/open-prose/SKILL.md");
 		expect(bootstrap).toContain("Resolve every file referenced by this SKILL.md relative to the OpenProse skill root.");
 		expect(bootstrap).toContain("Do not invoke the `prose`, `npx prose`, or `@openprose/prose-cli` shell command");
+		expect(bootstrap).toContain("Do not ask the user for permission to write declared OpenProse artifacts");
+		expect(bootstrap).toContain("the command itself grants permission to create or replace `dist/manifest.next.json`");
 		expect(bootstrap).toContain("<open-prose-introduction>");
 		expect(bootstrap).toContain("</open-prose-introduction>");
 		expect(bootstrap).toContain("<open-prose-skill>");


### PR DESCRIPTION
## Summary

This is stacked on #67. It captures the Sonnet/Claude SDK playtest failures and hardens the compile path so medium-intelligence runs can complete the documented example flow.

- default pathless `prose compile` to the repository `src` root before the harness sees the command
- teach the compiler to compile directory source roots as repository graphs, not interactive file choices
- configure SDK harnesses for non-interactive permissive execution by default, assuming the caller supplies the external sandbox boundary
- preserve deterministic compile validation: the compiler writes `dist/manifest.next.json`, then the CLI validates that file
- keep accepting a valid written manifest when a harness exits nonzero after the artifact is already present
- document and test the updated behavior

## Validation

- `npm test`
- `npm test -- tests/cli/cli.test.ts tests/harnesses/harnesses.test.ts tests/skills/open-prose.test.ts`
- `npm run typecheck`
- `npm run build`
- patched live probe: `stargazer-outreach` with `PROSE_HARNESS=claude-sdk ANTHROPIC_MODEL=claude-sonnet-4-6` wrote a valid `dist/manifest.next.json`

## Playtest Notes

Synthesis and raw logs are in the planning repo under:
`plans/2026-05-01-responsibility-primitive/examples-rewrite/sonnet-0.13.1-feedback/`