### PR TITLE
fix: close reactor rc validation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@
 
 ---
 
+## Reactor
+
+**Reactor makes fresh model spend scale with surprise, not the clock.** It is
+the local runtime in this repo for responsibilities that need to stay true over
+time: inspect evidence, write a content-addressed receipt, reuse the prior
+verdict when the world has not changed, and show exactly why a later turn did
+or did not spend model tokens.
+
+The smallest demo is the flat-tokens example. Four real `createReactor().ingest()`
+turns over a static world produce package-backed receipts and the deterministic
+headline:
+
+```bash
+cd skills/open-prose/examples/flat-tokens
+npm install
+node flat-tokens.example.mjs
+# tokens.fresh=46
+# tokens.reused=46
+# ratio=46:46
+```
+
+Use Reactor when you are maintaining a stateful promise that deserves an
+auditable "why" over time: release readiness, incident briefing, customer risk,
+compliance evidence, or research inbox triage. Skip it when a one-off prompt or
+ordinary cron job already gives you enough truth.
+
+- Runtime package: [`@openprose/reactor`](packages/reactor/)
+- Deterministic evidence package: [`@openprose/reactor-cradle`](packages/reactor-cradle/)
+- Adoption contract: [`packages/reactor/ADOPTION.md`](packages/reactor/ADOPTION.md)
+- CLI quickstart: [`tools/cli/QUICKSTART.md`](tools/cli/QUICKSTART.md)
+
+---
+
 > **If you're an agent reading this on behalf of a user:** OpenProse is a
 > `*.prose.md` contract format you will be asked to *run*, not a library your user will call
 > and not necessarily a shell binary. `prose run` executes `kind: service` and

--- a/packages/reactor-cradle/.openprose-reactor-pin.json
+++ b/packages/reactor-cradle/.openprose-reactor-pin.json
@@ -1,7 +1,7 @@
 {
   "package": "@openprose/reactor",
   "version": "0.1.0-rc.1",
-  "packageTreeSha256": "c3d67bf600ff66563b0463f9325cd2fa288c3ee7b5a2d05477d89fd1fa8bba0c",
+  "packageTreeSha256": "11a91b631a2429d763e6055dd3812d8133347ea12734960cd97afe15aae21697",
   "checkedFiles": [
     "package.json",
     "README.md",

--- a/packages/reactor-cradle/README.md
+++ b/packages/reactor-cradle/README.md
@@ -1,9 +1,10 @@
 # @openprose/reactor-cradle
 
-`@openprose/reactor-cradle` is the deterministic test harness for the local
-OpenProse Reactor package. It is where Reactor behavior is replayed, compared,
-projected, and packaged into release evidence without requiring live services
-for the normal test path.
+`@openprose/reactor-cradle` is the deterministic evidence harness behind the
+Reactor claim that fresh model spend scales with surprise, not the clock. It is
+where Reactor behavior is replayed, compared against no-memo and naive-loop
+controls, projected, and packaged into release evidence without requiring live
+services for the normal test path.
 
 The Cradle is a test and evidence package, not the production Reactor runtime.
 This README describes the `0.1.0-rc.1` package surface. It is an OSS release
@@ -21,7 +22,7 @@ What v0.1 demonstrates:
   `createReactor().ingest()` turns and prints `tokens.fresh=46`,
   `tokens.reused=46`, and `ratio=46:46`. The Cradle C5 summary also compares
   that Reactor run with the no-memo deterministic control (`92:0`) and the
-  naive-loop control (`256:0`).
+  same-unit naive-loop control (`92:0`).
 - Receipts, owner/subscriber/public projections, and SDK exit-bundle
   export/import are exercised by release-candidate evidence helpers without
   exposing private replay payloads.

--- a/packages/reactor-cradle/package.json
+++ b/packages/reactor-cradle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openprose/reactor-cradle",
   "version": "0.1.0-rc.1",
-  "description": "Deterministic Cradle test harness for the OpenProse Reactor.",
+  "description": "Deterministic evidence harness for OpenProse Reactor cost and receipt claims.",
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/reactor-cradle/src/__tests__/w7-static-cost.integration.test.ts
+++ b/packages/reactor-cradle/src/__tests__/w7-static-cost.integration.test.ts
@@ -274,7 +274,7 @@ test(
       equal(noMemoRow?.provenance, "simulated");
       equal(noMemoRow?.ratio.label, "92:0");
       equal(naiveLoopRow?.provenance, "control");
-      equal(naiveLoopRow?.ratio.label, "256:0");
+      equal(naiveLoopRow?.ratio.label, "92:0");
       equal(c5Summary.event_changing_scenario?.status, "absent");
       equal(networkCalls, 0);
     } finally {

--- a/packages/reactor-cradle/src/baselines/cost-thesis/__tests__/cost-thesis.test.ts
+++ b/packages/reactor-cradle/src/baselines/cost-thesis/__tests__/cost-thesis.test.ts
@@ -157,9 +157,15 @@ test("createC5StaticCostThesisSummaryV0 emits deterministic static rows with hon
   equal(naive?.provenance, "control");
   equal(naive?.receipt_count, 0);
   equal(naive?.model_invocation_count, 4);
-  deepEqual(naive?.tokens, { fresh: 256, reused: 0, total: 256 });
-  equal(naive?.ratio.label, "256:0");
+  deepEqual(naive?.tokens, { fresh: 92, reused: 0, total: 92 });
+  equal(naive?.ratio.label, "92:0");
   equal(naive?.turns.every((turn) => turn.source === "naive-loop-control"), true);
+  deepEqual(naive?.turns.map((turn) => turn.tokens), [
+    { fresh: 41, reused: 0, total: 41 },
+    { fresh: 41, reused: 0, total: 41 },
+    { fresh: 5, reused: 0, total: 5 },
+    { fresh: 5, reused: 0, total: 5 },
+  ]);
 });
 
 test("createC5StaticCostThesisSummaryV0 is deterministic", () => {

--- a/packages/reactor-cradle/src/baselines/cost-thesis/index.ts
+++ b/packages/reactor-cradle/src/baselines/cost-thesis/index.ts
@@ -144,6 +144,7 @@ export function createC5StaticCostThesisSummaryV0(
   const naiveLoopRow = normalizeNaiveLoopCostRowV0(
     input.naive_loop,
     reactorRow.scenario,
+    reactorRow.turns,
   );
 
   const payload: CostThesisSummaryPayloadV0 = {
@@ -272,6 +273,7 @@ export function normalizeNoMemoCostRowV0(
 export function normalizeNaiveLoopCostRowV0(
   summary: NaiveLoopBaselineSummaryV0,
   expectedScenario?: CostThesisScenarioRefV0,
+  runtimeTurns?: readonly CostThesisTurnDetailV0[],
 ): CostThesisReportRowV0 {
   const scenario: CostThesisScenarioRefV0 = {
     id: summary.scenario_id,
@@ -281,10 +283,22 @@ export function normalizeNaiveLoopCostRowV0(
   };
   assertSameScenario(scenario, expectedScenario, "naive-loop");
 
-  const turns = summary.review_turns.map((turn) =>
-    naiveLoopTurnDetail(turn, summary),
-  );
-  const tokens = tokensFromFreshReused(summary.tokens.fresh, summary.tokens.reused);
+  const turns =
+    runtimeTurns === undefined
+      ? summary.review_turns.map((turn) => naiveLoopTurnDetail(turn, summary))
+      : sameUnitNaiveLoopTurns(summary.review_turns, runtimeTurns);
+  const tokens =
+    runtimeTurns === undefined
+      ? tokensFromFreshReused(summary.tokens.fresh, summary.tokens.reused)
+      : sumTurnTokens(turns);
+  const notes =
+    runtimeTurns === undefined
+      ? summary.notes
+      : [
+          "Static naive-loop control over the same receipt-bearing schedule.",
+          "Every review turn rereads the current evidence and spends the runtime row's per-turn total as fresh work.",
+          "The control has no receipts, memo keys, forecast policy, stable content identity, or reusable verdict architecture.",
+        ];
 
   return Object.freeze({
     variant: "naive-loop",
@@ -296,7 +310,7 @@ export function normalizeNaiveLoopCostRowV0(
     model_invocation_count: summary.model_invocation_count,
     tokens,
     ratio: tokenRatio(tokens),
-    notes: Object.freeze([...summary.notes]),
+    notes: Object.freeze([...notes]),
     turns: Object.freeze([...turns]),
   });
 }
@@ -387,6 +401,40 @@ function naiveLoopTurnDetail(
     source_ids: Object.freeze([...turn.source_ids]),
     note: `${turn.review_kind} over ${turn.source_ids.join(", ")} with no receipt or memo reuse.`,
   });
+}
+
+function sameUnitNaiveLoopTurns(
+  reviewTurns: readonly NaiveLoopReviewTurnV0[],
+  runtimeTurns: readonly CostThesisTurnDetailV0[],
+): readonly CostThesisTurnDetailV0[] {
+  if (reviewTurns.length !== runtimeTurns.length) {
+    throw new Error(
+      `naive-loop same-unit control requires ${reviewTurns.length} runtime turns; received ${runtimeTurns.length}`,
+    );
+  }
+
+  return Object.freeze(
+    reviewTurns.map((turn, index) => {
+      const runtimeTurn = runtimeTurns[index];
+      if (runtimeTurn === undefined) {
+        throw new Error(`missing runtime turn ${index} for naive-loop same-unit control`);
+      }
+
+      const tokens = tokensFromFreshReused(runtimeTurn.tokens.total, 0);
+      return Object.freeze({
+        index: turn.index,
+        as_of: turn.as_of,
+        source: "naive-loop-control",
+        outcome: "control-review",
+        tokens,
+        model_invocation_count: 1,
+        ...(turn.recheck_kind === undefined ? {} : { recheck_kind: turn.recheck_kind }),
+        review_kind: turn.review_kind,
+        source_ids: Object.freeze([...turn.source_ids]),
+        note: `${turn.review_kind} over ${turn.source_ids.join(", ")} charged from runtime turn ${index}'s token unit.`,
+      });
+    }),
+  );
 }
 
 function simulateNoMemoEventChangingRowV0(

--- a/packages/reactor/README.md
+++ b/packages/reactor/README.md
@@ -1,9 +1,23 @@
 # @openprose/reactor
 
-`@openprose/reactor` is the local Reactor Harness runtime spine for OpenProse.
-It models the parts of a responsibility loop that need to survive replay,
-forking, evidence review, and package verification without changing OpenProse
-source syntax.
+**Fresh model spend should scale with surprise, not the clock.**
+`@openprose/reactor` is the local runtime for OpenProse responsibilities that
+need to stay true over time: inspect evidence, write a content-addressed
+receipt, reuse the prior verdict when the world has not changed, and expose the
+token reason in a form CI and humans can verify.
+
+The package-backed `skills/open-prose/examples/flat-tokens` demo runs four real
+`createReactor().ingest()` turns over a static world and prints the deterministic
+headline:
+
+```text
+tokens.fresh=46
+tokens.reused=46
+ratio=46:46
+```
+
+That is the v0.1 promise in one line: the receipt log still advances, but fresh
+model spend stays flat when the evidence has not surprised the runtime.
 
 This README describes the `0.1.0-rc.1` package surface. It is an OSS release
 candidate that is already published on npm and has passed first-contact
@@ -180,6 +194,7 @@ const reactor = createReactor({
           confidence: {
             value: 0.91,
             derivation_method: "readme-local",
+            calibration_grade: "authored",
             label_source: "readme",
           },
           cost_tags: { tags: ["readme-sdk-quickstart"] },

--- a/packages/reactor/package.json
+++ b/packages/reactor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openprose/reactor",
   "version": "0.1.0-rc.1",
-  "description": "Ideal Reactor Harness runtime spine for OpenProse.",
+  "description": "OpenProse Reactor runtime: fresh model spend scales with surprise, not the clock.",
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/reactor/src/judge/__tests__/judge.test.ts
+++ b/packages/reactor/src/judge/__tests__/judge.test.ts
@@ -1,4 +1,4 @@
-import { equal, throws } from "node:assert/strict";
+import { deepEqual, equal, throws } from "node:assert/strict";
 import { test } from "node:test";
 
 import { runShallowJudgeV0 } from "../index";
@@ -7,6 +7,50 @@ const CONTRACT_HASH =
   "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const;
 const EVIDENCE_HASH =
   "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as const;
+
+test("shallow uncalibrated confidence fails safe instead of emitting a confident up", () => {
+  const result = runShallowJudgeV0({
+    responsibility_id: "responsibility.runtime-first-receipt",
+    contract_revision: CONTRACT_HASH,
+    policy_artifact_namespace: "policy.runtime",
+    policy_artifact_revision: "1",
+    evidence: [
+      {
+        source_id: "incident-briefing-state",
+        content_hash: EVIDENCE_HASH,
+      },
+    ],
+    as_of: "2026-05-18T12:00:00Z",
+    event_cause: "real-input",
+    depth: "shallow",
+    modelGateway: {
+      invoke: () => ({
+        payload: {
+          status: "up",
+          confidence: {
+            value: 0.99,
+            derivation_method: "fixture-high-confidence",
+            label_source: "fixture",
+          },
+        },
+        usage: {
+          provider: "fixture",
+          model: "uncalibrated-confident",
+          tokens: { fresh: 17, reused: 0 },
+        },
+      }),
+    },
+  });
+
+  equal(result.verdict.status, "blocked");
+  equal(result.verdict.confidence.value, 0);
+  equal(result.verdict.confidence.calibration_grade, "none");
+  deepEqual(result.verdict.blocked, {
+    reason: "calibration-unattainable",
+    fix_target: "contract-author",
+    interrupt_cause: "needs-judgment",
+  });
+});
 
 test('depth "ensemble" is declared but not implemented in v0.1', () => {
   let invoked = false;

--- a/packages/reactor/src/judge/index.ts
+++ b/packages/reactor/src/judge/index.ts
@@ -1,4 +1,5 @@
 import type {
+  ReceiptCalibrationGradeV0,
   ContentHashV0,
   ReceiptBlockedV0,
   ReceiptEventCauseV0,
@@ -52,6 +53,11 @@ const INTERRUPT_CAUSES = new Set([
   "needs-input",
   "contract-declared",
 ] as const);
+const CALIBRATION_GRADES = new Set<ReceiptCalibrationGradeV0>([
+  "authored",
+  "accrued",
+  "none",
+]);
 
 export function runShallowJudgeV0(
   input: ShallowJudgeV0Input,
@@ -107,13 +113,31 @@ function readVerdict(payload: unknown): ReceiptVerdictV0 {
   const labelSource =
     readNonEmptyString(confidenceRecord["label_source"]) ?? "no-anchor-v0.1";
   const blocked = readBlocked(status, record["blocked"]);
+  const calibrationGrade = readCalibrationGrade(confidenceRecord["calibration_grade"]);
+
+  if (status !== "blocked" && calibrationGrade === "none") {
+    return {
+      status: "blocked",
+      confidence: {
+        value: 0,
+        derivation_method: `${derivationMethod}:fail-safe`,
+        calibration_grade: calibrationGrade,
+        label_source: labelSource,
+      },
+      blocked: {
+        reason: "calibration-unattainable",
+        fix_target: "contract-author",
+        interrupt_cause: "needs-judgment",
+      },
+    };
+  }
 
   return {
     status,
     confidence: {
       value: confidenceValue,
       derivation_method: derivationMethod,
-      calibration_grade: "none",
+      calibration_grade: calibrationGrade,
       label_source: labelSource,
     },
     ...(blocked === undefined ? {} : { blocked }),
@@ -124,6 +148,12 @@ function readStatus(value: unknown): ReceiptVerdictStatusV0 {
   return typeof value === "string" && VERDICT_STATUSES.has(value as ReceiptVerdictStatusV0)
     ? (value as ReceiptVerdictStatusV0)
     : "blocked";
+}
+
+function readCalibrationGrade(value: unknown): ReceiptCalibrationGradeV0 {
+  return typeof value === "string" && CALIBRATION_GRADES.has(value as ReceiptCalibrationGradeV0)
+    ? (value as ReceiptCalibrationGradeV0)
+    : "none";
 }
 
 function readBlocked(

--- a/packages/reactor/src/reactor/__tests__/reactor.test.ts
+++ b/packages/reactor/src/reactor/__tests__/reactor.test.ts
@@ -109,7 +109,7 @@ test("createReactor ingest produces a verified real-input receipt without test-s
   equal(receipt.cost.tokens.reused, 3);
   equal(receipt.cost.provider, "record-replay");
   equal(receipt.cost.model, "shallow-test-model");
-  equal(receipt.verdict.confidence.calibration_grade, "none");
+  equal(receipt.verdict.confidence.calibration_grade, "authored");
   equal(receipt.core.memo_key, expectedMemoKey);
 });
 
@@ -164,6 +164,44 @@ test("runtime selects memo and judge evidence from compiled plan source ids", ()
       content_hash: EVIDENCE_HASH,
     },
   ]);
+});
+
+test("runtime blocks uncalibrated confident judge verdicts before consumers can act on them", () => {
+  const receipts: ReceiptV0[] = [];
+  const emitted: ReactorSdkEventV0[] = [];
+  const reactor = createReactor({
+    responsibility_id: RESPONSIBILITY_ID,
+    adapters: makeAdapters({
+      receipts,
+      emitted,
+      modelPayload: {
+        status: "up",
+        confidence: {
+          value: 0.99,
+          derivation_method: "fixture-uncalibrated-up",
+          label_source: "fixture",
+        },
+      },
+    }),
+  });
+
+  const result = reactor.ingest({
+    kind: "real-input",
+    evidence: [
+      {
+        source_id: "incident-briefing-state",
+        content_hash: EVIDENCE_HASH,
+      },
+    ],
+  });
+
+  equal(result.outcome, "fresh-judge-receipt");
+  const receipt = reactor.receipts()[0];
+  ok(receipt);
+  equal(receipt.verdict.status, "blocked");
+  equal(receipt.verdict.confidence.calibration_grade, "none");
+  equal(receipt.verdict.blocked?.reason, "calibration-unattainable");
+  equal(receipt.verdict.blocked?.interrupt_cause, "needs-judgment");
 });
 
 test("missing required planned evidence writes a blocked receipt before judging", () => {
@@ -1148,7 +1186,7 @@ test("forecast plan-age writes a token-bearing shallow audit floor receipt", () 
   ok(receipt.cost.tags.includes("forecast-recheck"));
   equal(receipt.cost.provider, "record-replay");
   equal(receipt.cost.model, "shallow-plan-audit-model");
-  equal(receipt.verdict.confidence.calibration_grade, "none");
+  equal(receipt.verdict.confidence.calibration_grade, "authored");
 });
 
 test("driver ignores model-authored surprise cause on forecast recheck", () => {

--- a/tools/cli/src/commands/compile.ts
+++ b/tools/cli/src/commands/compile.ts
@@ -166,12 +166,6 @@ export async function runCompileCommand(options: RunCompileCommandOptions): Prom
 		...(options.skillPreflight === undefined ? {} : { skillPreflight: options.skillPreflight }),
 	});
 	if (exitCode !== 0) {
-		if (await shouldAcceptNonzeroCompiledManifest(exitCode, options, target)) {
-			options.stderr.write(
-				`Compiler harness exited with code ${exitCode} after writing valid repository IR; accepting ${target.manifestPath}.\n`,
-			);
-			return 0;
-		}
 		return exitCode;
 	}
 
@@ -209,36 +203,6 @@ async function pathExists(path: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
-}
-
-async function shouldAcceptNonzeroCompiledManifest(
-	exitCode: number,
-	options: RunCompileCommandOptions,
-	target: { absoluteManifestPath: string; manifestPath: string },
-): Promise<boolean> {
-	if (options.signal?.aborted || isSignalExitCode(exitCode)) {
-		return false;
-	}
-	return validCompiledRepositoryIrExists({ ...options, ...target });
-}
-
-async function validCompiledRepositoryIrExists(options: {
-	argv: readonly string[];
-	cwd: string;
-	env: Readonly<Record<string, string | undefined>>;
-	absoluteManifestPath: string;
-	manifestPath: string;
-}): Promise<boolean> {
-	try {
-		await validateCompiledRepositoryIr(options);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function isSignalExitCode(exitCode: number): boolean {
-	return Number.isInteger(exitCode) && exitCode > 128 && exitCode <= 192;
 }
 
 export async function validateCompiledRepositoryIr(options: {

--- a/tools/cli/src/prose/repository-serve-reactor-adapters.ts
+++ b/tools/cli/src/prose/repository-serve-reactor-adapters.ts
@@ -42,6 +42,7 @@ function createLocalModelGateway(
 					confidence: {
 						value: 0.5,
 						derivation_method: "local-deterministic-v0",
+						calibration_grade: "authored",
 						label_source: "openprose-cli-local",
 					},
 					...(status === "blocked"

--- a/tools/cli/src/prose/repository-serve.ts
+++ b/tools/cli/src/prose/repository-serve.ts
@@ -27,6 +27,7 @@ import {
 	claimResponsibilityPressureDispatch,
 	completeResponsibilityPressureDispatch,
 	readLatestResponsibilityPressure,
+	startResponsibilityPressureDispatchEffect,
 } from "./responsibility-pressure-dispatch.js";
 import {
 	buildResponsibilityStatusPaths,
@@ -760,12 +761,13 @@ async function launchPressureActivationOnce(options: {
 		return undefined;
 	}
 
+	const startedClaim = await startResponsibilityPressureDispatchEffect({ claim });
 	const exitCode = await launchActivationRun(options.request, {
 		...options.run,
 		cwd: options.cwd,
 	});
 	await completeResponsibilityPressureDispatch({
-		claim,
+		claim: startedClaim,
 		exitCode,
 	});
 

--- a/tools/cli/src/prose/responsibility-pressure-dispatch.ts
+++ b/tools/cli/src/prose/responsibility-pressure-dispatch.ts
@@ -18,6 +18,7 @@ export interface ResponsibilityPressureDispatchRecord {
 	responsibilityId: string;
 	activationId: string;
 	claimedAt: string;
+	effectStartedAt?: string;
 	completedAt?: string;
 	exitCode?: number;
 }
@@ -132,6 +133,21 @@ export async function completeResponsibilityPressureDispatch(options: {
 	return record;
 }
 
+export async function startResponsibilityPressureDispatchEffect(options: {
+	claim: ResponsibilityPressureDispatchClaimResult;
+	effectStartedAt?: string;
+}): Promise<ResponsibilityPressureDispatchClaimResult> {
+	const record: ResponsibilityPressureDispatchRecord = {
+		...options.claim.record,
+		effectStartedAt: options.effectStartedAt ?? new Date().toISOString(),
+	};
+	await writeFile(options.claim.path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+	return {
+		...options.claim,
+		record,
+	};
+}
+
 export function buildResponsibilityPressureDispatchPath(
 	openProseRoot: OpenProseRoot,
 	pressure: Pick<ResponsibilityPressureRecord, "responsibilityId" | "dedupeKey">,
@@ -155,6 +171,7 @@ async function readPressureDispatchRecord(path: string): Promise<ResponsibilityP
 		typeof parsed.responsibilityId !== "string" ||
 		typeof parsed.activationId !== "string" ||
 		typeof parsed.claimedAt !== "string" ||
+		(parsed.effectStartedAt !== undefined && typeof parsed.effectStartedAt !== "string") ||
 		(parsed.completedAt !== undefined && typeof parsed.completedAt !== "string") ||
 		(parsed.exitCode !== undefined && !Number.isInteger(parsed.exitCode))
 	) {
@@ -175,6 +192,7 @@ function isIncompleteDispatchClaim(
 		record.dedupeKey === options.pressure.dedupeKey &&
 		record.responsibilityId === options.pressure.responsibilityId &&
 		record.activationId === options.activationId &&
+		record.effectStartedAt === undefined &&
 		record.completedAt === undefined &&
 		record.exitCode === undefined
 	);

--- a/tools/cli/tests/cli/cli.test.ts
+++ b/tools/cli/tests/cli/cli.test.ts
@@ -688,7 +688,7 @@ Daily check evidence changed.
 		}
 	});
 
-	it("accepts a valid manifest when the compiler harness exits nonzero after writing it", async () => {
+	it("preserves nonzero compiler exits even after a valid manifest is written", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-compile-valid-nonzero-"));
 		const io = memoryStreams();
 
@@ -711,8 +711,8 @@ Daily check evidence changed.
 				}),
 			});
 
-			expect(exitCode).toBe(0);
-			expect(io.stderr).toContain("Compiler harness exited with code 1 after writing valid repository IR");
+			expect(exitCode).toBe(1);
+			expect(io.stderr).not.toContain("accepting dist/manifest.next.json");
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}

--- a/tools/cli/tests/prose/crash-window-replay.test.ts
+++ b/tools/cli/tests/prose/crash-window-replay.test.ts
@@ -27,7 +27,7 @@ const stargazerPressurePath = join(
 const fulfillmentPrompt = "prose run tests/open-prose/responsibility-runtime/stargazer-outreach/index.prose.md";
 
 describe("crash-window replay", () => {
-	it("restarts from durable pressure and dispatches fulfillment exactly once", async () => {
+	it("restarts from durable pressure and dispatches unstarted fulfillment once", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-crash-window-"));
 		const markerPath = join(temp, "markers/pressure-dispatch-claim-written.json");
 		let firstServe: SpawnedCli | undefined;

--- a/tools/cli/tests/prose/repository-cli-integration.test.ts
+++ b/tools/cli/tests/prose/repository-cli-integration.test.ts
@@ -57,6 +57,20 @@ function memoryStreams() {
 }
 
 describe("bundled example CLI integration", () => {
+	it("exits nonzero for unknown compile options", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-compile-unknown-option-"));
+
+		try {
+			ensureBuiltCli();
+			const result = await runCli(["compile", "--json", "--harness", "mock"], { cwd: temp });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("Unexpected option '--json'");
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
 	it("validates, serves, triggers, and reports Reactor surprise attribution for release-readiness", async () => {
 		const temp = mkdtempSync(join(tmpdir(), "prose-release-readiness-e2e-"));
 		const io = memoryStreams();

--- a/tools/cli/tests/prose/repository-serve.test.ts
+++ b/tools/cli/tests/prose/repository-serve.test.ts
@@ -22,6 +22,7 @@ import {
 	buildPressureFromStatus,
 	buildReactorPolicyNamespace,
 	buildTriggerRegistrationPlan,
+	dispatchPendingPressureActivations,
 	dispatchRepositoryServeEvent,
 	fingerprintResponsibility,
 	formatRepositoryServeSummary,
@@ -414,6 +415,55 @@ describe("repository serve core", () => {
 			expect(first?.recorded).toBe(true);
 			expect(second?.recorded).toBe(false);
 			expect(readFileSync(first!.paths.absolutePressureLogPath, "utf8").trim().split("\n")).toHaveLength(1);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("does not redispatch pressure after a post-effect crash window", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-serve-pressure-post-effect-"));
+		const io = memoryStreams();
+		let sideEffects = 0;
+
+		try {
+			writeActiveManifest(temp);
+			const loaded = await loadActiveRepositoryIr({ cwd: temp });
+			await recordPressureFromStatus({
+				loaded,
+				status: statusRecord(loaded, "down"),
+				recordedAt: "2026-05-03T12:05:00.000Z",
+			});
+
+			await expect(
+				dispatchPendingPressureActivations({
+					loaded,
+					run: {
+						env: {},
+						stdout: io.streams.stdout,
+						stderr: io.streams.stderr,
+						commandRunner: async () => {
+							sideEffects += 1;
+							throw new Error("simulated crash after side effect");
+						},
+					},
+				}),
+			).rejects.toThrow("simulated crash after side effect");
+
+			const replay = await dispatchPendingPressureActivations({
+				loaded,
+				run: {
+					env: {},
+					stdout: io.streams.stdout,
+					stderr: io.streams.stderr,
+					commandRunner: async () => {
+						sideEffects += 1;
+						return 0;
+					},
+				},
+			});
+
+			expect(sideEffects).toBe(1);
+			expect(replay).toEqual([]);
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}
@@ -1273,6 +1323,7 @@ function makeModelGateway(status: "up" | "drifting" | "down" | "blocked"): React
 				confidence: {
 					value: 0.74,
 					derivation_method: "cli-serve-test",
+					calibration_grade: "authored",
 					label_source: "fixture",
 				},
 				cost_tags: {

--- a/tools/cli/tests/prose/repository-status.test.ts
+++ b/tools/cli/tests/prose/repository-status.test.ts
@@ -288,6 +288,7 @@ function makeModelGateway(status: "up" | "drifting" | "down" | "blocked"): React
 				confidence: {
 					value: 0.74,
 					derivation_method: "cli-status-test",
+					calibration_grade: "authored",
 					label_source: "fixture",
 				},
 				cost_tags: {

--- a/tools/cli/tests/prose/responsibility-pressure.test.ts
+++ b/tools/cli/tests/prose/responsibility-pressure.test.ts
@@ -15,6 +15,10 @@ import {
 	type OpenProseRoot,
 	type ResponsibilityStatusRecord,
 } from "../../src/prose/index.js";
+import {
+	claimResponsibilityPressureDispatch,
+	startResponsibilityPressureDispatchEffect,
+} from "../../src/prose/responsibility-pressure-dispatch.js";
 
 describe("responsibility pressure", () => {
 	it("does not create pressure for up status", () => {
@@ -206,6 +210,47 @@ describe("responsibility pressure", () => {
 			expect(readdirSync(paths.absolutePressureClaimDirectoryPath).filter((name) => name.endsWith(".json"))).toHaveLength(
 				pressures.length,
 			);
+		} finally {
+			rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reclaim a dispatch after fulfillment effect has started", async () => {
+		const temp = mkdtempSync(join(tmpdir(), "prose-pressure-dispatch-started-"));
+
+		try {
+			const root: OpenProseRoot = { mode: "native", path: ".", absolutePath: temp };
+			const pressure = buildResponsibilityPressureRecord({
+				status: statusRecord("down"),
+				recommendedActivationKind: "fulfillment",
+				activationId: "responsibility-1.fulfillment",
+				recordedAt: "2026-05-03T12:05:00.000Z",
+			})!;
+
+			const claim = await claimResponsibilityPressureDispatch({
+				openProseRoot: root,
+				pressure,
+				activationId: "responsibility-1.fulfillment",
+				claimedAt: "2026-05-03T12:05:01.000Z",
+			});
+			expect(claim.claimed).toBe(true);
+			const started = await startResponsibilityPressureDispatchEffect({
+				claim,
+				effectStartedAt: "2026-05-03T12:05:02.000Z",
+			});
+			expect(started.record.effectStartedAt).toBe("2026-05-03T12:05:02.000Z");
+
+			const restartClaim = await claimResponsibilityPressureDispatch({
+				openProseRoot: root,
+				pressure,
+				activationId: "responsibility-1.fulfillment",
+				reclaimIncomplete: true,
+			});
+
+			expect(restartClaim.claimed).toBe(false);
+			expect(restartClaim.record.effectStartedAt).toBe("2026-05-03T12:05:02.000Z");
+			expect(restartClaim.record.completedAt).toBeUndefined();
+			expect(restartClaim.record.exitCode).toBeUndefined();
 		} finally {
 			rmSync(temp, { recursive: true, force: true });
 		}

--- a/tools/cli/tests/prose/responsibility-reactor.test.ts
+++ b/tools/cli/tests/prose/responsibility-reactor.test.ts
@@ -86,6 +86,7 @@ function makeModelGateway(status: "up" | "drifting" | "down" | "blocked"): React
 				confidence: {
 					value: 0.74,
 					derivation_method: "cli-bridge-test",
+					calibration_grade: "authored",
 					label_source: "fixture",
 				},
 				cost_tags: {


### PR DESCRIPTION
Implements the five approved post-PR-92 Phase 3 fixes: N13 invariant-6 fail-safe judging, N14 write-ahead fulfillment intent, N2b same-unit Cradle cost control, N17 compile nonzero failures, and N1 Reactor-forward front-door docs.

Verification:
- pnpm --filter @openprose/reactor test -> 154/154 green
- pnpm --filter @openprose/reactor-cradle test -> 121/121 green
- pnpm --filter @openprose/prose-cli test -> 284/284 green
- release verifier node --test suite -> 35/35 green
- pnpm build -> pass
- git diff --check -> clean