### PR TITLE
Prepare OpenProse 0.14.0 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-prose",
   "description": "Write a Markdown contract (`.prose.md`). Your agent reads it, wires services, runs subagents, and leaves an auditable trace.",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "license": "MIT",
   "homepage": "https://github.com/openprose/prose",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-prose",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Write a Markdown contract (`.prose.md`). Your agent reads it, wires services, runs subagents, and leaves an auditable trace.",
   "license": "MIT",
   "homepage": "https://github.com/openprose/prose",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-19
+
 ### Added
 
+- **`prose write` authoring workflow** — Added `std/ops/prose-author` and
+  `prose write [request...]` for turning rough English or pseudo-Prose into a
+  validated OpenProse source package. Direct in-harness `prose write` is
+  interactive by default and can ask targeted `ask_user` questions after a
+  read-only landscape scan and shape/root inference. The shell CLI wrapper
+  remains non-interactive, forwards argv/stdin with `interactive: false`, and
+  returns `unresolved-intent` rather than guessing when blocking decisions are
+  missing.
+- **Shape-aware authoring guidance** — `prose-author` now records whether the
+  output should be a compact single file, imperative-heavy `index.prose.md`,
+  multi-service folder, native OpenProse root, `.agents/prose` sidecar, or
+  `~/.agents/prose` user-global agent, then loads the targeted Contract
+  Markdown, ProseScript, Forme, Responsibility Runtime, and filesystem state
+  guidance needed for that shape.
 - **Declared `### Skills` section** — Components may now declare the agent
   harness skills they require in a `### Skills` section using the
   `namespace:name` colon form (e.g. `document-skills:pdf`). The compiler
@@ -41,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   writing `manifest.next.json` and leaves deterministic validation to the CLI.
 - **Smoke postconditions** — OpenProse smoke checks now trust verified run
   artifacts when a model exits nonzero after satisfying the fixture contract.
+- **Dependency audit** — Refreshed the `brace-expansion` lockfile entry so the
+  production dependency audit passes with no advisory findings.
 
 ## [0.13.1] - 2026-05-05
 

--- a/skills/open-prose/SKILL.md
+++ b/skills/open-prose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-prose
-version: 0.13.1
+version: 0.14.0
 runtime_contract: 1
 description: |
   Activate when the user types `prose ...`, opens a `.prose.md` file with

--- a/tools/cli/install.sh
+++ b/tools/cli/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Installs the Node-based Prose CLI from a verified release tarball.
-DEFAULT_VERSION="0.13.1"
+DEFAULT_VERSION="0.14.0"
 DEFAULT_REPO_URL="https://github.com/openprose/prose"
 
 log() {

--- a/tools/cli/package-lock.json
+++ b/tools/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openprose/prose-cli",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.90",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/prose-cli",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Run OpenProse commands through first-party Codex and Claude agent SDKs.",
   "type": "module",
   "packageManager": "npm@10.9.2",


### PR DESCRIPTION
## Summary

- Bump the unified OpenProse release train to `0.14.0` across SKILL/plugin metadata, CLI package metadata, package lock, and installer default.
- Move current Unreleased notes into `CHANGELOG.md` under `0.14.0` with the new `prose write` authoring workflow and shape-aware authoring guidance called out.
- Keep the release on the documented single release train for CLI + SKILL + plugin metadata.

## Local Validation

- `./scripts/bump-version.sh --check`
- `./scripts/sync-copy.sh --check`
- `./scripts/release-preflight.sh --version 0.14.0 --npm-tag latest --check-remote`
- `cd tools/cli && npm run audit:policy`
- `cd tools/cli && npm test`
- `cd tools/cli && npm run typecheck`
- `cd tools/cli && npm run build`
- `git diff --check`

## Release Plan After Merge

Run the protected **OpenProse Release** workflow from `main` with:

- `version`: `0.14.0`
- `npm_tag`: `latest`
- `dry_run`: `true`

If the dry run passes, rerun the same workflow with `dry_run: false` to publish the GitHub Release and `@openprose/prose-cli@0.14.0`.
