### PR TITLE
feat(spec): declare host tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `skills/open-prose/compiler/index.prose.md` (skills_resolver), and
   `skills/open-prose/examples/declared-skills/` for the spec and a worked
   example. Resolves [#60](https://github.com/openprose/prose/issues/60).
+- **Declared `### Tools` section** — Components may now declare host CLI
+  executables they require in a `### Tools` section using `cli:<name>`
+  declarations. The compiler program resolves supported declarations through a
+  PATH executable check, fails closed with `tool_invalid`,
+  `tool_unsupported_kind`, or `tool_unresolved` diagnostics, and emits resolved
+  tools into Forme manifests with `requiredBy` attribution. OpenProse never
+  installs or modifies host tools. Tracks
+  [#76](https://github.com/openprose/prose/issues/76).
 
 ### Fixed
 

--- a/skills/open-prose/compiler/index.prose.md
+++ b/skills/open-prose/compiler/index.prose.md
@@ -30,9 +30,11 @@ to keep each lowering step on a narrow context budget.
 - `self`: orchestrate the compile flow, enforce the IR contract, and write only
   a valid manifest.
 - `delegates`: source discovery, responsibility lowering, gateway lowering,
-  Forme lowering, IR emission, and IR validation.
+  skill resolution, tool resolution, Forme lowering, IR emission, and IR
+  validation.
 - `prohibited`: inventing schema fields, silently guessing ambiguous timing or
-  fulfillment, recursively invoking the `prose` CLI.
+  fulfillment, installing host capabilities, recursively invoking the `prose`
+  CLI.
 
 ### Strategies
 
@@ -46,6 +48,7 @@ to keep each lowering step on a narrow context budget.
   when the source graph makes the relationship clear.
 - Do not invent connector routes, queue names, provider payloads, secrets, or
   provider subscription setup.
+- Do not invent host skill or tool availability.
 - Stay inside `source_root`; do not inspect sibling examples, parent
   repositories, or unrelated source trees.
 - Prefer warnings over silent assumptions when timing, fulfillment, or Forme
@@ -140,6 +143,42 @@ agent skills_resolver:
     self: ["skill resolution", "host filesystem checks", "scope aggregation"]
     prohibited: ["installing skills", "modifying host state", "guessing skill locations"]
 
+agent tools_resolver:
+  model: "fast"
+  persist: false
+  prompt: """
+  Resolve declared `### Tools` for every system and service in the source
+  graph.
+  Load contract-markdown.md (Tools) and compiler/ir-v0.md.
+  Accept only deterministic CLI executable declarations in the exact
+  `cli:<executable-name>` form. The executable name must be non-empty and must
+  not contain path separators.
+  Report malformed declarations such as `gh`, `cli:`, or `cli:bin/gh` with a
+  diagnostic whose severity is `error` and whose message includes
+  `tool_invalid`.
+  Report non-CLI namespaces such as `mcp:github` with a diagnostic whose
+  severity is `error` and whose message includes `tool_unsupported_kind`.
+  For each supported CLI declaration, check host PATH for an executable with
+  that name. Do not run the executable and do not perform version or auth
+  checks.
+  Aggregate scope: a system's declared tools apply to every sub-service, and a
+  service's declarations are additive -- they extend, never replace, the
+  inherited set.
+  Tool declarations do not satisfy `### Requires` and do not create Forme
+  dependency-graph edges.
+  Never install, modify, upgrade, or remove host tools.
+  Return one aggregated manifest tool record per resolved CLI executable using
+  `{ kind: "cli", name, requiredBy }`, where `requiredBy` names the graph nodes
+  that need the executable.
+  Return an `unresolved` array of `{ tool, sourcePath, checked }` entries for
+  any executable that is not present on PATH. Emit one diagnostic with severity
+  `error` and message code `tool_unresolved` for each unresolved entry, naming
+  the tool and the PATH lookup that was checked.
+  """
+  shape:
+    self: ["tool resolution", "PATH executable checks", "scope aggregation"]
+    prohibited: ["installing tools", "running declared tools", "guessing tool availability"]
+
 agent forme_compiler:
   model: "fast"
   persist: false
@@ -148,6 +187,9 @@ agent forme_compiler:
   Load forme.md and compiler/ir-v0.md.
   Produce only the formeManifests array entries described by ir-v0.md.
   Use executionOrder entries with exactly nodeId and dependsOn fields.
+  Include resolved tool requirements from tools_resolution in each Forme
+  manifest's tools array. Use only `{ kind: "cli", name, requiredBy }` records,
+  and make `requiredBy` reference graph node ids in that manifest.
   Link fulfillment activations that target systems to the matching
   formeManifestId.
   Emit warnings for wiring that cannot be represented in v0.
@@ -179,7 +221,8 @@ agent ir_validator:
   Check exact top-level fields, required fields, allowed enum values,
   root-relative paths, trigger-to-judge links, exactly one judge activation per
   responsibility, fulfillment/source/Forme links, Forme graph references,
-  executionOrder dependencies, and diagnostic shape.
+  executionOrder dependencies, tool requiredBy references, and diagnostic
+  shape.
   Treat any diagnostic with severity error as invalid for writing.
   Return valid: true only when the manifest should be written.
   Return concrete errors with JSON paths when invalid.
@@ -220,13 +263,20 @@ let skills_resolution = session: skills_resolver
 if skills_resolution reports unresolved skills:
   return skills_resolution
 
+let tools_resolution = session: tools_resolver
+  prompt: "Resolve declared host tools for every system and service."
+  context: { source_root, discovered }
+
+if tools_resolution reports invalid, unsupported, or unresolved tools:
+  return tools_resolution
+
 let forme_output = session: forme_compiler
   prompt: "Compile systems and services into v0 Forme manifests."
-  context: { source_root, discovered, responsibility_output, gateway_output }
+  context: { source_root, discovered, responsibility_output, gateway_output, tools_resolution }
 
 let manifest = session: ir_emitter
   prompt: "Assemble the complete v0 repository IR JSON object."
-  context: { discovered, responsibility_output, gateway_output, forme_output }
+  context: { discovered, responsibility_output, gateway_output, tools_resolution, forme_output }
 
 let validation = session: ir_validator
   prompt: "Validate the complete manifest before it is written."

--- a/skills/open-prose/compiler/ir-v0.md
+++ b/skills/open-prose/compiler/ir-v0.md
@@ -201,6 +201,13 @@ Do not emit `service`, `source`, `sourceName`, `target`, `triggeredBy`,
     { "nodeId": "draft-risk-brief", "dependsOn": ["caller"] }
   ],
   "environment": [],
+  "tools": [
+    {
+      "kind": "cli",
+      "name": "jq",
+      "requiredBy": ["draft-risk-brief"]
+    }
+  ],
   "warnings": []
 }
 ```
@@ -215,6 +222,9 @@ Do not emit `service`, `source`, `sourceName`, `target`, `triggeredBy`,
 "dependsOn": [...] }`. It is not a numbered step list.
 
 `environment` is an array of `{ "name": "ENV_VAR", "requiredBy": ["node-id"] }`.
+`tools` is an array of `{ "kind": "cli", "name": "executable", "requiredBy":
+["node-id"] }`. `requiredBy` entries must reference graph node ids in the same
+Forme manifest. Current v0 IR supports only `kind: "cli"` tool records.
 `warnings` is an array of non-empty strings.
 
 ## Diagnostics

--- a/skills/open-prose/contract-markdown.md
+++ b/skills/open-prose/contract-markdown.md
@@ -141,6 +141,7 @@ Forme and the Prose VM recognize these `###` sections case-insensitively:
 | `### Runtime` | system, service | Execution hints such as `persist` and `model` |
 | `### Memory` | service | Declared reads from and writes to persistent agent memory. Only meaningful when `### Runtime` sets `persist: project` or `persist: user` |
 | `### Skills` | system, service | Agent harness skills the component requires the host harness to provide. See [Skills](#skills) |
+| `### Tools` | system, service | Host tools the component requires the host environment to provide. See [Tools](#tools) |
 | `### Shape` | service | Capability boundaries: self, delegates, and prohibited work |
 | `### Wiring` | system | Explicit Level 2 wiring declaration |
 | `### Execution` | system, service | ProseScript choreography that pins execution |
@@ -434,6 +435,51 @@ program-level contract.
 OpenProse never installs, modifies, or removes the user's harness skills.
 Installing skills is the user's responsibility; the compiler only verifies they
 are present and stops the compile when they are not.
+
+## Tools
+
+A system or service that depends on host executables declares them in a
+`### Tools` section. Tool declarations are host capability requirements: they
+do not satisfy `### Requires`, do not create Forme dependency-graph edges, and
+do not grant or restrict tool use. Use `### Shape` for service boundaries and
+prohibited actions.
+
+```markdown
+### Tools
+
+- `cli:gh`: GitHub CLI available on PATH for PR inspection
+- `cli:jq`: JSON CLI available on PATH for JSON validation
+```
+
+The current deterministic tool declaration shape is `cli:<executable-name>`.
+The executable name is the command name the host should find by PATH lookup. It
+must be non-empty and must not contain path separators. Tool declarations
+belong only in the `### Tools` section; there is no frontmatter form.
+
+Rules:
+
+- System-level declarations apply to every sub-service inside the system.
+  Service-level declarations are additive, not exclusive.
+- `cli:<name>` checks only executable presence on PATH. Version ranges, auth
+  checks, and installer behavior are outside the declaration.
+- Namespaces other than `cli` are reserved. The current compiler reports
+  `tool_unsupported_kind` for reserved but unsupported namespaces such as
+  `mcp:github`.
+- A malformed declaration, such as `gh` or `cli:`, reports `tool_invalid`.
+- A supported `cli:<name>` declaration that cannot be found on PATH reports
+  `tool_unresolved`.
+- `prose compile` fails closed when any `tool_invalid`,
+  `tool_unsupported_kind`, or `tool_unresolved` diagnostic is emitted.
+
+The compiler program implements this resolution rule; see
+`skills/open-prose/compiler/index.prose.md` (`tools_resolver`) for the
+program-level contract.
+
+### BYO host tools invariant
+
+OpenProse never installs, modifies, upgrades, or removes host tools. Installing
+and authenticating host tools is the user's responsibility; the compiler only
+verifies declared tools are present and stops the compile when they are not.
 
 ## Frontmatter
 

--- a/skills/open-prose/examples/README.md
+++ b/skills/open-prose/examples/README.md
@@ -26,6 +26,10 @@ receipts in `runs/`, durable state in `state/`, and dependencies in `deps/`.
   skills (grill-with-docs, to-prd, to-issues, tdd, plus his per-repo
   conventions) into a single non-interactive OpenProse system, with the
   two-subagent grill-and-decide split called out as an OpenProse adaptation.
+- [declared-skills](./declared-skills/) shows a minimal `### Skills`
+  requirement that fails closed at compile time when the host skill is missing.
+- [declared-tools](./declared-tools/) shows a minimal `### Tools` requirement
+  that fails closed at compile time when the host CLI executable is missing.
 
 ## Quick Start
 

--- a/skills/open-prose/examples/declared-tools/README.md
+++ b/skills/open-prose/examples/declared-tools/README.md
@@ -1,0 +1,14 @@
+# Declared Tools
+
+A minimal example demonstrating the `### Tools` section: how a `.prose.md`
+component declares which host CLI executables it requires the host environment
+to provide.
+
+The component in `src/json-verifier.prose.md` declares `cli:jq` as a required
+host tool. When `prose compile` is run against this directory, the compiler's
+`tools_resolver` checks for a `jq` executable on PATH and fails closed with
+`tool_unresolved` if it is not available.
+
+See `skills/open-prose/contract-markdown.md` (Tools) and
+`skills/open-prose/compiler/index.prose.md` (`tools_resolver`) for the full
+specification.

--- a/skills/open-prose/examples/declared-tools/src/json-verifier.prose.md
+++ b/skills/open-prose/examples/declared-tools/src/json-verifier.prose.md
@@ -1,0 +1,28 @@
+---
+name: json-verifier
+kind: service
+---
+
+# JSON Verifier
+
+### Description
+
+Validates generated JSON before a downstream system consumes it.
+
+### Requires
+
+- `candidate_json`: JSON text to validate
+
+### Ensures
+
+- `validation_report`: whether the JSON is valid, with parse errors and line
+  references when validation fails
+
+### Tools
+
+- `cli:jq`: JSON CLI available on PATH for syntax validation
+
+### Strategies
+
+- when JSON validation fails, report the parse error and location without
+  rewriting the input

--- a/skills/open-prose/forme.md
+++ b/skills/open-prose/forme.md
@@ -155,7 +155,7 @@ If a service or system cannot be resolved, emit an error:
 For each resolved service or system, extract from its `*.prose.md` file:
 
 - **Frontmatter:** `name`, `kind`
-- **Sections:** `### Services`, `### Requires`, `### Ensures`, `### Errors`, `### Invariants`, `### Strategies`, `### Environment`, `### Runtime`, `### Shape`
+- **Sections:** `### Services`, `### Requires`, `### Ensures`, `### Errors`, `### Invariants`, `### Strategies`, `### Environment`, `### Runtime`, `### Memory`, `### Skills`, `### Tools`, `### Shape`
 
 **Header hierarchy:**
 
@@ -315,6 +315,34 @@ After building the dependency graph, collect all `### Environment` declarations 
 
 This enables `prose preflight` to verify the entire environment from the top-level system without traversing the dependency graph at runtime.
 
+### Step 5c: Collect Tool Declarations
+
+Collect all `### Tools` declarations from every system and service in the
+graph. Tool declarations are host capability requirements. They do not satisfy
+`### Requires`, do not create dependency-graph edges, and do not make a tool an
+allowed or prohibited action.
+
+For repository compile, consume the compiler program's `tools_resolution`
+output. The compiler resolves only supported declarations before Forme emits a
+manifest:
+
+1. **Gather** -- for each system and service, extract its `### Tools` section
+   if present.
+2. **Inherit** -- system-level declarations apply to every sub-service in that
+   system; service-level declarations are additive.
+3. **Resolve** -- supported `cli:<name>` declarations must resolve to an
+   executable on host PATH before the manifest is emitted.
+4. **Attribute** -- emit one manifest entry per resolved CLI tool with the graph
+   nodes that require it:
+
+```json
+{ "kind": "cli", "name": "jq", "requiredBy": ["verifier"] }
+```
+
+Only resolved CLI tools are emitted. Invalid, unsupported, or unresolved tool
+declarations are compile errors and prevent `manifest.next.json` from being
+written.
+
 ### Step 6: Validate
 
 Before producing the manifest, check:
@@ -334,6 +362,9 @@ Before producing the manifest, check:
 | Config value placed under `with:` | `[Error] Pattern config 'max_rounds' belongs under config:, not with:` |
 | Cycle in nested patterns | `[Error] Cycle in pattern nesting: A → B → A` |
 | Slot name collides with config parameter name | `[Error] Pattern '{name}' has slot '{slot}' that collides with config parameter '{param}'. Slot and config names must be disjoint.` |
+| Malformed tool declaration | `[Error] Invalid tool declaration: 'gh' (expected cli:<executable-name>)` |
+| Unsupported tool namespace | `[Error] Unsupported tool kind: 'mcp:github'` |
+| Unresolved declared CLI tool | `[Error] Declared tool not found on PATH: 'cli:gh'` |
 
 **Warnings (proceed with caution):**
 
@@ -411,6 +442,9 @@ not need to re-read original source files to understand wiring.
     { "nodeId": "{service-name}", "dependsOn": ["caller"] }
   ],
   "environment": [],
+  "tools": [
+    { "kind": "cli", "name": "jq", "requiredBy": ["draft-risk-brief"] }
+  ],
   "warnings": []
 }
 ```
@@ -443,6 +477,10 @@ Constraint types emitted:
 - `delegates` — valid runtime delegation targets for this service (from `shape.delegates`), with paths to their source files. Only present if the service has `shape.delegates`.
 
 **Execution Order.** A numbered list showing which services run in what order, derived from the dependency graph. Includes parallelization notes. Delegates are not in the static execution order — they run on-demand when requested by their parent service via runtime delegation (see `prose.md`, Runtime Delegation).
+
+**Tools.** Host executable requirements collected from `### Tools`. Each record
+has `kind: "cli"`, the executable `name`, and `requiredBy` graph node ids. Tool
+records do not create graph edges.
 
 **Warnings.** Any warnings from the validation step. The execution engine can present these to the user before running.
 
@@ -889,7 +927,7 @@ The Forme Container:
 
 1. **Reads** the system file and its `### Services` section
 2. **Resolves** each service name to a `*.prose.md` file (including pattern definitions)
-3. **Extracts** contracts (`### Requires`, `### Ensures`, `### Errors`, `### Invariants`, `### Strategies`, `### Environment`), shapes, and pattern slot/config definitions
+3. **Extracts** contracts (`### Requires`, `### Ensures`, `### Errors`, `### Invariants`, `### Strategies`, `### Environment`, `### Tools`), shapes, and pattern slot/config definitions
 4. **Expands patterns** — binds slots from `with:` and parameters from `config:`, validates slot contracts, expands delegation patterns, computes derived contracts (inside-out for nested patterns)
 5. **Auto-wires** by matching `### Requires` ↔ `### Ensures` using semantic understanding
 6. **Validates** the dependency graph for errors and warnings (including pattern-specific checks)

--- a/skills/open-prose/prose.md
+++ b/skills/open-prose/prose.md
@@ -46,7 +46,7 @@ codex exec "prose run system.prose.md"
 | `prose run ...@<version>`        | Pin to a SHA or tag; require that version in `<openprose-root>/deps/`                     |
 | `prose run ... --offline`        | Require disk-only resolution; error if not in `<openprose-root>/deps/`                   |
 | `prose lint <file.prose.md>`      | Validate structure, schema, shapes, and contracts               |
-| `prose preflight <file.prose.md>` | Check dependencies and environment variables                    |
+| `prose preflight <file.prose.md>` | Check dependencies, declared tools, and environment variables   |
 | `prose test <path>`         | Run test(s) and report results                                  |
 | `prose install`             | Install dependencies from `use` statements into `<openprose-root>/deps/`        |
 | `prose install --update`    | Update pinned dependency SHAs                                   |
@@ -225,6 +225,7 @@ own tools:
 | `read_file` / `write_file` | Read and write `<openprose-root>/runs/{id}/` state artifacts and backend records |
 | `copy_binding` | Publish a declared output through the active backend; filesystem copies from `workspace/{service}/` to `bindings/{service}/` |
 | `check_env` | Confirm an environment variable exists without exposing its value |
+| `check_tool` | Confirm a declared host tool exists without installing, modifying, or running it |
 
 ---
 
@@ -324,6 +325,7 @@ filesystem snapshot at `<openprose-root>/runs/{id}/forme.manifest.json`. Extract
 - **Caller Interface** — what inputs the system needs, what it returns
 - **Graph** — each service with its source file, workspace path, inputs (with `←` mappings), and outputs
 - **Execution Order** — the sequence (with parallelization notes)
+- **Tools** — host executable requirements attributed to graph nodes
 - **Warnings** — present to the user before executing
 
 ### Step 2: Bind Caller Inputs
@@ -411,6 +413,11 @@ output for that clause.
 {if shape.prohibited exists: "You must NOT: {prohibited list}"}
 {if shape.self exists: "You are responsible for: {self list}"}
 {if shape.delegates exists: "You delegate to: {delegates list}"}
+
+## Declared Host Tools
+
+{if tools exist for this service: "The manifest declares these host tools for this service: {tool list}"}
+{if no tools exist for this service: "No host tools are declared for this service."}
 
 ## Error Signaling
 
@@ -1050,6 +1057,37 @@ The model references environment variables by name — it never reads, logs, or 
 - When a service declares `### Environment` variables, the VM verifies they are set before spawning the service's session. Verification means confirming the variable exists in the host environment — not reading or logging its value.
 - The service session can reference env vars via shell expansion (e.g., `$SLACK_WEBHOOK_URL` in a curl command) but must never construct strings containing the values, log them, or write them to workspace files.
 - If an environment variable is not set, the VM fails the service with a clear error rather than proceeding with an empty value. The error is logged to the active backend event store (filesystem: `vm.log.md`) as `N→ service-name ✗ missing-env:{VAR_NAME}`.
+
+### Resolving Tools
+
+`### Tools` declares host executables required by a service or system. The
+compiler resolves these declarations before writing repository IR, and the
+compiled Forme manifest carries resolved tools as:
+
+```json
+{ "kind": "cli", "name": "jq", "requiredBy": ["verifier"] }
+```
+
+Tool declarations are host capability checks. They do not satisfy
+`### Requires`, do not create Forme dependency-graph edges, and do not act as
+an allowlist. Use `### Shape` to describe service boundaries and prohibited
+actions.
+
+**VM behavior for manifest `tools` during execution:**
+
+- Before spawning a service, find manifest tool records whose `requiredBy`
+  includes that service's graph node id.
+- For `kind: "cli"`, verify the executable name is present on host PATH. The
+  VM checks presence only; it does not run the executable for version or auth
+  checks.
+- Include declared tool names in the service prompt so the service knows which
+  host tools its contract relies on.
+- If a required CLI tool is missing, fail the service before spawning its
+  session. Log the failure to the active backend event store as
+  `N→ service-name ✗ missing-tool:cli:{name}`.
+
+OpenProse never installs, modifies, upgrades, or removes host tools. Installing
+and authenticating tools belongs to the host/user outside the VM.
 
 ---
 

--- a/tests/open-prose/compiler/expected/stargazer.manifest.next.json
+++ b/tests/open-prose/compiler/expected/stargazer.manifest.next.json
@@ -314,6 +314,7 @@
         }
       ],
       "environment": [],
+      "tools": [],
       "warnings": []
     }
   ],

--- a/tools/cli/src/commands/compile.ts
+++ b/tools/cli/src/commands/compile.ts
@@ -17,6 +17,11 @@ import {
 	type SkillPreflight,
 } from "./base.js";
 import { preflightDeclaredSkillsInRoot, formatUnresolvedMessage } from "../skills/declared.js";
+import {
+	preflightDeclaredToolsInRoot,
+	formatInvalidToolsMessage,
+	formatUnresolvedToolsMessage,
+} from "../tools/declared.js";
 
 export class CompileValidationError extends Error {
 	readonly details: string[];
@@ -91,6 +96,10 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 
 	if (options.skillPreflight !== false) {
 		await preflightDeclaredSkillsForCompile({
+			cwd: options.cwd,
+			env: options.env,
+		});
+		await preflightDeclaredToolsForCompile({
 			cwd: options.cwd,
 			env: options.env,
 		});
@@ -214,6 +223,35 @@ async function preflightDeclaredSkillsForCompile(options: {
 			? "Declared skill could not be resolved (skill_unresolved)."
 			: `${result.unresolved.length} declared skills could not be resolved (skill_unresolved).`;
 	throw new CompileValidationError(heading, formatUnresolvedMessage(result.unresolved).split(/\r?\n/).slice(1));
+}
+
+async function preflightDeclaredToolsForCompile(options: {
+	cwd: string;
+	env: Readonly<Record<string, string | undefined>>;
+}): Promise<void> {
+	const root = await resolveOpenProseRoot({
+		cwd: options.cwd,
+		...(options.env.HOME === undefined ? {} : { home: options.env.HOME }),
+	});
+	const result = await preflightDeclaredToolsInRoot(root.absolutePath, {
+		cwd: options.cwd,
+		...(options.env.PATH === undefined ? {} : { path: options.env.PATH }),
+	});
+	if (result.invalid.length > 0) {
+		const heading =
+			result.invalid.length === 1
+				? `Declared tool declaration is invalid (${result.invalid[0]?.code ?? "tool_invalid"}).`
+				: `${result.invalid.length} declared tool declarations are invalid.`;
+		throw new CompileValidationError(heading, formatInvalidToolsMessage(result.invalid).split(/\r?\n/).slice(1));
+	}
+	if (result.unresolved.length === 0) {
+		return;
+	}
+	const heading =
+		result.unresolved.length === 1
+			? "Declared tool could not be resolved (tool_unresolved)."
+			: `${result.unresolved.length} declared tools could not be resolved (tool_unresolved).`;
+	throw new CompileValidationError(heading, formatUnresolvedToolsMessage(result.unresolved).split(/\r?\n/).slice(1));
 }
 
 async function resolveCompiledManifestTarget(options: {

--- a/tools/cli/src/prose/index.ts
+++ b/tools/cli/src/prose/index.ts
@@ -42,6 +42,8 @@ export {
 	type RepositoryIrFormeManifest,
 	type RepositoryIrFormeNode,
 	type RepositoryIrFormeOutputBinding,
+	type RepositoryIrFormeTool,
+	type RepositoryIrFormeToolKind,
 	type RepositoryIrResponsibility,
 	type RepositoryIrSource,
 	type RepositoryIrSourceKind,

--- a/tools/cli/src/prose/repository-ir.ts
+++ b/tools/cli/src/prose/repository-ir.ts
@@ -124,6 +124,14 @@ export interface RepositoryIrFormeEnvironmentVariable {
 	requiredBy: string[];
 }
 
+export type RepositoryIrFormeToolKind = "cli";
+
+export interface RepositoryIrFormeTool {
+	kind: RepositoryIrFormeToolKind;
+	name: string;
+	requiredBy: string[];
+}
+
 export interface RepositoryIrFormeManifest {
 	id: string;
 	systemName: string;
@@ -135,6 +143,7 @@ export interface RepositoryIrFormeManifest {
 	graph: RepositoryIrFormeNode[];
 	executionOrder: RepositoryIrFormeExecutionStep[];
 	environment: RepositoryIrFormeEnvironmentVariable[];
+	tools: RepositoryIrFormeTool[];
 	warnings: string[];
 }
 
@@ -206,6 +215,7 @@ const activationIntentKinds: readonly RepositoryIrActivationIntentKind[] = [
 	"escalation",
 ];
 const formeInputSources: readonly RepositoryIrFormeInputSource[] = ["caller", "service"];
+const formeToolKinds: readonly RepositoryIrFormeToolKind[] = ["cli"];
 const httpMethods = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
 
 export function validateRepositoryIr(value: unknown): RepositoryIrValidationResult {
@@ -649,6 +659,7 @@ function validateFormeManifests(value: unknown, sourcePaths: Set<string>, errors
 		validateFormeCaller(manifest.caller, `${prefix}.caller`, graph, errors);
 		validateFormeExecutionOrder(manifest.executionOrder, `${prefix}.executionOrder`, graph, errors);
 		validateFormeEnvironment(manifest.environment, `${prefix}.environment`, graph.nodeIds, errors);
+		validateFormeTools(manifest.tools, `${prefix}.tools`, graph.nodeIds, errors);
 		validateStringArrayAllowEmpty(manifest.warnings, `${prefix}.warnings`, errors);
 	}
 
@@ -969,16 +980,46 @@ function validateFormeEnvironment(
 		if (!isNonEmptyString(variable.name)) {
 			errors.push(`${variablePrefix}.name must be a non-empty string`);
 		}
-		if (!Array.isArray(variable.requiredBy)) {
-			errors.push(`${variablePrefix}.requiredBy must be an array`);
+		validateRequiredByNodeReferences(variable.requiredBy, `${variablePrefix}.requiredBy`, nodeIds, errors);
+	}
+}
+
+function validateFormeTools(value: unknown, prefix: string, nodeIds: Set<string>, errors: string[]): void {
+	if (!Array.isArray(value)) {
+		errors.push(`${prefix} must be an array`);
+		return;
+	}
+	for (const [index, tool] of value.entries()) {
+		if (!isRecord(tool)) {
+			errors.push(`${prefix}[${index}] must be an object`);
 			continue;
 		}
-		if (variable.requiredBy.length === 0) {
-			errors.push(`${variablePrefix}.requiredBy must contain at least one node id`);
+		const toolPrefix = `${prefix}[${index}]`;
+		if (!formeToolKinds.includes(tool.kind as RepositoryIrFormeToolKind)) {
+			errors.push(`${toolPrefix}.kind must be cli`);
 		}
-		for (const [requiredByIndex, requiredBy] of variable.requiredBy.entries()) {
-			validateNodeReference(requiredBy, nodeIds, `${variablePrefix}.requiredBy[${requiredByIndex}]`, errors);
+		if (!isNonEmptyString(tool.name)) {
+			errors.push(`${toolPrefix}.name must be a non-empty string`);
 		}
+		validateRequiredByNodeReferences(tool.requiredBy, `${toolPrefix}.requiredBy`, nodeIds, errors);
+	}
+}
+
+function validateRequiredByNodeReferences(
+	value: unknown,
+	prefix: string,
+	nodeIds: Set<string>,
+	errors: string[],
+): void {
+	if (!Array.isArray(value)) {
+		errors.push(`${prefix} must be an array`);
+		return;
+	}
+	if (value.length === 0) {
+		errors.push(`${prefix} must contain at least one node id`);
+	}
+	for (const [index, requiredBy] of value.entries()) {
+		validateNodeReference(requiredBy, nodeIds, `${prefix}[${index}]`, errors);
 	}
 }
 

--- a/tools/cli/src/tools/declared.ts
+++ b/tools/cli/src/tools/declared.ts
@@ -1,0 +1,335 @@
+// Harness-side implementation of declared host tool parsing and resolution.
+// This mirrors the declared skills resolver shape while keeping tool
+// resolution constrained to v1 `cli:<executable>` declarations on PATH.
+
+import { constants } from "node:fs";
+import { access, readdir, readFile, stat } from "node:fs/promises";
+import { delimiter, join } from "node:path";
+
+export interface DeclaredToolSearchOptions {
+	cwd: string;
+	path?: string;
+}
+
+export interface ResolvedDeclaredTool {
+	tool: string;
+	executable: string;
+	path: string;
+	source?: string;
+}
+
+export interface UnresolvedDeclaredTool {
+	tool: string;
+	executable: string;
+	searched: string[];
+	source?: string;
+}
+
+export type InvalidDeclaredToolCode = "tool_invalid" | "tool_unsupported_kind";
+
+export interface InvalidDeclaredTool {
+	declaration: string;
+	code: InvalidDeclaredToolCode;
+	message: string;
+	source?: string;
+}
+
+export interface ResolveDeclaredToolResult {
+	tool: string;
+	executable: string;
+	resolved: boolean;
+	path?: string;
+	searched: string[];
+}
+
+export interface ResolveDeclaredToolsForFileResult {
+	declared: string[];
+	invalid: InvalidDeclaredTool[];
+	resolved: ResolvedDeclaredTool[];
+	unresolved: UnresolvedDeclaredTool[];
+}
+
+const TOOL_HEADING = /^###[ \t]+tools[ \t]*$/i;
+const NEXT_HEADING = /^#{1,3}[ \t]/;
+const BULLET = /^[-*+][ \t]+(.+?)[ \t]*$/;
+const CLI_TOOL_EXACT = /^cli:([A-Za-z0-9][A-Za-z0-9_.-]*)$/;
+const NAMESPACE = /^([A-Za-z][A-Za-z0-9_.-]*):/;
+
+export function parseDeclaredTools(content: string): string[] {
+	return parseDeclaredToolSection(content).declared;
+}
+
+export function parseDeclaredToolDiagnostics(content: string): InvalidDeclaredTool[] {
+	return parseDeclaredToolSection(content).invalid;
+}
+
+function parseDeclaredToolSection(content: string): { declared: string[]; invalid: InvalidDeclaredTool[] } {
+	const lines = content.split(/\r?\n/);
+	const tools: string[] = [];
+	const invalid: InvalidDeclaredTool[] = [];
+	const seen = new Set<string>();
+	let inSection = false;
+
+	for (const rawLine of lines) {
+		const line = rawLine.trimEnd();
+
+		if (TOOL_HEADING.test(line)) {
+			inSection = true;
+			continue;
+		}
+
+		if (!inSection) {
+			continue;
+		}
+
+		if (NEXT_HEADING.test(line)) {
+			inSection = false;
+			continue;
+		}
+
+		const item = bulletItem(line);
+		if (item === undefined) {
+			continue;
+		}
+
+		const declaration = declarationToken(item);
+		const validation = validateToolDeclaration(declaration);
+		if (validation !== undefined) {
+			invalid.push(validation);
+			continue;
+		}
+
+		const tool = declaration;
+		if (!seen.has(tool)) {
+			seen.add(tool);
+			tools.push(tool);
+		}
+	}
+
+	return { declared: tools, invalid };
+}
+
+export function DECLARED_TOOL_SEARCH_DIRECTORIES(options: DeclaredToolSearchOptions): string[] {
+	const rawPath = options.path ?? (process.env.PATH ?? "");
+	const seen = new Set<string>();
+	const directories: string[] = [];
+
+	for (const part of rawPath.split(delimiter)) {
+		const directory = part === "" ? options.cwd : part;
+		if (!seen.has(directory)) {
+			seen.add(directory);
+			directories.push(directory);
+		}
+	}
+
+	return directories;
+}
+
+export async function resolveDeclaredTool(
+	tool: string,
+	options: DeclaredToolSearchOptions,
+): Promise<ResolveDeclaredToolResult> {
+	const searched = DECLARED_TOOL_SEARCH_DIRECTORIES(options);
+	const executable = executableForTool(tool);
+	if (executable === undefined) {
+		return { tool, executable: "", resolved: false, searched };
+	}
+
+	for (const directory of searched) {
+		const candidate = join(directory, executable);
+		if (await isExecutableFile(candidate)) {
+			return { tool, executable, resolved: true, path: candidate, searched };
+		}
+	}
+	return { tool, executable, resolved: false, searched };
+}
+
+export async function resolveDeclaredToolsForFile(
+	filePath: string,
+	options: DeclaredToolSearchOptions,
+): Promise<ResolveDeclaredToolsForFileResult> {
+	const content = await readFile(filePath, "utf8");
+	const parsed = parseDeclaredToolSection(content);
+	const declared = parsed.declared;
+	const invalid = parsed.invalid.map((entry) => ({ ...entry, source: filePath }));
+	const resolved: ResolvedDeclaredTool[] = [];
+	const unresolved: UnresolvedDeclaredTool[] = [];
+
+	for (const tool of declared) {
+		const result = await resolveDeclaredTool(tool, options);
+		if (result.resolved && result.path !== undefined) {
+			resolved.push({ tool: result.tool, executable: result.executable, path: result.path, source: filePath });
+		} else {
+			unresolved.push({
+				tool: result.tool,
+				executable: result.executable,
+				searched: result.searched,
+				source: filePath,
+			});
+		}
+	}
+
+	return { declared, invalid, resolved, unresolved };
+}
+
+export async function preflightDeclaredToolsInRoot(
+	rootPath: string,
+	options: DeclaredToolSearchOptions,
+): Promise<ResolveDeclaredToolsForFileResult> {
+	const files = await collectProseFiles(rootPath);
+	const declared: string[] = [];
+	const invalid: InvalidDeclaredTool[] = [];
+	const resolved: ResolvedDeclaredTool[] = [];
+	const unresolved: UnresolvedDeclaredTool[] = [];
+	const seen = new Set<string>();
+
+	for (const file of files) {
+		const result = await resolveDeclaredToolsForFile(file, options);
+		for (const tool of result.declared) {
+			if (!seen.has(tool)) {
+				seen.add(tool);
+				declared.push(tool);
+			}
+		}
+		invalid.push(...result.invalid);
+		resolved.push(...result.resolved);
+		unresolved.push(...result.unresolved);
+	}
+
+	return { declared, invalid, resolved, unresolved };
+}
+
+export class DeclaredToolsUnresolvedError extends Error {
+	readonly unresolved: readonly UnresolvedDeclaredTool[];
+
+	constructor(unresolved: readonly UnresolvedDeclaredTool[]) {
+		super(formatUnresolvedToolsMessage(unresolved));
+		this.name = "DeclaredToolsUnresolvedError";
+		this.unresolved = [...unresolved];
+	}
+}
+
+export function formatUnresolvedToolsMessage(unresolved: readonly UnresolvedDeclaredTool[]): string {
+	if (unresolved.length === 0) {
+		return "No unresolved declared tools.";
+	}
+	const heading =
+		unresolved.length === 1
+			? "Declared tool could not be resolved."
+			: `${unresolved.length} declared tools could not be resolved.`;
+	const details = unresolved.map((entry) => {
+		const source = entry.source ? ` (declared in ${entry.source})` : "";
+		const executable = entry.executable ? ` executable ${entry.executable}` : "";
+		const pathLines: string[] = [];
+		for (const searchedPath of entry.searched) {
+			pathLines.push(`    - ${searchedPath}`);
+		}
+		const paths = pathLines.join("\n");
+		return `- ${entry.tool}${source}${executable}\n  searched PATH:\n${paths}`;
+	});
+	return [heading, ...details].join("\n");
+}
+
+export function formatInvalidToolsMessage(invalid: readonly InvalidDeclaredTool[]): string {
+	if (invalid.length === 0) {
+		return "No invalid declared tools.";
+	}
+	const heading =
+		invalid.length === 1
+			? "Declared tool declaration is invalid."
+			: `${invalid.length} declared tool declarations are invalid.`;
+	const details = invalid.map((entry) => {
+		const source = entry.source ? ` (declared in ${entry.source})` : "";
+		return `- ${entry.declaration}${source}: ${entry.code} ${entry.message}`;
+	});
+	return [heading, ...details].join("\n");
+}
+
+async function collectProseFiles(rootPath: string): Promise<string[]> {
+	const out: string[] = [];
+	const queue: string[] = [rootPath];
+	while (queue.length > 0) {
+		const current = queue.pop();
+		if (current === undefined) {
+			continue;
+		}
+		let entries;
+		try {
+			entries = await readdir(current, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (entry.name.startsWith(".") || entry.name === "node_modules") {
+				continue;
+			}
+			const path = join(current, entry.name);
+			if (entry.isDirectory()) {
+				queue.push(path);
+			} else if (entry.isFile() && entry.name.endsWith(".prose.md")) {
+				out.push(path);
+			}
+		}
+	}
+	out.sort();
+	return out;
+}
+
+function stripBackticks(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.startsWith("`") && trimmed.endsWith("`") && trimmed.length >= 2) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function declarationToken(value: string): string {
+	const trimmed = value.trim();
+	const codeSpan = trimmed.match(/^`([^`]+)`/);
+	if (codeSpan?.[1] !== undefined) {
+		return codeSpan[1].trim();
+	}
+	return stripBackticks(trimmed.split(/\s+/)[0] ?? "").trim();
+}
+
+function bulletItem(line: string): string | undefined {
+	const match = line.match(BULLET);
+	return match?.[1];
+}
+
+function validateToolDeclaration(declaration: string): InvalidDeclaredTool | undefined {
+	if (CLI_TOOL_EXACT.test(declaration)) {
+		return undefined;
+	}
+	const namespace = declaration.match(NAMESPACE)?.[1];
+	if (namespace !== undefined && namespace !== "cli") {
+		return {
+			declaration,
+			code: "tool_unsupported_kind",
+			message: "expected cli:<executable-name>",
+		};
+	}
+	return {
+		declaration,
+		code: "tool_invalid",
+		message: "expected cli:<executable-name> with no path separators",
+	};
+}
+
+function executableForTool(tool: string): string | undefined {
+	const match = tool.match(CLI_TOOL_EXACT);
+	return match?.[1];
+}
+
+async function isExecutableFile(path: string): Promise<boolean> {
+	try {
+		const info = await stat(path);
+		if (!info.isFile()) {
+			return false;
+		}
+		await access(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -1,4 +1,13 @@
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	copyFileSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -503,6 +512,155 @@ kind: system
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed before forwarding when a declared CLI tool cannot be resolved", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-tool-unresolved-"));
+		const io = memoryStreams();
+		let harnessInvocations = 0;
+
+		try {
+			mkdirSync(join(temp, "src"), { recursive: true });
+			writeFileSync(
+				join(temp, "src", "invoice-extractor.prose.md"),
+				`---
+name: invoice-extractor
+kind: system
+---
+
+### Tools
+
+- cli:pdftotext
+`,
+			);
+
+			await expect(
+				runCompileCommand({
+					argv: [".", "--harness", "mock"],
+					cwd: temp,
+					env: { PATH: join(temp, "empty-bin") },
+					stdout: io.streams.stdout,
+					stderr: io.streams.stderr,
+					skillBootstrap: false,
+					harnessFactory: () => ({
+						name: "mock",
+						async run() {
+							harnessInvocations += 1;
+							return 0;
+						},
+					}),
+				}),
+			).rejects.toMatchObject({
+				name: "CompileValidationError",
+				message: expect.stringContaining("tool_unresolved"),
+				details: expect.arrayContaining([
+					expect.stringContaining("cli:pdftotext"),
+				]),
+			});
+
+			expect(harnessInvocations).toBe(0);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed before forwarding when a declared tool is invalid", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-tool-invalid-"));
+		const io = memoryStreams();
+		let harnessInvocations = 0;
+
+		try {
+			mkdirSync(join(temp, "src"), { recursive: true });
+			writeFileSync(
+				join(temp, "src", "browser-check.prose.md"),
+				`---
+name: browser-check
+kind: system
+---
+
+### Tools
+
+- mcp:browser
+`,
+			);
+
+			await expect(
+				runCompileCommand({
+					argv: [".", "--harness", "mock"],
+					cwd: temp,
+					env: { PATH: join(temp, "bin") },
+					stdout: io.streams.stdout,
+					stderr: io.streams.stderr,
+					skillBootstrap: false,
+					harnessFactory: () => ({
+						name: "mock",
+						async run() {
+							harnessInvocations += 1;
+							return 0;
+						},
+					}),
+				}),
+			).rejects.toMatchObject({
+				name: "CompileValidationError",
+				message: expect.stringContaining("tool_unsupported_kind"),
+				details: expect.arrayContaining([
+					expect.stringContaining("mcp:browser"),
+				]),
+			});
+
+			expect(harnessInvocations).toBe(0);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("forwards compile when declared CLI tools resolve on PATH", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-tool-resolved-"));
+		const io = memoryStreams();
+		let harnessInvocations = 0;
+
+		try {
+			const bin = join(temp, "bin");
+			mkdirSync(join(temp, "src"), { recursive: true });
+			mkdirSync(bin, { recursive: true });
+			writeFileSync(join(bin, "jq"), "#!/bin/sh\nexit 0\n");
+			chmodSync(join(bin, "jq"), 0o755);
+			writeFileSync(
+				join(temp, "src", "json-summarizer.prose.md"),
+				`---
+name: json-summarizer
+kind: system
+---
+
+### Tools
+
+- cli:jq
+`,
+			);
+
+			const exitCode = await runCompileCommand({
+				argv: [".", "--harness", "mock"],
+				cwd: temp,
+				env: { PATH: bin },
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				harnessFactory: () => ({
+					name: "mock",
+					async run() {
+						harnessInvocations += 1;
+						mkdirSync(join(temp, "dist"), { recursive: true });
+						copyFileSync(stargazerFixture, join(temp, "dist/manifest.next.json"));
+						return 0;
+					},
+				}),
+			});
+
+			expect(exitCode).toBe(0);
+			expect(harnessInvocations).toBe(1);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
 		}
 	});
 

--- a/tools/cli/tests/prose/repository-ir.test.ts
+++ b/tools/cli/tests/prose/repository-ir.test.ts
@@ -215,6 +215,56 @@ describe("repository IR v0", () => {
 		);
 	});
 
+	it("accepts Forme manifest tool requirements", () => {
+		const manifest = cloneFixture("tests/open-prose/compiler/expected/stargazer.manifest.next.json");
+		manifest.formeManifests[0].tools = [
+			{
+				kind: "cli",
+				name: "gh",
+				requiredBy: ["stargazer-fetcher", "profile-enricher"],
+			},
+		];
+
+		expect(validateRepositoryIr(manifest)).toEqual({
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it("rejects malformed Forme manifest tool requirements", () => {
+		const manifest = cloneFixture("tests/open-prose/compiler/expected/stargazer.manifest.next.json");
+		manifest.formeManifests[0].tools = [
+			{
+				kind: "http",
+				name: "",
+				requiredBy: ["missing-node", ""],
+			},
+			{
+				kind: "cli",
+				name: "gh",
+				requiredBy: [],
+			},
+			{
+				kind: "cli",
+				name: "gh",
+			},
+		];
+
+		const result = validateRepositoryIr(manifest);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				"formeManifests[0].tools[0].kind must be cli",
+				"formeManifests[0].tools[0].name must be a non-empty string",
+				"formeManifests[0].tools[0].requiredBy[0] must reference a known graph node",
+				"formeManifests[0].tools[0].requiredBy[1] must be a non-empty string",
+				"formeManifests[0].tools[1].requiredBy must contain at least one node id",
+				"formeManifests[0].tools[2].requiredBy must be an array",
+			]),
+		);
+	});
+
 	it("rejects responsibilities without exactly one judge activation", () => {
 		const manifest = cloneFixture("tests/open-prose/compiler/expected/stargazer.manifest.next.json");
 		manifest.activations = manifest.activations.filter((activation: any) => activation.kind !== "judge");

--- a/tools/cli/tests/tools/declared.test.ts
+++ b/tools/cli/tests/tools/declared.test.ts
@@ -1,0 +1,474 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	DECLARED_TOOL_SEARCH_DIRECTORIES,
+	DeclaredToolsUnresolvedError,
+	formatInvalidToolsMessage,
+	formatUnresolvedToolsMessage,
+	parseDeclaredToolDiagnostics,
+	parseDeclaredTools,
+	preflightDeclaredToolsInRoot,
+	resolveDeclaredTool,
+	resolveDeclaredToolsForFile,
+} from "../../src/tools/declared.js";
+
+function tempDir(): string {
+	return mkdtempSync(join(tmpdir(), "prose-declared-tool-"));
+}
+
+function writeFile(path: string, content: string): string {
+	mkdirSync(path.replace(/\/[^/]+$/, ""), { recursive: true });
+	writeFileSync(path, content);
+	return path;
+}
+
+function writeExecutableStub(root: string, name: string): string {
+	const toolPath = join(root, name);
+	mkdirSync(root, { recursive: true });
+	writeFileSync(toolPath, "#!/bin/sh\nexit 0\n");
+	chmodSync(toolPath, 0o755);
+	return toolPath;
+}
+
+describe("parseDeclaredTools", () => {
+	it("returns no tools when no ### Tools section is present", () => {
+		const tools = parseDeclaredTools(`---
+name: invoice-extractor
+kind: system
+---
+
+### Description
+
+A system that extracts invoice data.
+
+### Requires
+
+- \`invoice\`: a PDF document.
+`);
+		expect(tools).toEqual([]);
+	});
+
+	it("extracts v1 cli declarations from a ### Tools section", () => {
+		const tools = parseDeclaredTools(`---
+name: invoice-extractor
+kind: system
+---
+
+### Tools
+
+- cli:pdftotext
+- \`cli:jq\`
+`);
+		expect(tools).toEqual(["cli:pdftotext", "cli:jq"]);
+	});
+
+	it("ignores prose lines and free text inside the section", () => {
+		const tools = parseDeclaredTools(`### Tools
+
+The component needs these host tools available:
+
+- cli:pdftotext - used to parse invoices
+- cli:jq
+`);
+		expect(tools).toEqual(["cli:pdftotext", "cli:jq"]);
+	});
+
+	it("reports malformed and unsupported declarations from the section", () => {
+		const diagnostics = parseDeclaredToolDiagnostics(`### Tools
+
+- gh
+- cli:
+- cli:bin/gh
+- mcp:browser
+`);
+		expect(diagnostics).toEqual([
+			{
+				declaration: "gh",
+				code: "tool_invalid",
+				message: "expected cli:<executable-name> with no path separators",
+			},
+			{
+				declaration: "cli:",
+				code: "tool_invalid",
+				message: "expected cli:<executable-name> with no path separators",
+			},
+			{
+				declaration: "cli:bin/gh",
+				code: "tool_invalid",
+				message: "expected cli:<executable-name> with no path separators",
+			},
+			{
+				declaration: "mcp:browser",
+				code: "tool_unsupported_kind",
+				message: "expected cli:<executable-name>",
+			},
+		]);
+	});
+
+	it("does not bleed into the next ### section", () => {
+		const tools = parseDeclaredTools(`### Tools
+
+- cli:pdftotext
+
+### Requires
+
+- cli:jq
+`);
+		expect(tools).toEqual(["cli:pdftotext"]);
+	});
+
+	it("is case-insensitive on the section header", () => {
+		const tools = parseDeclaredTools(`### tools
+
+- cli:pdftotext
+`);
+		expect(tools).toEqual(["cli:pdftotext"]);
+	});
+
+	it("dedupes repeated declarations preserving first occurrence", () => {
+		const tools = parseDeclaredTools(`### Tools
+
+- cli:pdftotext
+- cli:pdftotext
+- cli:jq
+`);
+		expect(tools).toEqual(["cli:pdftotext", "cli:jq"]);
+	});
+});
+
+describe("DECLARED_TOOL_SEARCH_DIRECTORIES", () => {
+	it("lists PATH directories in order and treats empty entries as cwd", () => {
+		const cwd = "/work/project";
+		const dirs = DECLARED_TOOL_SEARCH_DIRECTORIES({
+			cwd,
+			path: ["/opt/bin", "", "/usr/local/bin", "/opt/bin"].join(delimiter),
+		});
+		expect(dirs).toEqual(["/opt/bin", cwd, "/usr/local/bin"]);
+	});
+});
+
+describe("resolveDeclaredTool", () => {
+	it("resolves to the first PATH directory that contains an executable", async () => {
+		const cwd = tempDir();
+		const firstBin = join(cwd, "first-bin");
+		const secondBin = join(cwd, "second-bin");
+		try {
+			writeExecutableStub(secondBin, "pdftotext");
+
+			const result = await resolveDeclaredTool("cli:pdftotext", {
+				cwd,
+				path: [firstBin, secondBin].join(delimiter),
+			});
+			expect(result.resolved).toBe(true);
+			expect(result.tool).toBe("cli:pdftotext");
+			expect(result.executable).toBe("pdftotext");
+			expect(result.path).toBe(join(secondBin, "pdftotext"));
+			expect(result.searched).toEqual([firstBin, secondBin]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers earlier PATH directories", async () => {
+		const cwd = tempDir();
+		const firstBin = join(cwd, "first-bin");
+		const secondBin = join(cwd, "second-bin");
+		try {
+			writeExecutableStub(firstBin, "jq");
+			writeExecutableStub(secondBin, "jq");
+
+			const result = await resolveDeclaredTool("cli:jq", {
+				cwd,
+				path: [firstBin, secondBin].join(delimiter),
+			});
+			expect(result.resolved).toBe(true);
+			expect(result.path).toBe(join(firstBin, "jq"));
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not resolve non-executable files", async () => {
+		const cwd = tempDir();
+		const bin = join(cwd, "bin");
+		try {
+			mkdirSync(bin, { recursive: true });
+			writeFileSync(join(bin, "jq"), "#!/bin/sh\nexit 0\n");
+
+			const result = await resolveDeclaredTool("cli:jq", { cwd, path: bin });
+			expect(result.resolved).toBe(false);
+			expect(result.searched).toEqual([bin]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("returns unresolved with the searched PATH directories when no executable is found", async () => {
+		const cwd = tempDir();
+		const firstBin = join(cwd, "first-bin");
+		const secondBin = join(cwd, "second-bin");
+		try {
+			const result = await resolveDeclaredTool("cli:pdftotext", {
+				cwd,
+				path: [firstBin, secondBin].join(delimiter),
+			});
+			expect(result.resolved).toBe(false);
+			expect(result.tool).toBe("cli:pdftotext");
+			expect(result.executable).toBe("pdftotext");
+			expect(result.searched).toEqual([firstBin, secondBin]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveDeclaredToolsForFile", () => {
+	it("returns no diagnostics for a file with no ### Tools section", async () => {
+		const cwd = tempDir();
+		try {
+			const file = writeFile(
+				join(cwd, "trivial.prose.md"),
+				`---
+name: trivial
+kind: service
+---
+
+### Description
+
+Nothing to declare.
+`,
+			);
+			const result = await resolveDeclaredToolsForFile(file, { cwd, path: "" });
+			expect(result.declared).toEqual([]);
+			expect(result.invalid).toEqual([]);
+			expect(result.unresolved).toEqual([]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("flags unresolved tools with the searched paths and the source file", async () => {
+		const cwd = tempDir();
+		const bin = join(cwd, "bin");
+		try {
+			const file = writeFile(
+				join(cwd, "src", "invoice-extractor.prose.md"),
+				`---
+name: invoice-extractor
+kind: system
+---
+
+### Tools
+
+- cli:pdftotext
+`,
+			);
+			const result = await resolveDeclaredToolsForFile(file, { cwd, path: bin });
+			expect(result.declared).toEqual(["cli:pdftotext"]);
+			expect(result.invalid).toEqual([]);
+			expect(result.unresolved.length).toBe(1);
+			expect(result.unresolved[0]?.tool).toBe("cli:pdftotext");
+			expect(result.unresolved[0]?.executable).toBe("pdftotext");
+			expect(result.unresolved[0]?.source).toBe(file);
+			expect(result.unresolved[0]?.searched).toEqual([bin]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("treats backticked tool declarations the same as plain ones", async () => {
+		const cwd = tempDir();
+		const bin = join(cwd, "bin");
+		try {
+			writeExecutableStub(bin, "pdftotext");
+			const file = writeFile(
+				join(cwd, "src", "extractor.prose.md"),
+				`---
+name: extractor
+kind: system
+---
+
+### Tools
+
+- \`cli:pdftotext\`
+`,
+			);
+			const result = await resolveDeclaredToolsForFile(file, { cwd, path: bin });
+			expect(result.unresolved).toEqual([]);
+			expect(result.resolved[0]?.path).toBe(join(bin, "pdftotext"));
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("returns no unresolved tools when every declared tool resolves", async () => {
+		const cwd = tempDir();
+		const bin = join(cwd, "bin");
+		try {
+			writeExecutableStub(bin, "pdftotext");
+			const file = writeFile(
+				join(cwd, "src", "invoice-extractor.prose.md"),
+				`---
+name: invoice-extractor
+kind: system
+---
+
+### Tools
+
+- cli:pdftotext
+`,
+			);
+			const result = await resolveDeclaredToolsForFile(file, { cwd, path: bin });
+			expect(result.declared).toEqual(["cli:pdftotext"]);
+			expect(result.unresolved).toEqual([]);
+			expect(result.resolved).toEqual([
+				{
+					tool: "cli:pdftotext",
+					executable: "pdftotext",
+					path: join(bin, "pdftotext"),
+					source: file,
+				},
+			]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("preflightDeclaredToolsInRoot", () => {
+	it("walks .prose.md files under the root and aggregates declared tools", async () => {
+		const cwd = tempDir();
+		const bin = join(cwd, "bin");
+		try {
+			writeExecutableStub(bin, "jq");
+			writeFile(
+				join(cwd, "src", "a.prose.md"),
+				`---
+name: a
+kind: service
+---
+
+### Tools
+
+- cli:pdftotext
+`,
+			);
+			writeFile(
+				join(cwd, "src", "nested", "b.prose.md"),
+				`---
+name: b
+kind: service
+---
+
+### Tools
+
+- cli:jq
+`,
+			);
+			writeFile(
+				join(cwd, "src", "no-tools.prose.md"),
+				`---
+name: c
+kind: service
+---
+
+### Description
+
+Nothing declared.
+`,
+			);
+			writeFile(join(cwd, "README.md"), "# not a prose file");
+
+			const result = await preflightDeclaredToolsInRoot(cwd, { cwd, path: bin });
+			expect(result.declared).toEqual(["cli:pdftotext", "cli:jq"]);
+			expect(result.resolved.map((entry) => entry.tool)).toEqual(["cli:jq"]);
+			expect(result.unresolved.map((entry) => entry.tool)).toEqual(["cli:pdftotext"]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores hidden directories and node_modules", async () => {
+		const cwd = tempDir();
+		try {
+			writeFile(
+				join(cwd, ".cache", "stale.prose.md"),
+				`---
+name: stale
+kind: service
+---
+
+### Tools
+
+- cli:pdftotext
+`,
+			);
+			writeFile(
+				join(cwd, "node_modules", "junk.prose.md"),
+				`---
+name: junk
+kind: service
+---
+
+### Tools
+
+- cli:jq
+`,
+			);
+			const result = await preflightDeclaredToolsInRoot(cwd, { cwd, path: "" });
+			expect(result.declared).toEqual([]);
+			expect(result.invalid).toEqual([]);
+			expect(result.unresolved).toEqual([]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("DeclaredToolsUnresolvedError + formatUnresolvedToolsMessage", () => {
+	it("formats a clear, multi-line message naming the tool and searched PATH directories", () => {
+		const message = formatUnresolvedToolsMessage([
+			{
+				tool: "cli:pdftotext",
+				executable: "pdftotext",
+				source: "/work/src/x.prose.md",
+				searched: ["/work/bin", "/usr/local/bin"],
+			},
+		]);
+		expect(message).toContain("Declared tool could not be resolved.");
+		expect(message).toContain("- cli:pdftotext");
+		expect(message).toContain("(declared in /work/src/x.prose.md)");
+		expect(message).toContain("executable pdftotext");
+		expect(message).toContain("searched PATH:");
+		expect(message).toContain("/work/bin");
+		expect(message).toContain("/usr/local/bin");
+	});
+
+	it("constructs an error subclass that preserves the unresolved entries", () => {
+		const error = new DeclaredToolsUnresolvedError([
+			{ tool: "cli:pdftotext", executable: "pdftotext", searched: ["/a", "/b"] },
+		]);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("DeclaredToolsUnresolvedError");
+		expect(error.unresolved).toHaveLength(1);
+		expect(error.unresolved[0]?.tool).toBe("cli:pdftotext");
+		expect(error.message).toContain("cli:pdftotext");
+	});
+
+	it("formats invalid declarations with their diagnostic codes", () => {
+		const message = formatInvalidToolsMessage([
+			{
+				declaration: "mcp:browser",
+				code: "tool_unsupported_kind",
+				message: "expected cli:<executable-name>",
+				source: "/work/src/x.prose.md",
+			},
+		]);
+		expect(message).toContain("Declared tool declaration is invalid.");
+		expect(message).toContain("- mcp:browser");
+		expect(message).toContain("(declared in /work/src/x.prose.md)");
+		expect(message).toContain("tool_unsupported_kind");
+	});
+});


### PR DESCRIPTION
## Summary

- add a section-level `### Tools` contract for `kind: service` and `kind: system`
- support deterministic v1 `cli:<executable-name>` declarations with fail-closed compile preflight
- document the semantics across Contract Markdown, compiler, Forme, VM, and repository IR v0
- add a CLI resolver/parser plus compile-gate, repository-IR, and focused unit tests
- add a minimal `declared-tools` example using `cli:jq`

Closes #76.

## Use Case / Run Evidence

This came from the Grant Finder dogfood flow that surfaced a missing host-capability declaration: OpenProse components can declare harness skills with `### Skills`, but could not declare ordinary host CLIs such as `gh`, `jq`, `sqlite3`, or `psql`.

Issue #76 captured the proposal and maintainer feedback. The answered questions landed on:

- section name: `### Tools`
- v1 declaration shape: strict `cli:<name>`
- enforcement parity with declared skills: fail closed on `prose compile`
- tests should be native and run through the normal CLI/GitHub Actions path

## Design Boundary

This follows the PR #75 contribution bar and keeps the language/framework/harness boundary explicit:

- semantics live in `skills/open-prose/contract-markdown.md`, `compiler/index.prose.md`, `forme.md`, `prose.md`, and `compiler/ir-v0.md`
- deterministic host implementation lives in `tools/cli/src/tools/declared.ts` and the compile command preflight
- repository IR validation accepts only resolved `{ kind: "cli", name, requiredBy }` records for now
- examples live under `skills/open-prose/examples/declared-tools/`

I also checked for an existing stable MCP/tool enumeration mechanism before broadening scope. I did not find one, so this PR reserves non-CLI namespaces and reports `tool_unsupported_kind` for declarations such as `mcp:browser` rather than inventing an off-policy detector. MCP resolution remains a follow-up once the host has a stable enumeration primitive.

## Examples

```markdown
### Tools

- `cli:gh`: GitHub CLI available on PATH for PR inspection
- `cli:jq`: JSON CLI available on PATH for JSON validation
```

A missing supported executable fails before the compiler is forwarded to the harness:

```text
Declared tool could not be resolved (tool_unresolved).
- cli:pdftotext (declared in src/invoice-extractor.prose.md) executable pdftotext
  searched PATH:
    - /path/checked
```

Malformed or unsupported declarations fail with `tool_invalid` or `tool_unsupported_kind`.

## Testing

- `cd tools/cli && npm run typecheck`
- `cd tools/cli && npm test` -> 14 files, 216 tests passed
- `cd tools/cli && npm test -- tests/tools/declared.test.ts tests/cli/cli.test.ts tests/prose/repository-ir.test.ts` -> 66 tests passed before rebase
- `git diff --check origin/main..HEAD`
- `dcg scan --staged`
- `ubs tools/cli/src/tools/declared.ts` -> 0 critical, 0 warnings after cleanup
- safe-push public-repo review approved the 17-file diff before publishing

## Residual Risk / Follow-ups

- `mcp:<name>` is reserved but unsupported in this PR; it should be implemented only after a stable host enumeration mechanism exists.
- v1 checks CLI executable presence only. Version ranges, auth checks, installer behavior, and configurable search paths remain non-goals.
- The compile preflight mirrors the current declared-skills root scan behavior. If that scan scope changes later, declared tools should move with it.