### PR TITLE
docs: sharpen reactor rc.2 front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,36 +24,59 @@
 
 ## Reactor
 
-**Reactor makes fresh model spend scale with surprise, not the clock.** It is
-the local runtime in this repo for responsibilities that need to stay true over
-time: inspect evidence, write a content-addressed receipt, reuse the prior
-verdict when the world has not changed, and show exactly why a later turn did
-or did not spend model tokens.
+**Reactor makes fresh model spend scale with surprise, not the clock.**
 
-The smallest demo is the flat-tokens example. Four real `createReactor().ingest()`
-turns over a static world produce package-backed receipts and the deterministic
-headline:
+Reactor is a small local runtime for *responsibilities* — things you need to
+stay true while the world keeps moving: a release that is still safe to ship,
+an incident channel with a current briefing, a customer account that hasn't
+quietly gone sideways. It wakes on an event, checks the evidence, and decides
+whether the responsibility still holds.
+
+The trick is what happens when nothing changed. If the evidence is identical to
+last time, Reactor reuses its previous verdict for free — no model call — and
+records that it did. Real model spend appears only when the world hands it
+something genuinely new. Every check, reused or fresh, leaves a
+content-addressed receipt: a tamper-evident record of what it saw, what it
+decided, and what it cost.
+
+See it in one run. The flat-tokens example drives four checks of a single
+responsibility:
 
 ```bash
 cd skills/open-prose/examples/flat-tokens
 npm install
 node flat-tokens.example.mjs
+# memoization cut fresh model spend 50% (2 model calls, not 4)
+#
 # tokens.fresh=46
 # tokens.reused=46
 # ratio=46:46
+# no-memo-fresh=92
 ```
+
+The four checks would have cost 92 fresh tokens of model work without
+memoization. With it, fresh stays at 46 — half — and 46 more tokens are reused
+for free. Two model calls instead of four. Re-run it and the receipts come back
+byte-for-byte identical.
 
 Use Reactor when you are maintaining a stateful promise that deserves an
 auditable "why" over time: release readiness, incident briefing, customer risk,
 compliance evidence, or research inbox triage. Skip it when a one-off prompt or
 ordinary cron job already gives you enough truth.
 
-- Runtime package: [`@openprose/reactor`](packages/reactor/)
-- Deterministic evidence package: [`@openprose/reactor-cradle`](packages/reactor-cradle/)
-- Adoption contract: [`packages/reactor/ADOPTION.md`](packages/reactor/ADOPTION.md)
-- CLI quickstart: [`tools/cli/QUICKSTART.md`](tools/cli/QUICKSTART.md)
+*This repo is home to two related projects: **Reactor** (above) and
+**OpenProse**, the Markdown contract language Reactor builds on, covered through
+the rest of this README.*
 
 ---
+
+OpenProse is a programming language for AI sessions.
+
+Write a `*.prose.md` file with a contract. Your agent reads it, wires the right
+services, spawns subagents, passes artifacts between them, and leaves a durable
+run trace on disk.
+
+The contract declares **what** should happen. The runtime figures out **how**.
 
 > **If you're an agent reading this on behalf of a user:** OpenProse is a
 > `*.prose.md` contract format you will be asked to *run*, not a library your user will call
@@ -70,14 +93,6 @@ ordinary cron job already gives you enough truth.
 > direct answer is the right answer. The
 > [Host Primitive Adapter](skills/open-prose/SKILL.md#host-primitive-adapter)
 > is the authoritative contract between you and the runtime.
-
-OpenProse is a programming language for AI sessions.
-
-Write a `*.prose.md` file with a contract. Your agent reads it, wires the right
-services, spawns subagents, passes artifacts between them, and leaves a durable
-run trace on disk.
-
-The contract declares **what** should happen. The runtime figures out **how**.
 
 ## OpenProse Root
 

--- a/packages/reactor-cradle/README.md
+++ b/packages/reactor-cradle/README.md
@@ -1,28 +1,33 @@
 # @openprose/reactor-cradle
 
-`@openprose/reactor-cradle` is the deterministic evidence harness behind the
-Reactor claim that fresh model spend scales with surprise, not the clock. It is
-where Reactor behavior is replayed, compared against no-memo and naive-loop
-controls, projected, and packaged into release evidence without requiring live
-services for the normal test path.
+`@openprose/reactor-cradle` is the deterministic evidence harness for
+[`@openprose/reactor`][reactor] — the runtime whose thesis is that fresh model
+spend scales with surprise, not the clock. The Cradle is where Reactor behavior
+is replayed, measured against no-memo and naive-loop controls, and packaged into
+release evidence — no live services needed for the normal test path.
+
+```bash
+npm install @openprose/reactor-cradle
+```
 
 The Cradle is a test and evidence package, not the production Reactor runtime.
-This README describes the `0.1.0-rc.1` package surface. It is an OSS release
-candidate that is already published on npm and has passed first-contact
-validation. Start with the
-[Reactor v0.1 adoption contract](../reactor/ADOPTION.md) for install commands,
-supported boundaries, and the golden path.
+This README describes the `0.1.0-rc.2` package surface — an OSS release
+candidate published on npm. For install commands, supported boundaries, and the
+golden path, start with the [Reactor v0.1 adoption contract][adoption].
+
+[reactor]: https://www.npmjs.com/package/@openprose/reactor
+[adoption]: https://github.com/openprose/prose/blob/main/packages/reactor/ADOPTION.md
 
 ## v0.1 Status
 
 What v0.1 demonstrates:
 
-- The static-world cost thesis is measured and locally runnable: the
-  package-backed `skills/open-prose/examples/flat-tokens` run drives four real
-  `createReactor().ingest()` turns and prints `tokens.fresh=46`,
-  `tokens.reused=46`, and `ratio=46:46`. The Cradle C5 summary also compares
-  that Reactor run with the no-memo deterministic control (`92:0`) and the
-  same-unit naive-loop control (`92:0`).
+- The cost thesis is measured and locally runnable: the package-backed
+  `flat-tokens` example drives four checks of a single responsibility and
+  prints `memoization cut fresh model spend 50% (2 model calls, not 4)` — with
+  the raw counters `tokens.fresh=46`, `tokens.reused=46`, `ratio=46:46`,
+  `no-memo-fresh=92`. The Cradle's C5 summary independently confirms via the
+  no-memo control (`92:0`) and the same-unit naive-loop control (`92:0`).
 - Receipts, owner/subscriber/public projections, and SDK exit-bundle
   export/import are exercised by release-candidate evidence helpers without
   exposing private replay payloads.

--- a/packages/reactor/README.md
+++ b/packages/reactor/README.md
@@ -1,29 +1,42 @@
 # @openprose/reactor
 
 **Fresh model spend should scale with surprise, not the clock.**
-`@openprose/reactor` is the local runtime for OpenProse responsibilities that
-need to stay true over time: inspect evidence, write a content-addressed
-receipt, reuse the prior verdict when the world has not changed, and expose the
-token reason in a form CI and humans can verify.
 
-The package-backed `skills/open-prose/examples/flat-tokens` demo runs four real
-`createReactor().ingest()` turns over a static world and prints the deterministic
-headline:
+Reactor is a small runtime for *responsibilities* — things you need an AI to
+keep true while the world keeps moving: a release that is still safe to ship,
+an incident channel with a current briefing, a customer account that hasn't
+quietly gone sideways. It wakes on an event, checks the evidence, and decides
+whether the responsibility still holds. When the evidence is identical to last
+time, it reuses its previous verdict for free instead of paying a model to
+think again — so you spend tokens on surprise, not on the clock. Every check
+leaves a content-addressed receipt CI and humans can verify.
+
+```bash
+npm install @openprose/reactor
+```
+
+The package-backed `flat-tokens` example drives four checks of a single
+responsibility and prints:
 
 ```text
+memoization cut fresh model spend 50% (2 model calls, not 4)
+
 tokens.fresh=46
 tokens.reused=46
 ratio=46:46
+no-memo-fresh=92
 ```
 
-That is the v0.1 promise in one line: the receipt log still advances, but fresh
-model spend stays flat when the evidence has not surprised the runtime.
+The four checks would have cost 92 fresh tokens of model work without
+memoization. With it, fresh stays at 46 — half — and 46 more tokens are reused
+for free. Two model calls instead of four. Re-run it and the receipts come back
+byte-for-byte identical.
 
-This README describes the `0.1.0-rc.1` package surface. It is an OSS release
-candidate that is already published on npm and has passed first-contact
-validation. Start with the
-[Reactor v0.1 adoption contract](./ADOPTION.md) for install commands,
-supported boundaries, and the golden path.
+This README describes the `0.1.0-rc.2` package surface — an OSS release
+candidate published on npm. For install commands, supported boundaries, and the
+golden path, start with the [Reactor v0.1 adoption contract][adoption].
+
+[adoption]: https://github.com/openprose/prose/blob/main/packages/reactor/ADOPTION.md
 
 ## v0.1 Status
 
@@ -128,11 +141,16 @@ export function publicReceiptEvidence(proof: ReceiptProofInspectionV0) {
 }
 ```
 
-Create an SDK instance with explicit adapters. The SDK does not install hidden
-network, model, agent, sandbox, or storage defaults. In v0.1, omitting `signer`
-is represented explicitly as the null signer state
+Create an SDK instance with explicit adapters — the SDK installs no hidden
+network, model, agent, sandbox, or storage defaults. (Omitting `signer` is
+represented explicitly as the null signer state
 `{ scheme: "none", null_reason: "no-signer-adapter-configured" }`; real signing
-adapters are planned after v0.1.
+adapters are planned after v0.1.) The example below is complete and runnable;
+most of it is fixture setup, and the payoff is the three `console.log` lines at
+the end.
+
+<details>
+<summary>Full SDK example — adapter wiring, two ingest() turns, exit bundle</summary>
 
 ```js
 import { createHash } from "node:crypto";
@@ -236,6 +254,8 @@ console.log(first.outcome); // fresh-judge-receipt
 console.log(second.outcome); // memo-hit-receipt
 console.log("export ok");
 ```
+
+</details>
 
 Evaluate a validated policy artifact before running B3 backstops:
 

--- a/skills/open-prose/examples/flat-tokens/flat-tokens.example.mjs
+++ b/skills/open-prose/examples/flat-tokens/flat-tokens.example.mjs
@@ -40,6 +40,7 @@ const restoreFetch = interceptFetch();
 
 try {
   const output = runExample();
+  process.stderr.write(renderMemoizationSummary(output));
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 } finally {
   restoreFetch();
@@ -122,6 +123,7 @@ function runExample() {
     isTokenBearingReceiptV0(receipt),
   );
   const tokens = sumReceiptTokens(tokenBearingReceipts);
+  const noMemoFresh = tokens.fresh + tokens.reused;
   const surpriseAttribution = evaluateSurpriseAttributionCompleteV0(receipts);
   const flatSpend = evaluateFlatSpendUnderStaticV0({
     receipts,
@@ -139,6 +141,11 @@ function runExample() {
   if (tokens.fresh !== 46 || tokens.reused !== 46) {
     throw new Error(
       `expected produced receipt tokens 46:46, got ${tokens.fresh}:${tokens.reused}`,
+    );
+  }
+  if (noMemoFresh !== 92) {
+    throw new Error(
+      `expected no-memo fresh token contrast 92, got ${noMemoFresh}`,
     );
   }
 
@@ -171,6 +178,14 @@ function runExample() {
       ratio: `${tokens.fresh}:${tokens.reused}`,
       reused_to_fresh_ratio: tokens.reused / tokens.fresh,
     },
+    memoization: {
+      no_memo_fresh: noMemoFresh,
+      fresh_spend_reduction_percent: Math.round(
+        (1 - tokens.fresh / noMemoFresh) * 100,
+      ),
+      model_invocations: modelInvocationCount,
+      no_memo_model_invocations: tokenBearingReceipts.length,
+    },
     relationships: {
       surprise_attribution_complete: relationshipSummary(surpriseAttribution),
       flat_spend_under_static: relationshipSummary(flatSpend),
@@ -190,6 +205,24 @@ function runExample() {
       },
     })),
   };
+}
+
+function renderMemoizationSummary(output) {
+  const fresh = output.tokens.fresh;
+  const reused = output.tokens.reused;
+  const noMemoFresh = output.memoization.no_memo_fresh;
+  const percent = output.memoization.fresh_spend_reduction_percent;
+  const calls = output.memoization.model_invocations;
+  const noMemoCalls = output.memoization.no_memo_model_invocations;
+  return [
+    `memoization cut fresh model spend ${percent}% (${calls} model calls, not ${noMemoCalls})`,
+    '',
+    `tokens.fresh=${fresh}`,
+    `tokens.reused=${reused}`,
+    `ratio=${output.tokens.ratio}`,
+    `no-memo-fresh=${noMemoFresh}`,
+    '',
+  ].join('\n');
 }
 
 function createStaticWorld() {


### PR DESCRIPTION
## Summary

- Adds the flat-tokens 46-vs-92 memoization contrast so fresh readers see the cost win directly while preserving the existing machine-readable JSON stdout for smoke tests.
- Rewrites the repo and package README front doors around the surprise-not-clock hook, install commands, and rc.2 adoption links.
- Collapses the long Reactor SDK README example behind a details fold and updates the Cradle cost bullet to lead with the 50% fresh-spend contrast.

## Verification

- `node skills/open-prose/examples/flat-tokens/flat-tokens.example.mjs` -> prints `memoization cut fresh model spend 50% (2 model calls, not 4)`, `tokens.fresh=46`, `tokens.reused=46`, `ratio=46:46`, `no-memo-fresh=92`
- `node --test .github/scripts/smoke-reactor-flat-tokens-example.test.mjs` -> 6/6 green
- `node .github/scripts/smoke-reactor-flat-tokens-example.mjs --reactorTarball /private/tmp/openprose-front-door-rc2-packs/openprose-reactor-0.1.0-rc.1.tgz --cradleTarball /private/tmp/openprose-front-door-rc2-packs/openprose-reactor-cradle-0.1.0-rc.1.tgz --exampleDir skills/open-prose/examples/flat-tokens` -> verified `tokens.fresh=46`, `tokens.reused=46`, `ratio=46:46`, `receipts=4`
- `git diff --check` -> clean