### PR TITLE
docs: link Grant Radar external example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,16 @@ Responsibility Runtime commands add a thin deterministic host layer for
 compiling, serving, and inspecting repository IR. The CLI checks for the
 `open-prose` skill before invoking a harness and can install the selected
 provider's global skill target automatically; run `prose doctor` to inspect the
-local setup.
+local setup. Automatic skill install uses `npx`; in a minimal shell where
+`prose` is available but `npx` is not, install the skill from this checkout:
+
+```bash
+mkdir -p "$HOME/.codex/skills" "$HOME/.agents/skills" "$HOME/.claude/skills"
+ln -sfn "$PWD/skills/open-prose" "$HOME/.codex/skills/open-prose"
+ln -sfn "$PWD/skills/open-prose" "$HOME/.agents/skills/open-prose"
+ln -sfn "$PWD/skills/open-prose" "$HOME/.claude/skills/open-prose"
+prose doctor
+```
 
 > By installing, you agree to the [Privacy Policy](PRIVACY.md) and
 > [Terms of Service](TERMS.md).

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Start with:
 | [customer-risk-radar](skills/open-prose/examples/customer-risk-radar/) | Customer risk monitoring before renewals or escalations |
 | [release-readiness](skills/open-prose/examples/release-readiness/) | Release evidence, risk, notes, and rollback context |
 | [compliance-evidence-tracker](skills/open-prose/examples/compliance-evidence-tracker/) | Audit evidence freshness and gap tracking |
+| [grant-radar](https://github.com/openprose/grant-finder/tree/main/examples/openprose) | External example: source-cited funding research for labs, startups, and technical teams |
 
 ## Libraries
 

--- a/skills/open-prose/examples/README.md
+++ b/skills/open-prose/examples/README.md
@@ -27,6 +27,18 @@ receipts in `runs/`, durable state in `state/`, and dependencies in `deps/`.
   conventions) into a single non-interactive OpenProse system, with the
   two-subagent grill-and-decide split called out as an OpenProse adaptation.
 
+## External Examples
+
+These examples live in separate repos when they depend on product-specific
+source code or should keep their own release cadence.
+
+- [grant-radar](https://github.com/openprose/grant-finder/tree/main/examples/openprose)
+  demonstrates an OpenProse system that drives the public
+  [`grant-finder`](https://github.com/openprose/grant-finder) CLI to produce
+  source-cited non-dilutive funding reports for research labs, startups, and
+  technical teams. The `grant-finder` repo remains the source of truth for that
+  example.
+
 ## Quick Start
 
 Open one example directory, then compile and serve it:


### PR DESCRIPTION
## Summary
- add Grant Radar to the README example table as an external example
- document the external example under `skills/open-prose/examples/`
- add a minimal-shell fallback for installing the local `open-prose` skill when `prose` is available but `npx` is not

## Validation
- validated the linked example path from a clean temporary environment with no preinstalled `grant-finder` binary or `grant-finder` skill
- no private validation artifacts, prompts, transcripts, or organization-specific holdout data committed
- safe-push/safe-pr reviewers approved public diffs