### PR TITLE
Harden Reactor v0.1 rc onboarding and edge cases

### DIFF
--- a/.github/scripts/build-reactor-release-candidate-evidence.test.mjs
+++ b/.github/scripts/build-reactor-release-candidate-evidence.test.mjs
@@ -44,7 +44,7 @@ test('release-candidate preflight builds deterministic bundle and report', async
   );
   assert.match(first.reportMarkdown, /Reactor Release Candidate Evidence Bundle/);
   assert.match(first.reportMarkdown, /Reactor imported entrypoints: 11/);
-  assert.match(first.reportMarkdown, /Cradle imported entrypoints: 23/);
+  assert.match(first.reportMarkdown, /Cradle imported entrypoints: 24/);
   assert.match(first.reportMarkdown, /release-readiness-example-smoke/);
 });
 

--- a/.github/scripts/smoke-reactor-cradle-tarball-import.mjs
+++ b/.github/scripts/smoke-reactor-cradle-tarball-import.mjs
@@ -39,6 +39,7 @@ export const CRADLE_PUBLIC_EXPORT_SUBPATHS = Object.freeze([
   './replay/model-gateway',
   './replay/parity',
   './scenario/parser',
+  './scenario',
   './scenario/runner',
   './scenario/time',
   './scenario/types',

--- a/.github/scripts/smoke-reactor-flat-tokens-example.test.mjs
+++ b/.github/scripts/smoke-reactor-flat-tokens-example.test.mjs
@@ -25,8 +25,8 @@ test('flat-tokens example source declares npm run example', async () => {
   );
 
   assert.equal(packageJson.scripts.example, 'node flat-tokens.example.mjs');
-  assert.equal(packageJson.dependencies['@openprose/reactor'], 'workspace:*');
-  assert.equal(packageJson.dependencies['@openprose/reactor-cradle'], 'workspace:*');
+  assert.equal(packageJson.dependencies['@openprose/reactor'], '0.1.0-rc.1');
+  assert.equal(packageJson.dependencies['@openprose/reactor-cradle'], '0.1.0-rc.1');
 });
 
 test('flat-tokens smoke accepts a packed-artifact consumer with valid output', async () => {

--- a/packages/reactor-cradle/.openprose-reactor-pin.json
+++ b/packages/reactor-cradle/.openprose-reactor-pin.json
@@ -1,10 +1,11 @@
 {
   "package": "@openprose/reactor",
   "version": "0.1.0-rc.1",
-  "packageTreeSha256": "a29444072fb0a02a61a9376bf3c942042afba370cc9c4d2e02f8ffb37b9301a2",
+  "packageTreeSha256": "c3d67bf600ff66563b0463f9325cd2fa288c3ee7b5a2d05477d89fd1fa8bba0c",
   "checkedFiles": [
     "package.json",
     "README.md",
+    "ADOPTION.md",
     "dist/index.js",
     "dist/index.d.ts",
     "dist/composition/index.js",

--- a/packages/reactor-cradle/README.md
+++ b/packages/reactor-cradle/README.md
@@ -7,8 +7,10 @@ for the normal test path.
 
 The Cradle is a test and evidence package, not the production Reactor runtime.
 This README describes the `0.1.0-rc.1` package surface. It is an OSS release
-candidate; the stable `0.1.0` launch waits for provenance publication and
-stranger-run verification.
+candidate that is already published on npm and has passed first-contact
+validation. Start with the
+[Reactor v0.1 adoption contract](../reactor/ADOPTION.md) for install commands,
+supported boundaries, and the golden path.
 
 ## v0.1 Status
 
@@ -40,14 +42,10 @@ What is designed and partial:
 - Provider parity is recorded, not a live runtime matrix. Cradle carries
   deterministic provider parity doubles and one live-recorded K1 cassette, but
   the runtime does not perform variable-depth live ensemble judging.
-- The tagged publish gate is wired for provenance publication, but no npm
-  publication has been run for this worktree.
+- The tagged publish gate is wired for trusted publishing with npm provenance.
 
-Deferred to v0.2 or external gates:
+Roadmap after v0.1:
 
-- Actual npm publication and provenance until a release tag and npm auth or
-  trusted publishing are available.
-- The stranger run that verifies both local demos outside the authoring team.
 - Production ingress, fulfillment, and oracle layers.
 - Runtime variable-depth ensemble judging, Postgres parity, and a non-null
   signer adapter.
@@ -88,6 +86,7 @@ The packed artifact exposes these CommonJS entrypoints:
 - `@openprose/reactor-cradle/rollback`
 - `@openprose/reactor-cradle/replay/model-gateway`
 - `@openprose/reactor-cradle/replay/parity`
+- `@openprose/reactor-cradle/scenario`
 - `@openprose/reactor-cradle/scenario/parser`
 - `@openprose/reactor-cradle/scenario/runner`
 - `@openprose/reactor-cradle/scenario/time`
@@ -224,11 +223,11 @@ observed counts for the current worktree instead of reusing stale numbers.
 It does not publish, push, contact a registry, run a live provider/model
 matrix, or claim remote CI provenance.
 
-## Explicit Deferred Rows
+## Explicit Roadmap Rows
 
 The current release-candidate evidence keeps these rows unrepresented:
 
-- `down-after-budget-exhaustion`: deferred until typed retry-budget and
+- `down-after-budget-exhaustion`: roadmap until typed retry-budget and
   pressure-dispatch primitives exist.
 - `postgres-parity`: future work; memory and filesystem parity rows are the
   represented rows today.
@@ -259,8 +258,7 @@ flat-tokens smoke runs from the same packed artifacts and expects
 
 ## Current Boundaries
 
-- This README describes the release-candidate package surface; the stable npm
-  release waits for registry-visible provenance and stranger-run evidence.
+- This README describes the published release-candidate package surface.
 - The Cradle is a deterministic harness and evidence package, not a production
   hosted service.
 - The package does not include the CLI implementation; local CLI

--- a/packages/reactor-cradle/package.json
+++ b/packages/reactor-cradle/package.json
@@ -82,6 +82,10 @@
       "types": "./dist/scenario/parser.d.ts",
       "default": "./dist/scenario/parser.js"
     },
+    "./scenario": {
+      "types": "./dist/scenario/index.d.ts",
+      "default": "./dist/scenario/index.js"
+    },
     "./scenario/runner": {
       "types": "./dist/scenario/runner.d.ts",
       "default": "./dist/scenario/runner.js"

--- a/packages/reactor-cradle/src/release-candidate/__tests__/release-candidate.test.ts
+++ b/packages/reactor-cradle/src/release-candidate/__tests__/release-candidate.test.ts
@@ -77,7 +77,7 @@ test("builds a deterministic R7 release-candidate evidence bundle", () => {
   match(first.content_hash, /^sha256:[a-f0-9]{64}$/);
   match(report, /Reactor Release Candidate Evidence Bundle/);
   match(report, /Reactor imported entrypoints: 11/);
-  match(report, /Cradle imported entrypoints: 23/);
+  match(report, /Cradle imported entrypoints: 24/);
   match(report, /release-readiness-example-smoke/);
   match(report, /Live model matrix: not-run/);
 });

--- a/packages/reactor-cradle/src/release-candidate/index.ts
+++ b/packages/reactor-cradle/src/release-candidate/index.ts
@@ -53,6 +53,7 @@ export const R7_CRADLE_PUBLIC_IMPORT_SPECIFIERS_V0 = [
   "@openprose/reactor-cradle/replay/model-gateway",
   "@openprose/reactor-cradle/replay/parity",
   "@openprose/reactor-cradle/scenario/parser",
+  "@openprose/reactor-cradle/scenario",
   "@openprose/reactor-cradle/scenario/runner",
   "@openprose/reactor-cradle/scenario/time",
   "@openprose/reactor-cradle/scenario/types",

--- a/packages/reactor-cradle/src/scenario/index.ts
+++ b/packages/reactor-cradle/src/scenario/index.ts
@@ -1,0 +1,4 @@
+export * from "./parser";
+export * from "./runner";
+export * from "./time";
+export * from "./types";

--- a/packages/reactor-cradle/src/world/__tests__/synthetic-world.test.ts
+++ b/packages/reactor-cradle/src/world/__tests__/synthetic-world.test.ts
@@ -30,6 +30,8 @@ test("static synthetic world exposes SDK connector reads from explicit state", (
   equal(first.as_of, "2026-05-18T12:00:00.000Z");
   equal(first.materialized_at, "2026-05-18T12:00:00.000Z");
   equal(first.material_version, 0);
+  equal(typeof first.payload_hash, "string");
+  equal(first.payload_hash?.startsWith("sha256:"), true);
   assertZeroSurprise(first);
 
   const timeAdvance = world.advance({
@@ -51,8 +53,38 @@ test("static synthetic world exposes SDK connector reads from explicit state", (
   deepEqual(second.state, first.state);
   equal(second.materialized_at, first.materialized_at);
   equal(second.material_version, first.material_version);
+  equal(second.payload_hash, first.payload_hash);
   equal(second.surprise.event_index, 1);
   assertZeroSurprise(second);
+});
+
+test("static synthetic world synthesizes semantic payload hashes by default", () => {
+  const world = createSyntheticWorldConnectorV0({
+    initial_as_of: "2026-05-18T12:00:00Z",
+    profile: STATIC_SURPRISE_PROFILE_V0,
+    sources: [
+      {
+        source_id: "source.incident",
+        payload: {
+          status: "green",
+          open_incidents: [],
+        },
+      },
+    ],
+  });
+
+  const initial = readWorld(world, "source.incident", "2026-05-18T12:00:00Z");
+  world.advance({
+    kind: "time",
+    as_of: "2026-05-18T12:15:00Z",
+  });
+  const recheck = readWorld(world, "source.incident", "2026-05-18T12:15:00Z");
+
+  equal(initial.as_of, "2026-05-18T12:00:00.000Z");
+  equal(recheck.as_of, "2026-05-18T12:15:00.000Z");
+  equal(initial.payload_hash, recheck.payload_hash);
+  equal(initial.materialized_at, recheck.materialized_at);
+  equal(initial.payload_hash?.startsWith("sha256:"), true);
 });
 
 test("static profile remains zero across explicit source events", () => {

--- a/packages/reactor-cradle/src/world/synthetic-world.ts
+++ b/packages/reactor-cradle/src/world/synthetic-world.ts
@@ -318,10 +318,10 @@ export class SyntheticWorldConnectorV0 implements ReactorConnectorAdapterV0 {
       payload: payload.value,
       payload_canonical: payload.canonical,
     };
-    const revision: SourceRevision =
-      seed.payload_hash === undefined
-        ? revisionBase
-        : { ...revisionBase, payload_hash: seed.payload_hash };
+    const revision: SourceRevision = {
+      ...revisionBase,
+      payload_hash: seed.payload_hash ?? payloadContentHash(payload.canonical),
+    };
 
     this.#sources.set(seed.source_id, {
       source_id: seed.source_id,

--- a/packages/reactor/ADOPTION.md
+++ b/packages/reactor/ADOPTION.md
@@ -1,0 +1,103 @@
+# Reactor v0.1 Adoption Contract
+
+This page is the current first-contact contract for `@openprose/reactor` and
+`@openprose/reactor-cradle`.
+
+## Current Release
+
+- npm packages: `@openprose/reactor@0.1.0-rc.1` and
+  `@openprose/reactor-cradle@0.1.0-rc.1`.
+- npm dist-tags: `rc` and `latest` both currently point at `0.1.0-rc.1`.
+- Source: <https://github.com/openprose/prose>, under `packages/reactor`,
+  `packages/reactor-cradle`, `tools/cli`, and
+  `skills/open-prose/examples`.
+- Publish path: GitHub Actions trusted publishing with npm provenance. The
+  stable Reactor release uses the `reactor-v0.1.0` git tag.
+- Current local gate: 153 Reactor tests, 121 Cradle tests, 281 CLI tests,
+  35 release-verifier tests, and `pnpm build` are green after the rc-to-stable
+  hardening pass. The rc passed 12 independent first-contact validations.
+
+## Install
+
+Use Node 20 or newer. Enable Corepack if you are working from the repo:
+
+```sh
+corepack enable
+pnpm install
+pnpm build
+```
+
+Use npm when trying the published packages outside the workspace:
+
+```sh
+npm install @openprose/reactor@0.1.0-rc.1 @openprose/reactor-cradle@0.1.0-rc.1
+```
+
+## Golden Path
+
+Run the package-only token demo:
+
+```sh
+tmp="$(mktemp -d)"
+cp -R skills/open-prose/examples/flat-tokens "$tmp/"
+cd "$tmp/flat-tokens"
+npm install
+npm run example
+```
+
+Expected headline:
+
+```text
+"fresh": 46
+"reused": 46
+"ratio": "46:46"
+```
+
+Run the CLI demo from a prepared checkout:
+
+```sh
+cd /path/to/prose
+corepack enable
+pnpm install
+pnpm build
+cd tools/cli
+npm link
+cd ../..
+demo_parent="$(mktemp -d)"
+cp -R skills/open-prose/examples/incident-briefing-room "$demo_parent/"
+cd "$demo_parent/incident-briefing-room"
+prose compile src --harness mock
+cp dist/manifest.next.json dist/manifest.active.json
+PROSE_REACTOR_LOCAL_STATUS=down prose serve --port 7331 --harness mock
+```
+
+In a second terminal, post the example incident event from
+`tools/cli/QUICKSTART.md`, then inspect:
+
+```sh
+prose status --tier=owner
+prose status --tier=public
+```
+
+Look for a receipt log under `state/reactor/`, a fulfillment artifact under
+`runs/`, and `surprise_cause=real-input` in status output.
+
+## Supported For v0.1
+
+- Local deterministic receipt production through `createReactor().ingest()`.
+- Receipt verification, projection, export/import, and composition pins.
+- Cradle scenario replay, storage doubles, release parity, provider replay,
+  and package smoke checks.
+- Local CLI compile/serve/status demos that write real Reactor receipts.
+- Package-only reproduction of the static token headline (`46:46`).
+
+## Do Not Use v0.1 For
+
+- Hosted production ingress, fulfillment quality, or oracle guarantees.
+- Compliance-grade raw-evidence retention or non-null signing.
+- Runtime live ensemble judging on every turn.
+- Postgres parity as a supported storage row.
+- Large unbounded receipt logs without an external compaction/indexing plan.
+
+If that boundary matches your use case, v0.1 is suitable for a technical spike,
+local evaluation, integration prototyping, and receipt-shape review.

--- a/packages/reactor/README.md
+++ b/packages/reactor/README.md
@@ -6,8 +6,10 @@ forking, evidence review, and package verification without changing OpenProse
 source syntax.
 
 This README describes the `0.1.0-rc.1` package surface. It is an OSS release
-candidate; the stable `0.1.0` launch waits for provenance publication and
-stranger-run verification.
+candidate that is already published on npm and has passed first-contact
+validation. Start with the
+[Reactor v0.1 adoption contract](./ADOPTION.md) for install commands,
+supported boundaries, and the golden path.
 
 ## v0.1 Status
 
@@ -36,14 +38,10 @@ What is designed and partial:
 - Provider parity is recorded, not a live runtime matrix. Cradle carries
   deterministic provider parity doubles and one live-recorded K1 cassette, but
   this package does not perform runtime variable-depth ensemble judging.
-- The tagged publish gate is wired for provenance publication, but no npm
-  publication has been run for this worktree.
+- The tagged publish gate is wired for trusted publishing with npm provenance.
 
-Deferred to v0.2 or external gates:
+Roadmap after v0.1:
 
-- Actual npm publication and provenance until a release tag and npm auth or
-  trusted publishing are available.
-- The stranger run that verifies both local demos outside the authoring team.
 - Production ingress, fulfillment, and oracle layers.
 - Runtime variable-depth ensemble judging, Postgres parity, and a non-null
   signer adapter.
@@ -120,40 +118,108 @@ Create an SDK instance with explicit adapters. The SDK does not install hidden
 network, model, agent, sandbox, or storage defaults. In v0.1, omitting `signer`
 is represented explicitly as the null signer state
 `{ scheme: "none", null_reason: "no-signer-adapter-configured" }`; real signing
-adapters are deferred:
+adapters are planned after v0.1.
 
-```ts
-import { createReactor, type ReactorAdaptersV0 } from "@openprose/reactor/sdk";
+```js
+import { createHash } from "node:crypto";
+import { createReactor } from "@openprose/reactor/sdk";
+import { verifyReceiptV0 } from "@openprose/reactor/receipt";
 
-const adapters: ReactorAdaptersV0 = {
-  clock: { now: () => "2026-05-19T00:00:00Z" },
-  storage: {
-    appendReceipt: () => undefined,
-    listReceipts: () => [],
-    readRegistry: () => ({
-      contract_revision:
-        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      policy_artifact_id: "policy.incident-briefing",
-      policy_artifact_identity: "incident-briefing",
-      policy_artifact_namespace: "policy.static",
-      policy_artifact_revision: "policy-revision-1",
-      policy_artifact_validation_state: "validated",
-    }),
+const sha256 = (value) =>
+  `sha256:${createHash("sha256").update(value).digest("hex")}`;
+const CONTRACT = sha256("incident-briefing-contract");
+const EVIDENCE = sha256("incident-briefing-state:quiet");
+const POLICY = sha256("incident-briefing-policy");
+let now = "2026-05-18T12:00:00.000Z";
+let registry = {
+  contract_revision: CONTRACT,
+  policy_artifact_id: "policy.incident-briefing",
+  policy_artifact_identity: "policy.incident-briefing",
+  policy_artifact_namespace: "policy.readme",
+  policy_artifact_revision: "1",
+  policy_artifact_validation_state: "validated",
+  policy_artifact_content_hash: POLICY,
+  compiled_evidence_plan: {
+    responsibility_id: "responsibility.incident-briefing",
+    contract_revision: CONTRACT,
+    policy_artifact_namespace: "policy.readme",
+    policy_artifact_revision: "1",
+    plan_revision: "readme-plan-1",
+    as_of: now,
+    evidence_order: "declared",
+    sources: [
+      { id: "incident-briefing-state", kind: "adapter", required: true },
+    ],
   },
-  modelGateway: { invoke: (request) => ({ payload: request.payload }) },
-  agentSdk: { launch: (request) => ({ payload: request.payload }) },
-  sandbox: { run: () => ({ exit_code: 0, stdout: "", stderr: "" }) },
-  connectors: { read: () => ({ payload: null }) },
-  eventSink: { emit: () => undefined },
+  forecast_schedule: {
+    responsibility_id: "responsibility.incident-briefing",
+    contract_revision: CONTRACT,
+    memo_key: "readme-seed",
+    evidence_input_ids: [EVIDENCE],
+    next_evidence_recheck: "2026-05-19T12:00:00.000Z",
+    next_plan_recheck: "2026-05-25T12:00:00.000Z",
+  },
 };
-
+const receipts = [];
 const reactor = createReactor({
   responsibility_id: "responsibility.incident-briefing",
-  adapters,
+  adapters: {
+    clock: { now: () => now },
+    storage: {
+      appendReceipt: (receipt) => receipts.push(receipt),
+      listReceipts: () => [...receipts],
+      readRegistry: () => registry,
+      writeRegistry: (next) => {
+        registry = next;
+      },
+    },
+    modelGateway: {
+      invoke: () => ({
+        payload: {
+          status: "up",
+          confidence: {
+            value: 0.91,
+            derivation_method: "readme-local",
+            label_source: "readme",
+          },
+          cost_tags: { tags: ["readme-sdk-quickstart"] },
+        },
+        usage: {
+          provider: "local",
+          model: "readme-shallow",
+          tokens: { fresh: 17, reused: 3 },
+        },
+      }),
+    },
+    agentSdk: { launch: (request) => ({ payload: request.payload }) },
+    sandbox: { run: () => ({ exit_code: 0, stdout: "", stderr: "" }) },
+    connectors: {
+      read: () => ({ payload: { status: "quiet" }, payload_hash: EVIDENCE }),
+    },
+    eventSink: { emit: () => undefined },
+  },
 });
 
-reactor.ingest({ kind: "tick" });
+const event = {
+  kind: "real-input",
+  evidence: [{ source_id: "incident-briefing-state", content_hash: EVIDENCE }],
+};
+const first = reactor.ingest(event);
+now = "2026-05-18T12:15:00.000Z";
+const second = reactor.ingest(event);
+
+for (const receipt of reactor.receipts()) {
+  const verified = verifyReceiptV0(receipt);
+  if (!verified.ok) throw new Error(verified.errors.join("; "));
+}
 const exitBundle = reactor.export();
+if ("ok" in exitBundle && exitBundle.ok === false) {
+  throw new Error(exitBundle.errors.join("; "));
+}
+
+console.log(first.outcome); // fresh-judge-receipt
+console.log(second.outcome); // memo-hit-receipt
+console.log("export ok");
 ```
 
 Evaluate a validated policy artifact before running B3 backstops:
@@ -220,12 +286,11 @@ artifacts into a temporary offline consumer and expects `tokens.fresh=46`,
 
 ## Current Boundaries
 
-- This README describes the release-candidate package surface; the stable npm
-  release waits for registry-visible provenance and stranger-run evidence.
+- This README describes the published release-candidate package surface.
 - GitHub Actions contain a tagged publish gate that relies on npm trusted
   publishing/OIDC and rejects tag/package-version mismatches.
 - The package does not include the CLI implementation; local CLI
   `serve/status` evidence lives in the companion OpenProse CLI worktree.
 - Postgres parity, production adapter release, live provider/model matrix, and
   deployment checks are still outside this package surface.
-- `cost.provider_norm` remains the deferred receipt v0 normalization field.
+- `cost.provider_norm` remains a future receipt v0 normalization field.

--- a/packages/reactor/package.json
+++ b/packages/reactor/package.json
@@ -59,6 +59,7 @@
     "!dist/**/*.test.js",
     "!dist/**/*.test.d.ts",
     "!dist/**/*.test.d.ts.map",
+    "ADOPTION.md",
     "README.md"
   ],
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,11 +33,11 @@ importers:
   skills/open-prose/examples/flat-tokens:
     dependencies:
       '@openprose/reactor':
-        specifier: workspace:*
-        version: link:../../../../packages/reactor
+        specifier: 0.1.0-rc.1
+        version: 0.1.0-rc.1
       '@openprose/reactor-cradle':
-        specifier: workspace:*
-        version: link:../../../../packages/reactor-cradle
+        specifier: 0.1.0-rc.1
+        version: 0.1.0-rc.1
 
   tools/cli:
     dependencies:
@@ -513,6 +513,14 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@openprose/reactor-cradle@0.1.0-rc.1':
+    resolution: {integrity: sha512-2s7rtyqV0gXYN23y3OZT3P/PVkXfVpXuIojuYPc6/R01LydnhubOVhu269ukp6riYed7u7iSG9/N/P4zXIUQ+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@openprose/reactor@0.1.0-rc.1':
+    resolution: {integrity: sha512-zXsntbycSJfKrd79TTtpn4ufEYlEyrJu6uHVjEbn33K2Qc10yc30lvTvMg9lb5f+T5qWa0vU0VZqjWgILMqo8Q==}
+    engines: {node: '>=20.0.0'}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -1691,6 +1699,12 @@ snapshots:
 
   '@openai/codex@0.125.0-win32-x64':
     optional: true
+
+  '@openprose/reactor-cradle@0.1.0-rc.1':
+    dependencies:
+      '@openprose/reactor': 0.1.0-rc.1
+
+  '@openprose/reactor@0.1.0-rc.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true

--- a/skills/open-prose/examples/flat-tokens/package.json
+++ b/skills/open-prose/examples/flat-tokens/package.json
@@ -7,8 +7,8 @@
     "example": "node flat-tokens.example.mjs"
   },
   "dependencies": {
-    "@openprose/reactor": "workspace:*",
-    "@openprose/reactor-cradle": "workspace:*"
+    "@openprose/reactor": "0.1.0-rc.1",
+    "@openprose/reactor-cradle": "0.1.0-rc.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/tools/cli/QUICKSTART.md
+++ b/tools/cli/QUICKSTART.md
@@ -1,25 +1,31 @@
 # Prose CLI Quickstart
 
 This is the local deterministic Reactor demo path for the CLI worktree. It
-does not claim npm publication, live-model fulfillment content, hosted
-production ingress, or stranger-run evidence. It exercises the bundled
-`incident-briefing-room` example with local adapters and writes Reactor
-receipts on disk.
+uses the bundled `incident-briefing-room` example with local adapters and
+writes Reactor receipts on disk. The path is intentionally local: it proves
+compile, serve, status projection, receipt production, and fulfillment dispatch
+without claiming hosted ingress or live-model fulfillment quality.
+
+## Environment Prerequisites
+
+- Node.js 20 or newer.
+- Corepack enabled (`corepack enable`) so the repo uses `pnpm@9.15.0`.
+- A prepared checkout of <https://github.com/openprose/prose>.
 
 ## Install From A Prepared Checkout
 
 ```bash
 cd /path/to/prose
+corepack enable
 pnpm install
-pnpm --filter @openprose/prose-cli build
+pnpm build
 cd tools/cli
 npm link
 prose --help
 ```
 
-The current release-candidate CLI package is tested from the prepared
-worktree. The public npm install path belongs to the release gate. Until that
-gate lands, use the checkout install above when reproducing this quickstart.
+The checkout build compiles the Reactor packages, Cradle, and the CLI in the
+same order used by CI.
 
 ## Copy The Bundled Example
 

--- a/tools/cli/src/prose/repository-source-compiler.ts
+++ b/tools/cli/src/prose/repository-source-compiler.ts
@@ -272,7 +272,18 @@ function compileGatewayTriggers(
 	const seen = new Set<string>();
 	for (const gateway of gateways) {
 		const receives = bulletItems(gateway.sections.get("receives") ?? "");
-		const receivedHttp = receives.map(parseHttpReceive).find((receive) => receive !== undefined);
+		const receivedHttpRoutes = receives.flatMap((receive) => {
+			const parsed = parseHttpReceive(receive);
+			return parsed === undefined ? [] : [parsed];
+		});
+		const receivedHttp = receivedHttpRoutes[0];
+		for (const dropped of receivedHttpRoutes.slice(1)) {
+			diagnostics.push({
+				severity: "warning",
+				message: `Gateway '${gateway.name ?? slugFromSourcePath(gateway.sourcePath)}' declares extra Receives route ${dropped.method} ${dropped.path}; only the first HTTP route ${receivedHttp?.method ?? "unknown"} ${receivedHttp?.path ?? "unknown"} lowers into repository IR in v0.`,
+				sourcePath: gateway.sourcePath,
+			});
+		}
 		const emits = bulletItems(gateway.sections.get("emits") ?? "");
 
 		for (const emitted of emits) {

--- a/tools/cli/src/prose/responsibility-pressure.ts
+++ b/tools/cli/src/prose/responsibility-pressure.ts
@@ -1,6 +1,6 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { appendFile, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
-import { posix, resolve } from "node:path";
+import { dirname, posix, resolve } from "node:path";
 import type { OpenProseRoot } from "./openprose-root.js";
 import type { RepositoryIrActivationIntentKind } from "./repository-ir.js";
 import type { ResponsibilityStatusRecord, ResponsibilityStatusValue } from "./responsibility-status.js";
@@ -78,6 +78,7 @@ const pressureActivationKinds: readonly ResponsibilityPressureActivationKind[] =
 	"retry",
 	"escalation",
 ];
+const pressureWriteQueues = new Map<string, Promise<void>>();
 
 export function buildResponsibilityPressurePaths(
 	openProseRoot: OpenProseRoot,
@@ -201,6 +202,16 @@ export async function recordResponsibilityPressure(options: {
 	}
 
 	const paths = buildResponsibilityPressurePaths(options.openProseRoot, options.record.responsibilityId);
+	return enqueueResponsibilityPressureWrite(paths.responsibilityId, () =>
+		recordResponsibilityPressureSerialized({ record: options.record, paths }),
+	);
+}
+
+async function recordResponsibilityPressureSerialized(options: {
+	record: ResponsibilityPressureRecord;
+	paths: ResponsibilityPressurePaths;
+}): Promise<ResponsibilityPressureRecordResult> {
+	const { paths } = options;
 	const latest = await readLatestPressure(paths);
 	if (latest !== undefined && pressureClaimsMatch(latest, options.record)) {
 		return { paths, record: latest, recorded: false };
@@ -225,6 +236,24 @@ export async function recordResponsibilityPressure(options: {
 	await writeJsonFileAtomic(paths.absoluteLatestPressurePath, options.record);
 	await appendFile(paths.absolutePressureLogPath, `${JSON.stringify(options.record)}\n`, "utf8");
 	return { paths, record: options.record, recorded: true };
+}
+
+async function enqueueResponsibilityPressureWrite<T>(responsibilityId: string, operation: () => Promise<T>): Promise<T> {
+	const previous = pressureWriteQueues.get(responsibilityId) ?? Promise.resolve();
+	const run = previous.catch(() => undefined).then(operation);
+	const next = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	pressureWriteQueues.set(responsibilityId, next);
+
+	try {
+		return await run;
+	} finally {
+		if (pressureWriteQueues.get(responsibilityId) === next) {
+			pressureWriteQueues.delete(responsibilityId);
+		}
+	}
 }
 
 async function readLatestPressure(paths: ResponsibilityPressurePaths): Promise<ResponsibilityPressureRecord | undefined> {
@@ -304,17 +333,24 @@ function fingerprintPressureClaim(record: ResponsibilityPressureRecord): string 
 }
 
 async function writeJsonFileAtomic(path: string, value: unknown): Promise<void> {
-	const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`;
-	try {
-		await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-		await rename(temporaryPath, path);
-	} catch (error) {
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
 		try {
-			await unlink(temporaryPath);
-		} catch {
-			// Best-effort cleanup; preserve the original write/rename failure.
+			await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+			await rename(temporaryPath, path);
+			return;
+		} catch (error) {
+			try {
+				await unlink(temporaryPath);
+			} catch {
+				// Best-effort cleanup; preserve the original write/rename failure.
+			}
+			if (attempt === 0 && isNodeError(error) && error.code === "ENOENT") {
+				await mkdir(dirname(path), { recursive: true });
+				continue;
+			}
+			throw error;
 		}
-		throw error;
 	}
 }
 

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -632,6 +632,62 @@ describe("runCompileCommand", () => {
 		}
 	});
 
+	it("emits a diagnostic when a gateway drops extra Receives routes", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-extra-receives-"));
+		const io = memoryStreams();
+
+		try {
+			writeResponsibilitySource(temp);
+			writeFileSync(
+				join(temp, "src/daily-check-events.prose.md"),
+				`---
+name: daily-check-events
+kind: gateway
+---
+
+### Receives
+
+- POST /daily/check
+- POST /daily/check/alternate
+
+### Emits
+
+- daily-check.evidence-change
+
+### Payload
+
+Daily check evidence changed.
+`,
+			);
+
+			const exitCode = await runCompileCommand({
+				argv: ["src", "--harness", "mock"],
+				cwd: temp,
+				env: {},
+				stdout: io.streams.stdout,
+				stderr: io.streams.stderr,
+				skillBootstrap: false,
+				skillPreflight: false,
+			});
+
+			expect(exitCode).toBe(0);
+			const manifest = JSON.parse(readFileSync(join(temp, "dist/manifest.next.json"), "utf8")) as {
+				diagnostics: Array<{ severity: string; message: string; sourcePath?: string }>;
+				triggers: Array<{ method?: string; path?: string }>;
+			};
+			expect(manifest.triggers).toContainEqual(expect.objectContaining({ method: "POST", path: "/daily/check" }));
+			expect(manifest.diagnostics).toContainEqual(
+				expect.objectContaining({
+					severity: "warning",
+					message: expect.stringContaining("extra Receives route POST /daily/check/alternate"),
+					sourcePath: "src/daily-check-events.prose.md",
+				}),
+			);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
 	it("accepts a valid manifest when the compiler harness exits nonzero after writing it", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-compile-valid-nonzero-"));
 		const io = memoryStreams();

--- a/tools/cli/tests/prose/quickstart.test.ts
+++ b/tools/cli/tests/prose/quickstart.test.ts
@@ -20,7 +20,9 @@ describe("CLI quickstart", () => {
 
 		expect(quickstart).toContain("incident-briefing-room");
 		expect(quickstart).toContain("local deterministic Reactor demo path");
-		expect(quickstart).toContain("does not claim npm publication");
+		expect(quickstart).toContain("Node.js 20 or newer");
+		expect(quickstart).toContain("corepack enable");
+		expect(quickstart).toContain("pnpm build");
 		expect(quickstart).toContain("prose compile src --harness mock");
 		expect(quickstart).toContain("cp dist/manifest.next.json dist/manifest.active.json");
 		expect(quickstart).toContain("PROSE_REACTOR_LOCAL_STATUS=down prose serve --port 7331 --harness mock");

--- a/tools/cli/tests/prose/responsibility-pressure.test.ts
+++ b/tools/cli/tests/prose/responsibility-pressure.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -166,6 +166,46 @@ describe("responsibility pressure", () => {
 			expect(first.recorded).toBe(true);
 			expect(second.recorded).toBe(true);
 			expect(readFileSync(first.paths.absolutePressureLogPath, "utf8").trim().split("\n")).toHaveLength(2);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("serializes concurrent writes without losing pressure records", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-responsibility-pressure-concurrent-"));
+
+		try {
+			const root: OpenProseRoot = { mode: "native", path: ".", absolutePath: temp };
+			const pressures = Array.from({ length: 12 }, (_, index) =>
+				buildResponsibilityPressureRecord({
+					status: {
+						...statusRecord("down"),
+						recordedAt: `2026-05-03T12:${String(index).padStart(2, "0")}:00.000Z`,
+						evidence: [`Concurrent pressure ${index}.`],
+					},
+					recommendedActivationKind: "fulfillment",
+					activationId: "responsibility-1.fulfillment",
+					recordedAt: `2026-05-03T12:${String(index).padStart(2, "0")}:30.000Z`,
+				})!,
+			);
+
+			const results = await Promise.all(
+				pressures.map((record) => recordResponsibilityPressure({ openProseRoot: root, record })),
+			);
+			const paths = results[0]!.paths;
+			const logRecords = readFileSync(paths.absolutePressureLogPath, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+			const latest = JSON.parse(readFileSync(paths.absoluteLatestPressurePath, "utf8"));
+
+			expect(results.every((result) => result.recorded)).toBe(true);
+			expect(logRecords).toHaveLength(pressures.length);
+			expect(new Set(logRecords.map((record) => record.dedupeKey)).size).toBe(pressures.length);
+			expect(pressures.some((record) => record.dedupeKey === latest.dedupeKey)).toBe(true);
+			expect(readdirSync(paths.absolutePressureClaimDirectoryPath).filter((name) => name.endsWith(".json"))).toHaveLength(
+				pressures.length,
+			);
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
- add the Reactor v0.1 adoption contract and refresh rc docs/quickstart language
- make flat-tokens install from published rc packages and replace the broken SDK README snippet
- add Cradle ./scenario export, stable synthetic-world payload hashes, serialized pressure writes, and extra-Receives diagnostics

## Verification
- pnpm --filter @openprose/reactor test
- pnpm --filter @openprose/reactor-cradle test
- pnpm --filter @openprose/prose-cli test
- node --test .github/scripts/verify-reactor-pin.test.mjs .github/scripts/smoke-reactor-tarball-import.test.mjs .github/scripts/smoke-reactor-cradle-tarball-import.test.mjs .github/scripts/build-reactor-release-candidate-evidence.test.mjs .github/scripts/smoke-reactor-release-readiness-example.test.mjs .github/scripts/smoke-reactor-flat-tokens-example.test.mjs .github/scripts/verify-reactor-publish-workflow.test.mjs
- pnpm build
- copied flat-tokens example outside workspace, npm install, node flat-tokens.example.mjs -> ratio 46:46