### PR TITLE
[codex] Refresh README brand hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-  <img src="assets/readme-header.svg" alt="OpenProse - Engineer your agents" width="100%" />
+  <img src="https://openprose.ai/readme-header.png" alt="OpenProse - Author Outcomes" width="100%" />
 </p>
 
 <p align="center">
-  <strong>Contracts, composition, and version control for the Markdown your agents run on.</strong>
+  <strong>Write the future as a Markdown contract agents can run, review, and maintain.</strong>
 </p>
 
 <p align="center">

--- a/assets/README.md
+++ b/assets/README.md
@@ -10,7 +10,7 @@ Static assets for the OpenProse language specification repository.
 
 ## Contents
 
-- `readme-header.svg` — SVG header graphic displayed at the top of the root README.md
+- `readme-header.svg` — Legacy SVG header graphic. The root README now points at the generated `https://openprose.ai/readme-header.png` route from the Run app so the GitHub hero stays aligned with the live brand system.
 
 ## Plugin assets
 


### PR DESCRIPTION
## Summary
- Point the prose README hero at the generated OpenProse brand image route
- Update the README tagline to the current Author Outcomes language
- Mark the old inline SVG as a legacy asset

## Checks
- git diff --check