### PR TITLE
fix(cli): load user and project settings in claude-sdk harness

### DIFF
--- a/tools/cli/src/harnesses/claude-sdk.ts
+++ b/tools/cli/src/harnesses/claude-sdk.ts
@@ -33,6 +33,7 @@ export function createClaudeSdkHarness(options: ClaudeSdkHarnessOptions = {}): H
 						...(runOptions.cwd === undefined ? {} : { cwd: runOptions.cwd }),
 						...(runOptions.env === undefined ? {} : { env: runOptions.env }),
 						includePartialMessages: true,
+						settingSources: ["user", "project"],
 						stderr: (chunk: string) => runOptions.stderr.write(chunk),
 						...(runOptions.systemPromptAppend === undefined
 							? {}

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -270,4 +270,68 @@ describe("claude-sdk harness", () => {
 		await expect(harness.run("prose status", { ...io.options })).resolves.toBe(1);
 		expect(io.stderr).toBe("bad\n");
 	});
+
+	test("always forwards settingSources: ['user', 'project']", async () => {
+		const io = memoryStreams();
+		const calls: unknown[] = [];
+		const harness = createClaudeSdkHarness({
+			query: async (args) => {
+				calls.push(args);
+				return {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "result", subtype: "success", result: "ok", is_error: false };
+					},
+					close() {},
+				} as never;
+			},
+		});
+
+		await harness.run("prose status", { ...io.options });
+
+		expect(calls).toEqual([
+			expect.objectContaining({
+				options: expect.objectContaining({
+					settingSources: ["user", "project"],
+				}),
+			}),
+		]);
+	});
+
+	test("auth_status with error writes output and error to stderr and exits 1", async () => {
+		const io = memoryStreams();
+		const harness = createClaudeSdkHarness({
+			query: async () =>
+				({
+					async *[Symbol.asyncIterator]() {
+						yield {
+							type: "auth_status",
+							output: ["Visit https://example.com to authenticate"],
+							error: "Not authenticated",
+						};
+					},
+					close() {},
+				}) as never,
+		});
+
+		await expect(harness.run("prose status", { ...io.options })).resolves.toBe(1);
+		expect(io.stderr).toContain("Visit https://example.com to authenticate");
+		expect(io.stderr).toContain("Not authenticated");
+	});
+
+	test("auth_status info-only writes lines to stderr and exits 0", async () => {
+		const io = memoryStreams();
+		const harness = createClaudeSdkHarness({
+			query: async () =>
+				({
+					async *[Symbol.asyncIterator]() {
+						yield { type: "auth_status", output: ["Authenticated as user@example.com"] };
+						yield { type: "result", subtype: "success", result: "ok", is_error: false };
+					},
+					close() {},
+				}) as never,
+		});
+
+		await expect(harness.run("prose status", { ...io.options })).resolves.toBe(0);
+		expect(io.stderr).toBe("Authenticated as user@example.com\n");
+	});
 });


### PR DESCRIPTION
The Claude Agent SDK defaults settingSources to empty, so the claude-sdk harness silently ignored ~/.claude and <repo>/.claude: user skills, project skills, hooks, MCP servers, and project CLAUDE.md never reached the agent. Set ["user", "project"] so prose runs match the workspace a user already configured for Claude Code.

Adds three tests: settingSources is always forwarded; auth_status messages stream their output lines to stderr; auth_status with an error field exits 1 (the existing branch was untested).