### PR TITLE
fix(cli): pass granular Codex runtime options

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -97,6 +97,11 @@ For externally sandboxed CI environments, Codex harnesses also honor
 `danger-full-access`) and `PROSE_CODEX_APPROVAL_POLICY` (`never`, `on-request`,
 `on-failure`, or `untrusted`) and forward those values to Codex.
 
+To keep `workspace-write` sandboxing while granting narrow extra capabilities,
+Codex harnesses also honor `PROSE_CODEX_ADD_DIR` as a comma-separated list of
+additional writable directories and `PROSE_CODEX_NETWORK` (`true` or `false`)
+for outbound network access.
+
 ## Skill Setup
 
 OpenProse execution depends on the `open-prose` agent skill. Before running a

--- a/tools/cli/package-lock.json
+++ b/tools/cli/package-lock.json
@@ -2150,12 +2150,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2174,9 +2174,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2410,9 +2410,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2471,9 +2471,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/tools/cli/src/harnesses/codex-options.ts
+++ b/tools/cli/src/harnesses/codex-options.ts
@@ -6,15 +6,22 @@ const CODEX_APPROVAL_POLICIES = ["never", "on-request", "on-failure", "untrusted
 export function codexThreadRuntimeOptions(
 	env: Record<string, string | undefined> | undefined,
 	additionalDirectories: readonly string[] = [],
-): Pick<CodexThreadOptions, "additionalDirectories" | "approvalPolicy" | "sandboxMode" | "skipGitRepoCheck"> {
+): Pick<
+	CodexThreadOptions,
+	"additionalDirectories" | "approvalPolicy" | "networkAccessEnabled" | "sandboxMode" | "skipGitRepoCheck"
+> {
 	const sandboxMode = codexEnvOption("PROSE_CODEX_SANDBOX_MODE", CODEX_SANDBOX_MODES, env);
 	const approvalPolicy = codexEnvOption("PROSE_CODEX_APPROVAL_POLICY", CODEX_APPROVAL_POLICIES, env);
+	const envAdditionalDirectories = codexEnvList("PROSE_CODEX_ADD_DIR", env);
+	const networkAccessEnabled = codexEnvBoolean("PROSE_CODEX_NETWORK", env);
+	const mergedAdditionalDirectories = [...additionalDirectories, ...envAdditionalDirectories];
 
 	return {
 		skipGitRepoCheck: true,
 		...(sandboxMode === undefined ? {} : { sandboxMode }),
 		...(approvalPolicy === undefined ? {} : { approvalPolicy }),
-		...(additionalDirectories.length === 0 ? {} : { additionalDirectories: [...additionalDirectories] }),
+		...(networkAccessEnabled === undefined ? {} : { networkAccessEnabled }),
+		...(mergedAdditionalDirectories.length === 0 ? {} : { additionalDirectories: mergedAdditionalDirectories }),
 	};
 }
 
@@ -41,4 +48,35 @@ function codexEnvOption<const T extends readonly string[]>(
 	}
 
 	throw new Error(`${name} must be one of: ${allowedValues.join(", ")}`);
+}
+
+function codexEnvList(name: string, env: Record<string, string | undefined> | undefined): string[] {
+	const value = env?.[name] ?? process.env[name];
+	if (value === undefined || value === "") {
+		return [];
+	}
+
+	return value
+		.split(",")
+		.map((item) => item.trim())
+		.filter((item) => item !== "");
+}
+
+function codexEnvBoolean(
+	name: string,
+	env: Record<string, string | undefined> | undefined,
+): boolean | undefined {
+	const value = env?.[name] ?? process.env[name];
+	if (value === undefined || value === "") {
+		return undefined;
+	}
+
+	if (value === "true") {
+		return true;
+	}
+	if (value === "false") {
+		return false;
+	}
+
+	throw new Error(`${name} must be one of: true, false`);
 }

--- a/tools/cli/tests/harnesses/harnesses.test.ts
+++ b/tools/cli/tests/harnesses/harnesses.test.ts
@@ -141,7 +141,7 @@ describe("codex-sdk harness", () => {
 		]);
 	});
 
-	test("forwards requested sandbox and approval settings to Codex SDK threads", async () => {
+	test("forwards requested runtime settings to Codex SDK threads", async () => {
 		const io = memoryStreams();
 		const starts: unknown[] = [];
 		const factory: CodexSdkFactory = () => ({
@@ -159,14 +159,45 @@ describe("codex-sdk harness", () => {
 
 		const exitCode = await createCodexSdkHarness({ factory }).run("prose run inspector.prose.md", {
 			...io.options,
+			additionalDirectories: ["/skills/open-prose"],
 			env: {
+				PROSE_CODEX_ADD_DIR: " /var/lib/prose, /tmp/grant-finder ,,",
 				PROSE_CODEX_APPROVAL_POLICY: "never",
+				PROSE_CODEX_NETWORK: "true",
 				PROSE_CODEX_SANDBOX_MODE: "danger-full-access",
 			},
 		});
 
 		expect(exitCode).toBe(0);
-		expect(starts).toEqual([{ approvalPolicy: "never", sandboxMode: "danger-full-access", skipGitRepoCheck: true }]);
+		expect(starts).toEqual([
+			{
+				additionalDirectories: ["/skills/open-prose", "/var/lib/prose", "/tmp/grant-finder"],
+				approvalPolicy: "never",
+				networkAccessEnabled: true,
+				sandboxMode: "danger-full-access",
+				skipGitRepoCheck: true,
+			},
+		]);
+	});
+
+	test("rejects invalid Codex network setting", async () => {
+		const io = memoryStreams();
+		const harness = createCodexSdkHarness({
+			factory: () => ({
+				startThread: () => {
+					throw new Error("unexpected startThread");
+				},
+			}),
+		});
+
+		await expect(
+			harness.run("prose run inspector.prose.md", {
+				...io.options,
+				env: {
+					PROSE_CODEX_NETWORK: "yes",
+				},
+			}),
+		).rejects.toThrow("PROSE_CODEX_NETWORK must be one of: true, false");
 	});
 
 	test("maps failed turns to stderr and nonzero exit", async () => {


### PR DESCRIPTION
## Summary

- forward `PROSE_CODEX_ADD_DIR` into Codex SDK `additionalDirectories`
- forward strict `PROSE_CODEX_NETWORK=true|false` into `networkAccessEnabled`
- document the new Codex harness env vars
- refresh vulnerable transitive production lockfile entries so CLI release audit stays green

This PR targets `main` directly and contains only the Codex runtime-options fix. The earlier PR #77 landed the same fix into `feat/cli-prose-chain`; this PR is the main-targeted cherry-pick.

## Verification

- `npm ci`
- `npm run typecheck`
- `TMPDIR=/var/tmp/prose-codex-tests npm test -- tests/harnesses/harnesses.test.ts`
- `npm audit --omit=dev`
- `git diff --check origin/main..HEAD`

Golden-finch also confirmed the patch end-to-end with `workspace-write`, `PROSE_CODEX_ADD_DIR`, and `PROSE_CODEX_NETWORK=true` against a live grant-radar run.
