### PR TITLE
[codex] Add prose contributor program and contribution bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,9 @@ Treat `prose run ...` as an instruction inside the current agent session. Do not
 Use `prose upgrade --dry-run` to preview legacy migrations and `prose upgrade` to apply them; do not recommend the old migrate command.
 
 Open `skills/open-prose/SKILL.md` and treat it as the authoritative router. Every command, every file routing decision, and every capability assumption lives there or behind a pointer inside it. Do not search the workspace for alternate copies of the OpenProse documentation — the canonical files are the ones bundled under `skills/open-prose/`.
+
+If your run exposes a concrete improvement to OpenProse itself, consider
+`prose run std/evals/prose-contributor -- subjects: <run-ids>`. It turns run
+evidence into one focused draft PR. It still needs explicit user approval before
+using the user's GitHub identity to push a branch or open the PR. Read
+`CONTRIBUTING.md` before selecting the patch; it is the public contribution bar.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,155 @@
 # Contributing to OpenProse
 
-Thanks for your interest in contributing to OpenProse! This document outlines how to get involved.
+OpenProse is a programming language for AI sessions, expressed as durable
+Markdown contracts. Good contributions make agent workflows more readable,
+reviewable, versioned, reusable, inspectable, and cheaper to trust over time.
 
-## Ways to Contribute
+This repository is the open-source language, skill, CLI, standard library, and
+examples. It is not the hosted product roadmap, billing surface, subscription
+marketplace, or private operating plan. Contributions should strengthen the
+public substrate that any Prose Complete host can run.
 
-- **Report bugs** — Open an issue describing what went wrong
-- **Suggest features** — Open an issue with your idea
-- **Submit PRs** — Fix bugs or implement features
-- **Share feedback** — Tell us how you're using OpenProse
+## Contribution Bar
 
-## Before You Start
+A strong OpenProse PR should:
 
-### Small Changes
+- Start from a concrete use case or run observation. Name the workflow, agent
+  failure mode, customer-shaped need, or completed run that made the change
+  necessary.
+- Address one responsibility. If the work fixes docs, CLI behavior, and a std
+  pattern independently, open separate PRs.
+- Respect the language/framework/harness boundary. Put semantics in the skill
+  and interpreter docs, reusable contracts in `packages/std/`, and shell or
+  deterministic host behavior in `tools/cli/`.
+- Make the library more developer-friendly and agent-friendly at the same time:
+  clearer for humans to review, easier for agents to execute correctly.
+- Add or identify a retestable mechanism. Use existing tests when they cover
+  the change; add a focused test or eval when they do not.
+- Reduce sprawl. Prefer one precise contract, example, test, or CLI behavior
+  over a broad feature sweep.
 
-For bug fixes, documentation improvements, or small enhancements — just open a PR. No need to ask first.
+## Project Tenets
 
-### Large Changes
+Use these when deciding whether a change belongs:
 
-Before investing significant time in a major feature or architectural change, please reach out first. This helps ensure your work aligns with the project direction and doesn't conflict with ongoing development.
+- **Markdown source defines intent.** Authored `*.prose.md` files say what must
+  be true; runtime and harness code should not smuggle in semantic policy.
+- **Outcomes stay decoupled from implementation.** Users declare the result or
+  desired state; OpenProse can improve models, judges, retries, and program
+  structure beneath that contract without changing the user's intent.
+- **The skill and interpreter docs define semantics.** Contract Markdown,
+  Forme, Prose VM, ProseScript, and Responsibility Runtime are the load-bearing
+  language/framework surface.
+- **The harness serves IR and launches runs.** The CLI can validate, compile,
+  serve local triggers, forward commands to a selected harness, and report
+  deterministic status. It should not become a second VM.
+- **Contracts before choreography.** Prefer `### Requires`, `### Ensures`,
+  `### Errors`, `### Invariants`, `### Shape`, and `### Strategies`; use
+  `### Execution` only when order, loops, retries, gates, or branches are
+  actually part of the requirement.
+- **Services stay isolated.** Services write private scratch to `workspace/`;
+  only declared outputs become public `bindings/`.
+- **Forme wires; services do not discover each other.** Services declare data
+  they require and ensure. Wiring belongs to Forme manifests or explicit
+  `### Wiring` when ambiguity must be pinned.
+- **Responsibilities are standing goals, not cron jobs.** Keep the source
+  semantic; compile and serve lower it into triggers, activations, status, and
+  pressure.
+- **Harness and model agnostic by default.** A change should work across Prose
+  Complete hosts unless it is explicitly in a host adapter or CLI harness.
+- **The public OSS repo remains disciplined.** Hosted product concepts such as
+  billing, subscriptions, royalties, subscriber identity, and amortization
+  economics belong outside the language unless a minimal public hook becomes
+  necessary later.
 
-Ways to discuss ideas:
-- Open a GitHub issue describing your proposal
-- Reach out on X/Twitter: [@irl_danB](https://x.com/irl_danB)
+## Where Changes Belong
 
-This isn't gatekeeping — it's to save you from wasted effort if the change runs counter to something already in progress.
+| Change | Put It Here | Notes |
+| --- | --- | --- |
+| Contract syntax, section meaning, authored kinds | `skills/open-prose/contract-markdown.md` | Keep examples current and agent-readable |
+| Wiring semantics and dependency injection | `skills/open-prose/forme.md` or `packages/std/ops/wire.prose.md` | Specs define behavior; std contracts expose reusable operations |
+| VM execution, run state, bindings, run-typed inputs | `skills/open-prose/prose.md` and `skills/open-prose/state/` | Do not move VM semantics into the CLI |
+| Responsibility Runtime, compile/serve/status doctrine | `skills/open-prose/responsibility-runtime.md` and compiler docs | Keep responsibilities semantic; compile creates concrete IR |
+| Reusable roles, patterns, evals, ops, delivery, memory | `packages/std/` | Only promote repeated, use-case-agnostic behavior |
+| Company-operation starter contracts | `packages/co/` | Opinionated company-as-prose building blocks |
+| Agent-facing routing and activation guidance | `skills/open-prose/SKILL.md`, `AGENTS.md` | Keep globally loaded guidance concise |
+| Shell entrypoint, harness forwarding, deterministic local commands | `tools/cli/` | CLI wraps and validates; it does not replace the VM |
+| Examples that teach a complete pattern | `skills/open-prose/examples/` | Include enough context for an agent to run or adapt them |
+| Public contribution/process guidance | `CONTRIBUTING.md` | Keep it public, practical, and aligned with the repo |
 
-## Submitting a PR
+## Testing Expectations
 
-1. Fork the repository
-2. Create a branch for your change
-3. Make your changes
-4. Test locally (run example `*.prose.md` services and systems)
-5. Submit the PR with a clear description
+Every PR should say how it was tested. Prefer the narrowest check that can fail
+again in the future when the behavior regresses.
 
-## Code of Conduct
+| Change Type | Expected Checks |
+| --- | --- |
+| CLI or harness behavior | `cd tools/cli && npm run typecheck && npm test`, or the narrow affected Vitest file |
+| Repository IR, compile, serve, status, pressure | Relevant tests under `tools/cli/tests/prose/` |
+| Skill/spec docs | Link/structure checks plus a small scenario showing how an agent should route the command or file |
+| `*.prose.md` std/co contracts | Structural check for frontmatter and required sections; add or update a `kind: test` when behavior is executable |
+| Examples | Run or dry-run the example in a Prose Complete host when practical; otherwise document the missing host capability |
+| Docs-only copy | `git diff --check`, link existence checks, and examples reviewed for current command names |
 
-Be respectful and constructive. We're building something new and experimental — thoughtful feedback helps everyone.
+If no deterministic test exists yet, say that plainly in the PR and either add
+the smallest useful test or explain why a future eval is the right follow-up.
 
-## Questions?
+## PR Description Shape
+
+Use progressive disclosure. Maintainers and agents should understand the change
+from the top, then dig into examples and verification when needed.
+
+1. **Summary** — what changed in 3-5 bullets.
+2. **Use Case / Run Evidence** — why this change exists. Include run IDs,
+   issue links, user-visible friction, or a concrete workflow.
+3. **Design Boundary** — why the change belongs in the files you touched, and
+   why it does not belong in the skill, CLI, stdlib, or hosted product instead.
+4. **Examples** — inline before/after snippets, command examples, or a minimal
+   `*.prose.md` fragment when the change affects authoring.
+5. **Testing** — commands or evals run, plus key results.
+6. **Residual Risk / Follow-ups** — what remains intentionally out of scope.
+
+Keep the PR body honest. If the change only improves docs, do not imply runtime
+behavior changed. If the change needs a future hosted product feature, name it
+as out of scope rather than baking private strategy into the OSS language.
+
+## Agent-Assisted Contributions
+
+If you are an agent and an OpenProse run exposed a concrete improvement, prefer
+the standard contributor program:
+
+```bash
+prose run std/evals/prose-contributor -- subjects: <run-ids>
+```
+
+Use it for small, evidence-backed improvements: docs clarifications, std
+contract fixes, eval guardrails, or examples extracted from a real run. It
+should read this file, select one PR-sized responsibility, open one focused
+draft PR, and include the run evidence plus verification in the PR body.
+
+Do not push or open a PR with the user's GitHub identity unless the user has
+explicitly approved that specific contribution. If approval is missing, draft
+the diff and ask once.
+
+## When To Open An Issue First
+
+Small, evidence-backed fixes can go straight to PR. Open an issue first when:
+
+- the change alters language semantics or authored syntax
+- the change spans multiple responsibilities or packages
+- the right layer is unclear
+- the proposal depends on hosted product concepts not currently present in the
+  OSS repository
+- you cannot describe a retestable success condition
+
+## Code Of Conduct
+
+Be respectful and constructive. OpenProse is early and experimental; precise,
+evidence-backed feedback helps more than broad taste notes.
+
+## Questions
 
 - GitHub Issues: [github.com/openprose/prose/issues](https://github.com/openprose/prose/issues)
 - X/Twitter: [@irl_danB](https://x.com/irl_danB)
 
-Thanks for helping improve OpenProse!
+Thanks for helping improve OpenProse.

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Reference them with the `std/` and `co/` shorthands, then install and pin:
 
 ```prose
 use "std/evals/inspector"
+use "std/evals/prose-contributor"
 use "co/systems/company-repo-checker"
 ```
 
@@ -348,7 +349,12 @@ prose install
 
 Dependencies are cloned into `<openprose-root>/deps/`, locked in
 `<openprose-root>/prose.lock`, and read from disk at runtime. No network fetch
-happens during execution.
+happens for dependency resolution during execution.
+
+If a run teaches an agent how OpenProse itself should improve, use
+`std/evals/prose-contributor`. It consumes run evidence, makes one focused
+change, verifies it, and opens a draft PR after explicit approval to use the
+current GitHub identity.
 
 ## Project Map
 

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -6,6 +6,7 @@ Reusable OpenProse services, systems, patterns, roles, delivery adapters, memory
 
 ```prose
 use "std/evals/inspector"
+use "std/evals/prose-contributor"
 use "std/patterns/worker-critic"
 use "std/patterns/pipeline"
 use "std/roles/critic"
@@ -32,6 +33,12 @@ Systems for evaluating and improving OpenProse runs, contracts, and platform beh
 | `eval-calibrator` | Validates light evals against deep evals for reliability |
 | `system-improver` | Analyzes inspections and proposes source improvements |
 | `platform-improver` | Analyzes inspections and proposes platform/runtime improvements |
+| `prose-contributor` | Turns run evidence into an approved branch and draft PR back to OpenProse |
+
+When a std run exposes friction, confusing docs, or a reusable pattern that
+belongs upstream, run `std/evals/prose-contributor` after inspection. It is the
+standard path from run evidence to a focused pull request. It still requires
+explicit user approval before pushing a branch or opening a PR.
 
 ### ops/
 

--- a/packages/std/evals/prose-contributor.prose.md
+++ b/packages/std/evals/prose-contributor.prose.md
@@ -1,0 +1,287 @@
+---
+name: prose-contributor
+kind: system
+---
+
+# Prose Contributor
+
+Given one or more completed OpenProse runs, turn real run friction into a small, reviewable contribution to `openprose/prose`. This system is the standard path from "this run taught us something" to "there is a draft pull request that improves the library for the next agent."
+
+Use this when a run exposes confusing docs, missing examples, weak std contracts, brittle eval criteria, or a repeated pattern that belongs in `packages/std/`. It is not a general refactoring system. It should open one focused PR, grounded in run evidence and aligned with the repository contribution guidelines, after explicit approval to use the current GitHub identity.
+
+### Services
+
+- contribution-context
+- evidence-collector
+- opportunity-selector
+- patch-author
+- verifier
+- pr-opener
+
+### Requires
+
+- subjects: run[] -- completed runs, inspection runs, improver runs, or cross-run comparisons that contain the evidence for the contribution
+- repository: path -- local checkout of `openprose/prose` or a fork
+- scope: contribution scope, one of "std", "skills", "docs", "examples", or "platform" (default: "std")
+- base-branch: target branch for the PR (default: "main")
+- pr-approval: explicit user approval to create a branch, push it, and open a GitHub pull request using the current authenticated GitHub identity
+
+### Ensures
+
+- contribution: structured report containing:
+    - evidence: run IDs and specific findings that motivated the change
+    - guideline_alignment: how the change satisfies the repository contribution bar and project tenets
+    - selected_opportunity: the single improvement selected for this PR, with rationale and why larger alternatives were deferred
+    - files_changed: list of changed files
+    - verification: commands or evals run, with pass/fail status and key output
+    - branch: branch name created for the contribution
+    - pull_request: URL, title, draft/ready status, and base branch
+    - follow_ups: related opportunities intentionally left out of this PR
+- pull_request is opened as draft unless the user explicitly asks for a ready-for-review PR
+- PR body includes the run evidence, verification performed, and any residual risk
+- if no evidence-backed, PR-sized improvement exists: no branch is pushed and no PR is opened
+
+### Errors
+
+- approval-required: pr-approval is absent or ambiguous
+- no-actionable-improvement: subjects do not support a concrete, small contribution
+- repository-not-found: repository path is missing or is not a git checkout
+- dirty-worktree: repository contains unrelated uncommitted changes that would make authorship unclear
+- gh-unavailable: GitHub CLI is unavailable or not authenticated
+- verification-failed: the change was made but validation failed
+- pr-create-failed: branch pushed but pull request creation failed
+
+### Invariants
+
+- never push directly to the base branch
+- never open a pull request without explicit user approval for this specific contribution
+- never batch unrelated improvements into one PR
+- never modify files outside the selected scope unless the PR body names and justifies the exception
+- never move language semantics into the CLI, or harness mechanics into the skill/specs
+- never turn hosted product or subscription strategy into OSS language surface without a minimal public-runtime need
+- never hide failed validation; if verification fails, stop before opening the PR unless the user explicitly asks for a failing draft PR
+- never ask for more than one giving-back action in the same run
+
+### Strategies
+
+- before selecting a change: read `CONTRIBUTING.md`, `README.md`, `AGENTS.md`, `skills/open-prose/SKILL.md`, `skills/open-prose/guidance/tenets.md`, `skills/open-prose/guidance/authoring.md`, and the relevant CLI/std/example docs for the touched scope
+- prefer the smallest change that helps a future agent: a docs clarification, a std contract fix, an eval guardrail, or an example extracted from a real run
+- ground every change in evidence from the provided runs; do not invent improvements because a file "could be nicer"
+- classify the change by layer before editing: language/framework semantics, std contract, CLI harness behavior, example, docs, or hosted-product-adjacent idea
+- if the evidence points to source-system quality, reuse the reasoning shape of `std/evals/system-improver`
+- if the evidence points to Forme or VM behavior, reuse the reasoning shape of `std/evals/platform-improver`
+- if the evidence spans multiple runs, use `std/evals/cross-run-differ` thinking to identify the recurring pattern before selecting a PR
+- open draft PRs by default; ready-for-review PRs require explicit user direction
+- write the PR for maintainers and future agents using the shape from `CONTRIBUTING.md`: Summary, Use Case / Run Evidence, Design Boundary, Examples, Testing, Residual Risk / Follow-ups
+
+---
+
+## contribution-context
+
+Read the repository's contribution guidelines, project tenets, public docs, and relevant implementation docs before proposing any patch.
+
+### Requires
+
+- repository: local checkout path
+- scope: requested contribution scope
+
+### Ensures
+
+- context-pack: structured context containing:
+    - contribution_bar: the requirements from `CONTRIBUTING.md`
+    - project_tenets: the relevant design tenets from `skills/open-prose/guidance/tenets.md` and `skills/open-prose/guidance/authoring.md`
+    - boundary_map: where changes belong across the skill/specs, `packages/std/`, examples, `packages/co/`, and `tools/cli/`
+    - testing_map: existing tests, evals, or structural checks available for the requested scope
+    - public_positioning: public-facing framing from `README.md` and `AGENTS.md` that the PR should preserve
+    - private_boundary: any detected hosted-product, billing, subscription, or business-strategy ideas that should remain out of OSS language/runtime changes unless the user explicitly scopes them
+
+### Errors
+
+- repository-not-found: repository cannot be inspected
+- contribution-guidelines-missing: `CONTRIBUTING.md` cannot be found
+
+### Strategies
+
+- start with `CONTRIBUTING.md`; it is the contribution quality bar
+- read `skills/open-prose/SKILL.md` to understand the agent-facing language/framework surface
+- read `tools/cli/README.md` and relevant CLI source only when the proposed scope touches shell entrypoints, harness selection, deterministic compile/serve/status behavior, or tests
+- read `packages/std/README.md` and neighboring std contracts when the proposed scope is a reusable library change
+- treat hosted product and subscription ideas as positioning context, not OSS implementation requirements
+
+---
+
+## evidence-collector
+
+Read the subject runs and extract the evidence that could justify an upstream contribution.
+
+### Requires
+
+- subjects: run[] binding from the caller
+- context-pack: contribution context from contribution-context
+- repository: local checkout path
+- scope: requested contribution scope
+
+### Ensures
+
+- evidence-pack: structured evidence containing:
+    - runs: list of run IDs, paths, systems, timestamps, and statuses
+    - findings: specific friction points, failures, repeated patterns, confusing docs, missing examples, or std gaps
+    - candidate_files: repository files plausibly implicated by each finding
+    - existing_context: relevant current docs, std files, tests, issues, project tenets, or previous improver outputs
+
+### Errors
+
+- repository-not-found: repository cannot be inspected
+- no-actionable-improvement: no finding maps to a concrete repository file or contribution target
+
+### Strategies
+
+- read vm logs, final bindings, inspector outputs, and improver outputs before reading broad source files
+- search the repository for the exact docs or std APIs that the run used
+- when the same friction appears in multiple subjects, mark it as higher confidence
+- when evidence is only a vague preference, exclude it
+
+---
+
+## opportunity-selector
+
+Choose exactly one PR-sized improvement from the evidence pack.
+
+### Requires
+
+- evidence-pack: collected run evidence
+- context-pack: contribution context from contribution-context
+- scope: requested contribution scope
+
+### Ensures
+
+- selected-opportunity: one improvement containing:
+    - title: short human-readable title
+    - category: "docs", "std-contract", "eval", "example", "skill-guidance", or "platform"
+    - affected_files: files to edit
+    - rationale: why this improves future runs
+    - design_boundary: why the change belongs in these files and not another layer
+    - test_strategy: how the change can be retested on future PRs
+    - evidence_refs: run findings that justify the change
+    - risk: "low", "medium", or "high"
+    - deferred: related opportunities intentionally excluded
+
+### Errors
+
+- no-actionable-improvement: no candidate is small enough and evidence-backed enough for a PR
+
+### Strategies
+
+- prefer low-risk changes that are obviously useful to agents who will run the same system later
+- prefer one file or one tightly related set of files
+- reject candidates that cannot name a concrete use case, design boundary, and retestable success condition
+- defer broad architecture changes, speculative API additions, and style-only rewrites
+- if the best change is large, select a preparatory docs/example PR instead
+
+---
+
+## patch-author
+
+Create a branch and apply the selected opportunity as a concrete patch.
+
+### Requires
+
+- selected-opportunity: selected PR-sized improvement
+- repository: local checkout path
+- base-branch: target base branch
+- pr-approval: explicit approval to create a contribution branch
+
+### Ensures
+
+- patch: applied change containing:
+    - branch: created branch name
+    - files_changed: list of changed files
+    - diff: concise diff summary
+    - commit: commit SHA and message
+
+### Errors
+
+- approval-required: approval is absent or does not cover branch creation and PR opening
+- dirty-worktree: unrelated local changes are present
+- repository-not-found: repository is not a git checkout
+
+### Strategies
+
+- create a branch named `prose-contributor/<short-topic>`
+- check `git status --short` before editing; stop if unrelated dirty files are present
+- apply the smallest patch that satisfies the selected opportunity
+- use a commit message that starts with the affected area, for example `std: add contributor guidance to evals`
+
+---
+
+## verifier
+
+Validate the patch before it is pushed.
+
+### Requires
+
+- patch: applied patch from patch-author
+- selected-opportunity: selected opportunity
+- context-pack: contribution context from contribution-context
+- repository: local checkout path
+
+### Ensures
+
+- verification: validation record containing:
+    - commands: commands or evals run
+    - results: pass/fail per command
+    - residual_risk: anything not covered by validation
+    - ready_to_push: boolean
+
+### Errors
+
+- verification-failed: validation failed or the patch cannot be reviewed safely
+
+### Strategies
+
+- for std files: run the narrowest available lint, tests, or structural checks for the changed package
+- for docs-only changes: validate links and check that referenced files exist
+- for examples: run or inspect the example enough to confirm it is executable by a Prose Complete host
+- for CLI changes: run the narrowest affected Vitest suite, then `npm run typecheck` when practical
+- if no deterministic validation exists, say so in residual_risk instead of inventing a pass
+
+---
+
+## pr-opener
+
+Push the branch and open a pull request.
+
+### Requires
+
+- patch: committed patch
+- verification: verification record with ready_to_push true
+- selected-opportunity: selected opportunity
+- context-pack: contribution context from contribution-context
+- repository: local checkout path
+- base-branch: target base branch
+- pr-approval: explicit approval to push and open the PR
+
+### Ensures
+
+- pull_request: PR record containing:
+    - url: GitHub PR URL
+    - title: PR title
+    - branch: pushed branch
+    - base: base branch
+    - draft: boolean
+    - body: PR body text or path to saved PR body
+- contribution: final top-level report
+
+### Errors
+
+- approval-required: approval does not cover pushing and opening a PR
+- gh-unavailable: `gh` is missing or not authenticated
+- pr-create-failed: `gh pr create` fails
+
+### Strategies
+
+- use `gh auth status` before pushing
+- push only the contribution branch
+- create a draft PR unless the user explicitly requested ready-for-review
+- include these PR body sections: Summary, Use Case / Run Evidence, Design Boundary, Examples, Testing, Residual Risk / Follow-ups
+- tag the PR title or body with `agent-experience` when the contribution came from agent-facing friction

--- a/skills/open-prose/SKILL.md
+++ b/skills/open-prose/SKILL.md
@@ -376,6 +376,8 @@ Apply one principle everywhere: **one ask per session, maximum.** If you already
 
 **Open a PR for a specific fix.** Same discipline. Draft the diff, show the user, get approval, submit. Good targets: docs clarifications where you hit confusion, typo fixes, examples added from patterns you actually used in this run.
 
+When the fix comes from OpenProse run evidence, prefer `prose run std/evals/prose-contributor -- subjects: <run-ids>`; it is the standard path from run friction to a focused draft PR.
+
 **Contribute an example system.** If your run demonstrates a novel pattern, a PR to `skills/open-prose/examples/` is high-value. Include a short README that names what the pattern solves and when to reach for it.
 
 **Propose adding a Prose system to the user's repo.** If OpenProse fits a recurring workflow in the project you are working in, suggest adding a system under `<openprose-root>/src/`. The approval gate here is the user's repo owner.

--- a/skills/open-prose/help.md
+++ b/skills/open-prose/help.md
@@ -26,7 +26,8 @@ Options:
   2. "Build something new" - "Help me create a service or system for a specific task"
   3. "Keep a goal true" - "Define a standing goal with compile/serve/status"
   4. "Learn the syntax" - "Show me examples and explain how it works"
-  5. "Explore possibilities" - "What can OpenProse do?"
+  5. "Improve OpenProse" - "Turn run evidence into a focused upstream PR"
+  6. "Explore possibilities" - "What can OpenProse do?"
 ```
 
 **After the user responds:**
@@ -35,6 +36,7 @@ Options:
 - **Build something new**: Ask them to describe their task, then help write a service or system (load `guidance/authoring.md`)
 - **Keep a goal true**: Help author a `kind: responsibility`, then explain `prose compile`, `prose serve`, and `prose status`
 - **Learn the syntax**: Show examples from `examples/`, explain the VM model
+- **Improve OpenProse**: Run `std/evals/prose-contributor` on relevant run IDs; require explicit user approval before pushing or opening a PR
 - **Explore possibilities**: Walk through examples like `stargazer-outreach/`
 
 ---
@@ -84,6 +86,11 @@ written to `<openprose-root>/runs/`.
 **Use a library service or system:**
 ```text
 prose run std/evals/inspector -- subject: 20260406-201439-1a3369
+```
+
+**Contribute an improvement from run evidence:**
+```text
+prose run std/evals/prose-contributor -- subjects: 20260406-201439-1a3369
 ```
 
 **Add a dependency:**

--- a/skills/open-prose/prose.md
+++ b/skills/open-prose/prose.md
@@ -86,6 +86,7 @@ prose run github.com/alice/research@abc1234      # pin to SHA
 prose run gitlab.com/alice/research              # any git host
 prose run git.company.com/team/repo              # self-hosted
 prose run std/evals/inspector                    # OpenProse package shorthand
+prose run std/evals/prose-contributor            # turn run evidence into an approved PR
 
 # Flags
 prose run github.com/alice/research --offline    # assert disk-only resolution

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -73,6 +73,7 @@ Examples:
 
 ```bash
 prose run std/evals/inspector
+prose run std/evals/prose-contributor -- subjects: 20260406-201439-1a3369
 prose run std/evals/inspector --harness codex-sdk
 prose run co/systems/company-repo-checker --harness claude-sdk
 PROSE_HARNESS=claude-sdk prose run std/evals/inspector


### PR DESCRIPTION
## Summary

Adds `std/evals/prose-contributor`, a standard-library system that turns completed OpenProse run evidence into one focused upstream contribution PR.

The PR also rewrites `CONTRIBUTING.md` from a generic contribution note into a contribution quality bar for humans and agents. It now covers:

- project tenets for OSS contributions
- the language/framework/harness boundary
- where changes belong across the skill/specs, stdlib, examples, co package, and CLI
- testing expectations by change type
- a progressively disclosed PR description shape
- guidance for agent-assisted contributions

The contributor program now has an explicit `contribution-context` service that reads the contribution bar, project tenets, authoring guidance, SKILL, CLI docs, std docs, and public positioning before selecting or patching an improvement.

## Use Case / Run Evidence

This came from designing the missing loop around OpenProse's existing improver systems. `system-improver`, `platform-improver`, and `cross-run-differ` can identify improvements, but there was not a standard program that turns run evidence into an approved, reviewable PR.

While reviewing that first version, we found another gap: the contributor program could open a PR mechanically, but it did not force the agent to understand the project tenets, contribution guidelines, or the boundary between language/framework semantics and CLI harness mechanics.

## Design Boundary

- `packages/std/evals/prose-contributor.prose.md` belongs in std evals because it composes run evidence, improvement selection, verification, and PR creation into a reusable upstream contribution workflow.
- `CONTRIBUTING.md` is the right public source for the contribution bar: it can be read by humans, agents, and the contributor program itself.
- `AGENTS.md`, `README.md`, `SKILL.md`, `help.md`, `prose.md`, and `tools/cli/README.md` get light pointers only, so the globally loaded and high-traffic docs do not become bloated.
- Hosted product and subscription strategy are treated as positioning context, not language/runtime implementation requirements.

## Examples

New contributor-program invocation:

```bash
prose run std/evals/prose-contributor -- subjects: <run-ids>
```

New PR-body shape expected by the guidelines:

1. Summary
2. Use Case / Run Evidence
3. Design Boundary
4. Examples
5. Testing
6. Residual Risk / Follow-ups

## Verification

- `git diff --check`
- Structure check for `packages/std/evals/prose-contributor.prose.md` frontmatter and required sections
- Referenced-file check for the docs that `contribution-context` requires agents to read

## Residual Risk

This adds a new contract and documentation hooks, but I did not execute the new system end-to-end through a Prose Complete host. The PR is draft so maintainers can review the contribution workflow semantics before treating it as ready.
