### PR TITLE
fix: upgrade npm for reactor trusted publish

### DIFF
--- a/.github/scripts/verify-reactor-publish-workflow.test.mjs
+++ b/.github/scripts/verify-reactor-publish-workflow.test.mjs
@@ -30,6 +30,11 @@ test('reactor package workflow runs publish path only for reactor-v* tags', asyn
     /id-token: write/,
     'publish job must request OIDC id-token permission for npm provenance',
   );
+  assert.match(
+    publishJob,
+    /npm install -g npm@11\.5\.1/,
+    'publish job must upgrade npm to a Trusted Publishing-capable CLI before provenance publish',
+  );
   assert.doesNotMatch(
     extractJob(source, 'ci'),
     /npm publish/,
@@ -113,6 +118,11 @@ test('reactor package workflow publishes both smoked tarballs with provenance', 
     'publish job must rely on npm trusted publishing/OIDC without token fallback',
   );
   assertInOrder(publishJob, 'Publish Reactor package', 'Publish Cradle package');
+  assertInOrder(
+    publishJob,
+    'Upgrade npm for trusted publishing',
+    'Publish Reactor package',
+  );
   assert.doesNotMatch(
     publishJob,
     /--dry-run/,

--- a/.github/workflows/ci-reactor-package.yml
+++ b/.github/workflows/ci-reactor-package.yml
@@ -169,6 +169,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.5.1
+
       - name: Download Reactor tarball
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Adds a deterministic `npm install -g npm@11.5.1` step in the Reactor package publish job before any `npm publish --provenance` call.
- Extends the publish-workflow verifier so the npm upgrade remains present and ordered before publishing.
- Leaves the rest of the rc.2 publish wiring unchanged: `reactor-v*` tag trigger, `id-token: write`, `--provenance`, and no `NPM_TOKEN` / `_authToken` fallback.

## Verification

- `node --test .github/scripts/verify-reactor-publish-workflow.test.mjs` -> 3/3 green
- release verifier node suite -> 35/35 green
- `git diff --check` -> clean