### PR TITLE
docs: publish reactor spec reconciliation

### DIFF
--- a/spec/00-Tenets.md
+++ b/spec/00-Tenets.md
@@ -1,0 +1,62 @@
+# OpenProse Tenets
+
+###### Load-bearing principles that constrain every architectural decision. Read alongside [01-Language.md](./01-Language.md), [02-ReactorHarness.md](./02-ReactorHarness.md), and [03-ReactorPattern.md](./03-ReactorPattern.md).
+
+These are the commitments that make OpenProse what it is. They are not feature
+requirements; they are constraints that shape every downstream decision,
+evaluated before any new capability is considered.
+
+When the system is in tension with a tenet, the tenet wins. When two tenets
+collide, the lower-numbered tenet wins — the order below is descending
+precedence. The Harness precedence stack
+(`correctness > safety > cost > interrupt-minimization`) is the runtime
+projection of this ordering, not an independent authority:
+correctness⇄Tenets 1–3, safety⇄Tenet 4, cost/interrupt⇄Tenets 5–6.
+
+---
+
+## 1. Intent lives only in the contract.
+
+The `*.prose.md` is the single authored source of meaning. Everything else —
+compiled artifacts, projections, operational policy — is *derived* and
+reconcilable; when a derived artifact disagrees with the contract, the contract
+is right. There is no second authored surface for intent: not a prompt, a
+config, or a tuned judge.
+
+## 2. Intelligence is the model's; determinism only bounds it.
+
+The model acts as a bounded *agent* — with an environment, a filesystem, and
+the ability to read, write, and run code — that dynamically explores rather
+than consuming a one-shot context. It authors judgment, compilation, and
+policy. Deterministic code validates, schedules, records, and executes what the
+agent authored, and constrains it with limits the agent cannot override — it
+never authors judgment itself.
+
+## 3. Continuity lives in the trail, not a session.
+
+Every unit of work is bounded; nothing depends on a process that runs forever.
+Standing intent is the program and persists across bounded runs in durable
+state — a one-shot run is its degenerate case.
+
+## 4. Fail safe.
+
+Under uncertainty the system escalates or stops rather than acts, and asks a
+human only when one is genuinely needed. Safety outranks cost; cost outranks
+silence.
+
+## 5. Trust is demonstrated, not claimed.
+
+Every decision leaves verifiable evidence; that evidence is at once the audit
+record, the composition edge, and the exit ticket. Consumers verify it
+independently rather than trusting the producer.
+
+## 6. Nothing is held hostage.
+
+A contract and its trail can leave for any compliant host with no lost meaning.
+Portability is the discipline that keeps every host honest.
+
+---
+
+*Governance — not a numbered tenet: the OpenProse language, runtime, and skill
+are MIT-licensed and free, forever. Commerce is out of scope of this
+specification and nothing in it depends on it.*

--- a/spec/01-Language.md
+++ b/spec/01-Language.md
@@ -1,0 +1,1062 @@
+# OpenProse
+
+###### A programming language for AI sessions, expressed as durable Markdown contracts.
+
+This document is the specification of **the OpenProse Language & Framework** —
+the durable `*.prose.md` contract format, the skill semantics that interpret
+it, the model-run compiler that lowers it, the standard library that packages
+reusable behavior, and the CLI surface that drives it. It is the spec for what
+ships **bundled as the SKILL**.
+
+The OpenProse corpus divides labor exactly, and each document maps to what
+ships:
+
+- [01-Language.md](./01-Language.md) — **this document, the Language &
+  Framework**, bundled as the **SKILL**: syntax, kinds, sections, compile
+  model, std/co, CLI surface.
+- [02-ReactorHarness.md](./02-ReactorHarness.md) — **the Reactor
+  Harness**, bundled as the **CLI/Server**: the runtime control architecture
+  (loop, invariants, kernel, memoization, forecast, receipts, composition)
+  that *serves* these contracts.
+- [03-ReactorPattern.md](./03-ReactorPattern.md) — **the
+  Reactor-Native Authoring Pattern**, **SKILL-bundled but harness-governed**:
+  how to write `*.prose.md` so the harness's mechanisms engage. It bridges
+  this doc and the Harness doc.
+- **Internal decision log** — not shipped: the dialectic that produced the
+  Harness doc; the clean statements live in the public specs above.
+- [00-Tenets.md](./00-Tenets.md) — **the constitution**. When any
+  document tensions with a tenet, the tenet wins.
+
+This file has three parts, mirroring its companions:
+
+1. **Ideal** — the OpenProse language and framework as it *should* be. This is
+   the frozen authored vision.
+2. **Current** — an accurate, code-grounded snapshot of what the
+   public `openprose/prose` skill package and CLI *actually do today*. This
+   section is mechanically re-derivable from the code; it is named real
+   modules, real types, real behaviors, with paths.
+3. **Roadmap (the Delta)** — the honest gap: what bridges Current → Ideal.
+
+`Ideal − Current = Roadmap`. The three are kept distinct so the document can
+never again claim shipped what isn't, or aspire in the same breath it reports.
+
+---
+
+## Part I — The Ideal OpenProse Language & Framework
+
+OpenProse is a contract format, runtime doctrine, skill package, standard
+library, and CLI wrapper for making agent work readable, reviewable, versioned,
+reusable, and inspectable. A user writes one `*.prose.md` file of durable
+intent. A Prose Complete agent host reads it, wires the services, spawns
+isolated bounded sessions, passes artifacts through declared bindings, and
+leaves a durable receipt under an OpenProse root.
+
+The central idea:
+
+```text
+Markdown source defines intent.
+Skill and interpreter docs define semantics.
+A model-run compiler lowers semantics into IR; deterministic code validates it.
+The harness serves IR.
+Runs interpret and act inside bounded activations.
+```
+
+### The commitments that define the language
+
+Each is a Tenet made concrete at the language layer. They are the north star;
+Part II is honest about how far the current skill has climbed toward them.
+
+- **Markdown is the only contract (Tenet 1).** `*.prose.md` carries 100% of
+  semantic weight. Compiled IR, manifests, projections, and read models are
+  derived views; if any disagrees with the Markdown, the Markdown is right.
+  There is no second surface where intent lives — not a prompt, not a tool
+  config, not a hidden judge prompt (Tenet 1).
+- **The responsibility is the program (the inversion).** A standing goal
+  written as durable intent is the top-level authored object. A `kind: system`
+  is one beat of its loop; bounded service/system work is the **N=0
+  (no-continuity) special case**, not the default.
+- **The same Markdown runs on any Prose Complete host (Tenet 1).** Every
+  contract authored against this spec executes identically on any compliant
+  host. A fresh `git clone` is a first-class experience; a long-lived host
+  adds reliability and scale, never semantics.
+- **Intelligence lives in the model, not in deterministic code (Tenet 2).**
+  The compiler is itself a Prose service the model runs; deterministic code
+  only validates IR, wires connectors, enforces boundaries, schedules, and
+  signs. The language never grows a config format to encode what the model
+  should decide.
+- **The authored surface is small, stable, and complete.** Six kinds
+  (`service`, `system`, `test`, `pattern`, `responsibility`, `gateway`), the
+  canonical `###` section set (enumerated in Part II), the `### Runtime`
+  `persist` setting and the `### Memory` contract it gates, and the header
+  hierarchy are the entire language. New capability is new *semantics* in
+  skill docs, never new syntax or a YAML overlay.
+- **A sensing service may return a stable content identity (Harness invariant
+  5).** A service that observes the world to inform a judgment may declare, as
+  an ordinary `### Ensures` output, a *stable content identity*: a cheaply
+  computed value that changes if and only if the semantically relevant
+  observed content changed. This is not new syntax — it is one `### Ensures`
+  item, optionally diffed against a `### Memory` ledger key. It is what lets
+  the harness reuse a prior verdict instead of re-judging an unchanged world;
+  absent it, maintenance cost scales with time, not surprise. The
+  *normalization convention* (hash of what, normalized how) is deliberately
+  not fixed here — see [03-ReactorPattern.md](./03-ReactorPattern.md) Rules 2
+  & 5 and [02-ReactorHarness.md](./02-ReactorHarness.md) open item I.1.
+- **The language packages reusable behavior and stays a public good.** `std`
+  and `co` prove OpenProse programs compose like code. The language, runtime
+  doctrine, and skill are MIT and free, forever; commerce is out of scope of
+  this specification and nothing here depends on it.
+- **Agents are first-class authors.** Humans and agents co-equally
+  author, fork, and compose contracts. Every surface, error, and metadata
+  field is designed for both readers from the start.
+- **Every contract is portable (Tenet 6).** The Markdown, with its
+  durable trail, can leave for any Prose Complete harness with no lost
+  semantics. The public artifact is the contract; the deployment's secrets and
+  data stay private.
+
+### What the responsibility's two semantic sections mean
+
+Most `###` sections are catalogued in Part II; their meaning is self-evident
+from their name. Two are not, and carry semantic load the Ideal must state
+rather than defer: `### Continuity` and `### Criteria` in a
+`kind: responsibility`.
+
+**`### Continuity` is the author's input to forecast and memoization.** It is
+not a schedule. It names: the *freshness referents* (what makes the goal go
+stale, how fast, and which external signal — if any — announces a change); the
+*memo-breaking condition* (what makes a prior verdict no longer reusable); the
+*plan-audit horizon* (how long a no-escalation run may continue before a forced
+deep revalidation, independent of judge confidence); and *whether a cheap
+stable identity exists at all* — if "did the semantically relevant content
+change" cannot be decided more cheaply than the judgment itself, the author
+must say so, and the contract runs at forecast cadence by deliberate
+declaration, not by accident.
+
+**`### Criteria` states satisfaction in observable referents.** Every criterion
+must point at something a judge can observe. When a criterion has no observable
+referent the correct verdict is `blocked` with a judge-authored reason routed
+to the contract author — an expected, high-value output, never an error and
+never an enumerated status.
+
+The author writes these; the harness owns the memo, the forecast, and the
+control policy derived from them. The granular how-to — decomposition for
+memoization, the confidence gate, projection-only shapes — is the Reactor
+authoring pattern's ([03-ReactorPattern.md](./03-ReactorPattern.md)); the
+runtime mechanics are the harness's
+([02-ReactorHarness.md](./02-ReactorHarness.md)).
+
+The full mechanics of the runtime that *serves* these contracts — memoization,
+forecast-gated quiescence, the two-timescale model-authored policy, receipts,
+composition — are **not** specified here. They are the Reactor harness's
+concern ([02-ReactorHarness.md](./02-ReactorHarness.md)). This
+document's ideal is the *language*: the contract a human or agent writes, and
+the semantics by which it is understood.
+
+---
+
+## Part II — Current
+
+> This part is a fresh, code-grounded audit of the public `openprose/prose`
+> repository at `main` (HEAD `52724ed`, tag `reactor-v0.1.0`). It
+> reports what the bundled skill and the `@openprose/prose-cli` package
+> **actually do** at the audited state — version `0.14.0`. Where the language
+> as authored exceeds what the code exercises, this part says so. It is named
+> against real files; it is mechanically re-derivable from the code, and it is
+> the section that must stay true.
+>
+> Older framing around hosted cloud products, social execution networks,
+> company financing, `kind: program`, `.prose` source files, and the old
+> registry model is not part of this audit unless the current repo still
+> contains a live implementation or spec for it.
+
+### Current Shape
+
+OpenProse is distributed as a skill bundle plus a CLI. The skill at
+`skills/open-prose/` carries the language doctrine; the CLI at `tools/cli/`
+(`@openprose/prose-cli`) hosts the deterministic runtime pieces.
+
+The load-bearing skill docs are:
+
+| Doc | Location | Role |
+| --- | --- | --- |
+| Contract Markdown | `skills/open-prose/contract-markdown.md` | Canonical `*.prose.md` source format |
+| Forme | `skills/open-prose/forme.md` | Semantic dependency-injection container for systems |
+| Prose VM | `skills/open-prose/prose.md` | Execution semantics for services, systems, tests, and runs |
+| ProseScript | `skills/open-prose/prosescript.md` | Imperative choreography inside `### Execution` and pattern `### Delegation` |
+| Responsibility Runtime | `skills/open-prose/responsibility-runtime.md` | Standing goals, Reactor, repository IR, `compile`, `serve`, `status` |
+| Compiler program | `skills/open-prose/compiler/index.prose.md` | The pinned ProseScript compiler service |
+| IR v0 contract | `skills/open-prose/compiler/ir-v0.md` | The repository IR v0 output contract |
+| Concepts | `skills/open-prose/concepts/responsibility.md`, `concepts/reactor.md` | Responsibility and Reactor semantic contracts |
+| State backends | `skills/open-prose/state/{filesystem,in-context,sqlite,postgres}.md` | The four declared state backends |
+| Authoring guidance | `skills/open-prose/guidance/{authoring,tenets,system-prompt}.md` | Authoring how-to and design reasoning |
+| `SKILL.md` | `skills/open-prose/SKILL.md` | Agent-facing skill entrypoint |
+
+The shippable repository also contains:
+
+| Area | Location | Role |
+| --- | --- | --- |
+| OpenProse skill | `skills/open-prose/` | Agent-facing runtime/spec bundle |
+| CLI | `tools/cli/` | Shell entrypoint and deterministic host for compile/status/serve |
+| Standard library | `packages/std/` | Reusable roles, patterns, ops, delivery, memory, evals |
+| Company-as-Prose package | `packages/co/` | Generic company-operations starter contracts |
+| Reactor packages | `packages/reactor/`, `packages/reactor-cradle/` | The Reactor harness runtime; specified in [02-ReactorHarness.md](./02-ReactorHarness.md) |
+| Examples | `skills/open-prose/examples/` | Native OpenProse repositories and minimal feature demos |
+| Tests and fixtures | `tests/open-prose/`, `tools/cli/tests/` | Smoke fixtures, compiler fixtures, IR/runtime tests |
+| Plugin envelopes | `.codex-plugin/`, `.claude-plugin/`, `.agents/plugins/` | Marketplace/install metadata |
+
+OpenProse is distributed as an MIT-licensed beta (`LICENSE`, `TERMS.md`,
+`PRIVACY.md`) and collects no telemetry.
+
+> **Audit note.** The Reactor harness runtime (`packages/reactor`,
+> `packages/reactor-cradle`) is present in the repository but is not language
+> material. Its current state is audited in `02-ReactorHarness.md`. This
+> document audits only the language, the source-compile, and the CLI surface
+> that drives them.
+
+### What OpenProse Is Not
+
+The current repository narrows the ground truth:
+
+- Current source files are `*.prose.md`, not plain `.md` contracts or
+  standalone `.prose` programs.
+- Current authored kinds are `service`, `system`, `gateway`, `test`, `pattern`,
+  and `responsibility`. The source-compiler's `knownSourceKinds` set
+  (`tools/cli/src/prose/repository-source-compiler.ts`) enumerates exactly
+  these six; any other `kind:` lowers to `unknown`.
+- `kind: program`, `kind: composite`, `compose:`, old numbered examples, old
+  `.deps/` layout, `~/.prose`, and `.prose/runs/` are legacy upgrade context.
+- `prose migrate` and `prose wire` are retired; current migration is
+  `prose upgrade`, and current source compilation is `prose compile`. The
+  CLI's command set (`tools/cli/src/commands/index.ts`) contains no `migrate`
+  or `wire` command.
+- Bare `owner/repo` identifiers and `p.prose.md` registry resolution are
+  reserved/inert. Current dependency resolution is explicit git-host based,
+  with `std/` and `co/` shorthands.
+- The current repo does not specify a product/business platform surface like
+  Cloud billing, sprites, Constellation, or an investor narrative. Hosted
+  product, public/social, subscription, royalty, dependency-graph, brand, and
+  design surfaces are intentionally outside this public language/runtime spec.
+
+### Prose Complete
+
+OpenProse runs inside an agent host. A host is "Prose Complete" when it can map
+the abstract VM primitives onto real capabilities:
+
+| Primitive | Required behavior |
+| --- | --- |
+| `spawn_session` | Start an isolated agent/session with a prompt, optional model, and access to declared input/output paths |
+| `ask_user` | Pause for missing required caller input and resume with the answer |
+| `read_file` / `write_file` | Read and write `<openprose-root>/runs/{id}/` state artifacts and backend records |
+| `copy_binding` | Publish a declared output through the active backend (filesystem copies `workspace/{service}/` → `bindings/{service}/`) |
+| `check_env` | Confirm an environment variable exists without exposing its value |
+| `check_tool` | Confirm a declared host tool exists without installing, modifying, or running it |
+
+Codex-style and Claude Code-style environments are the primary documented
+targets. The CLI ships three harness adapters
+(`tools/cli/src/harnesses/`): `codex-sdk` (`codex-sdk.ts`, built on
+`@openai/codex-sdk`), `claude-sdk` (`claude-sdk.ts`), and a local `mock`
+harness (`mock.ts`). `HARNESS_NAMES` in `harnesses/index.ts` is exactly
+`["codex-sdk", "claude-sdk", "mock"]`. OpenProse commands are therefore first
+an agent-session command language. A shell command such as:
+
+```bash
+prose run src/hello.prose.md
+```
+
+means "ask the selected agent harness to embody the OpenProse VM and execute
+this contract." The CLI is not a replacement VM.
+
+### OpenProse Root
+
+Every run happens relative to an OpenProse root:
+
+| Scope | Root |
+| --- | --- |
+| Native repository | Repository root |
+| Attached repository | `repo/.agents/prose` |
+| User-global | `~/.agents/prose` |
+
+These are the constants in `tools/cli/src/prose/openprose-root.ts`
+(`ATTACHED_OPENPROSE_ROOT_PATH = ".agents/prose"`,
+`USER_OPENPROSE_ROOT_PATH = "~/.agents/prose"`). A native root is detected by
+the presence of `prose.lock` or `.git`.
+
+The root layout is:
+
+| Path | Purpose |
+| --- | --- |
+| `src/` | Authored intent: services, systems, tests, patterns, gateways, responsibilities |
+| `dist/` | Compiled intent, especially repository IR |
+| `runs/` | Activation receipts for bounded VM runs |
+| `state/` | Durable cross-run state |
+| `state/agents/` | Durable agent memory |
+| `state/responsibilities/` | Responsibility status and pressure |
+| `deps/` | Installed git-native dependencies |
+| `prose.lock` | Dependency lockfile |
+| `.env` | Local runtime environment |
+
+This root model matters because OpenProse is not just syntax. Its runtime
+contract includes where runs are recorded, how dependencies are found, and
+where standing goals keep their history.
+
+### Contract Markdown
+
+Contract Markdown is the human-facing language surface. A `*.prose.md` file has
+small YAML frontmatter for identity and Markdown `###` sections for contracts,
+runtime hints, shape, execution, memory, and responsibility semantics. The
+canonical spec is `skills/open-prose/contract-markdown.md`.
+
+```markdown
+---
+name: research-report
+kind: service
+---
+
+### Requires
+
+- `topic`: the question to investigate
+
+### Ensures
+
+- `report`: concise answer with sources
+
+### Strategies
+
+- when sources are thin: broaden search terms
+```
+
+**Frontmatter.** Every file declares identity with `name` and `kind`. A
+`kind: test` file also declares `subject:`. A `kind: responsibility` file
+**also carries a required `id:` frontmatter field** — and the source-compile
+*enforces* this (see audit note below). `id:` is a tooling-generated 16-byte
+UUIDv7-compatible value rendered as a **26-character uppercase Crockford
+base32** string (`isMarkdownResponsibilityId` in
+`tools/cli/src/prose/repository-ir.ts`: `markdownIdLength = 26`,
+`markdownIdByteLength = 16`, with the UUIDv7 version/variant nibbles checked).
+It is minted once and preserved across `name:` and filename renames. `name:`
+is the human-facing slug; `id:` is the durable identity used to key
+standing-goal state under `state/responsibilities/{id}/`, to fence decisions on
+contract revision, and as the composition referent. Authors do not hand-write
+`id:`; tooling manages it.
+
+> **Audit note — `id:` on responsibility files.** Both the spec
+> (`contract-markdown.md`) **and every bundled example** carry the required
+> `id:`. All eight responsibility files under
+> `skills/open-prose/examples/*/src/*.prose.md` (e.g.
+> `stargazer-outreach/src/high-intent-stargazer-outreach.prose.md` with
+> `id: 067NC4KG19TPD9V8D5N6PV3DDR`) declare a valid 26-char id. The compile
+> path enforces it three ways: a preflight check
+> (`validateResponsibilitySources` in `tools/cli/src/commands/compile.ts`)
+> emits a `missing_id` or `malformed_id` diagnostic and fails the compile
+> *before* harness forwarding; the IR validator
+> (`validateResponsibilities` in `repository-ir.ts`) rejects any
+> responsibility whose `id` is not a Crockford-base32 UUIDv7 Markdown id; and
+> a post-compile source-contract check
+> (`validateCompiledResponsibilitySourceContracts`) re-confirms each emitted
+> `id` matches the source frontmatter. The required-`id:` claim is **true and
+> exercised** in the current code — there is no drift here.
+
+The six current authored kinds are:
+
+| Kind | Directly runnable? | Purpose |
+| --- | --- | --- |
+| `service` | Yes | Atomic execution boundary: one contract, one session, one workspace |
+| `system` | Yes, when structurally complete | Composition boundary: one contract implemented as a graph |
+| `test` | Via `prose test` | Fixtures plus semantic assertions against a service or system |
+| `pattern` | No | Reusable agent design pattern instantiated by systems |
+| `responsibility` | No | Standing goal compiled into repository IR |
+| `gateway` | No | Ingress source compiled into trigger registrations |
+
+The `###` sections recognized by `contract-markdown.md`, case-insensitively,
+are:
+
+| Section | Applies to | Meaning |
+| --- | --- | --- |
+| `### Description` | system/service/test/pattern | Human summary; preserved for readers, not a contract |
+| `### Services` | system | Services, systems, or pattern instances to wire |
+| `### Requires` | system/service/test/pattern slots; `responsibility` for a pinned composition reference | Inputs or dependencies the caller/container must provide |
+| `### Ensures` | system/service/pattern | Outputs or postconditions |
+| `### Errors` | system/service | Declared failure modes |
+| `### Invariants` | system/service/pattern | Properties that hold regardless of outcome |
+| `### Strategies` | system/service/test | Judgment rules and edge-case guidance |
+| `### Environment` | system/service | Required runtime variables, checked by name only |
+| `### Runtime` | system/service | Execution settings; `persist: project\|user` gates the durable-state surface and the `### Memory` contract; `model` selects the model |
+| `### Memory` | service | Declared durable reads/writes; only meaningful when `### Runtime` sets `persist: project` or `persist: user` |
+| `### Skills` | system/service | Agent harness skills the component requires the host to provide, declared by `namespace:name` |
+| `### Tools` | system/service/responsibility | Host tools (`cli:<name>`, `mcp:<name>`) the component requires the host to provide, declared by name only |
+| `### Shape` | service | Capability boundaries: self, delegates, prohibited work |
+| `### Wiring` | system | Explicit binding when auto-wiring should be pinned |
+| `### Execution` | system/service | ProseScript choreography |
+| `### Fixtures` / `### Expects` / `### Expects Not` | test | Test data and assertions |
+| `### Slots` / `### Config` / `### Delegation` | pattern | Pattern interface and algorithm |
+| `### Goal` / `### Continuity` / `### Criteria` / `### Constraints` / `### Tools` / `### Fulfillment` | responsibility | Standing-goal contract |
+| `### Schedule` / `### Receives` / `### Emits` / `### Payload` | gateway | Time/event ingress declarations |
+
+Unknown `###` sections are preserved as documentation; they are not contract
+sections.
+
+> **Audit note — `### Tools` is required on responsibilities; `### Skills` is
+> a real section.** The compile preflight
+> (`validateResponsibilitySources` in `compile.ts`) emits a
+> `missing_required_section` diagnostic and fails the compile if a
+> `kind: responsibility` file has no `### Tools` section — an empty
+> `### Tools` with `(none)` satisfies it, an absent one does not. Every
+> bundled responsibility example includes an explicit `### Tools` section for
+> this reason. Separately, `### Skills` is a current canonical section
+> (declaring harness skills in `namespace:name` form, resolved fail-closed
+> against `./skills/`, `~/.claude/skills/`, `~/.codex/skills/`,
+> `~/.agents/skills/`); the deterministic preflight
+> (`preflightDeclaredSkillsInRoot`) emits `skill_unresolved`. `### Skills`
+> and `### Description` are part of the live language surface.
+
+Header hierarchy is part of the language:
+
+| Header | Meaning |
+| --- | --- |
+| `#` | Optional human title |
+| `##` | Inline service boundary inside multi-service files |
+| `###` | Section inside the current service/system/test/pattern/responsibility |
+| `####`+ | Free-form nested documentation inside a section |
+
+The source-compiler's `parseMarkdownSections` and `splitMarkdownComponents`
+implement this hierarchy directly (`repository-source-compiler.ts`,
+`compile.ts`), including fenced-code awareness so a `###` inside a code fence
+is not mistaken for a section.
+
+Systems compose work four ways:
+
+1. Plain service names in `### Services`.
+2. Subsystems, where a `kind: system` is treated as a graph node by its parent.
+3. Explicit `### Wiring`.
+4. Pattern instances declared as YAML inside `### Services`.
+
+Pattern instances are current syntax:
+
+```yaml
+- name: reviewed-output
+  pattern: std/patterns/worker-critic
+  with:
+    worker: writer
+    critic: reviewer
+  config:
+    max_rounds: 3
+```
+
+> **Audit note — pattern-instance lowering in the deterministic compiler.**
+> The deterministic source-compiler's `compileFormeManifest`
+> (`repository-source-compiler.ts`) wires systems by parsing `### Services`
+> into plain service names and resolving each against discovered source by
+> `name`. Structured pattern-instance YAML (`pattern:`/`with:`/`config:`) is
+> *authored* syntax that the language recognizes and the pinned ProseScript
+> compiler is meant to expand, but the deterministic TypeScript fallback
+> compiler resolves only plain service-name entries and subsystem-by-name
+> entries; a pattern-instance entry that does not name a resolvable source
+> emits a `warning` diagnostic. Pattern instantiation is therefore fully
+> *specified* and exercised in smoke fixtures
+> (`tests/open-prose/smoke/09-local-pattern.prose.md`), but the deterministic
+> compiler's Forme lowering does not itself expand patterns into graph nodes.
+
+### Forme
+
+Forme is OpenProse's semantic dependency-injection container. Traditional
+containers wire by type. Forme wires by reading contracts. The doctrine is
+`skills/open-prose/forme.md`.
+
+For a `kind: system`, Forme:
+
+1. Reads the system contract and `### Services`.
+2. Resolves local services, subsystems, dependency paths, and pattern files.
+3. Expands pattern instances into concrete graph constraints.
+4. Matches `### Requires` to caller inputs or upstream `### Ensures`.
+5. Uses exact names, semantic equivalence, shape hints, and explicit wiring.
+6. Warns on soft ambiguity and errors on hard ambiguity.
+7. Builds a dependency graph, execution order, parallelization opportunities,
+   environment requirements, and warnings.
+8. Produces a compiled Forme manifest consumed by the Prose VM.
+
+The current repository keeps the Forme doctrine in `skills/open-prose/forme.md`
+and also expresses the wiring operation as a standard-library contract in
+`packages/std/ops/wire.prose.md`. That is an important architectural point:
+OpenProse uses Prose to describe parts of its own toolchain.
+
+The deterministic source-compiler emits a structured Forme manifest per system
+as `formeManifests[]` in repository IR: graph nodes with workspace paths,
+input/output bindings, a topological `executionOrder`, declared `environment`
+variables, and declared `tools`, each with `requiredBy` node lists
+(`compileFormeManifest`, `wireFormeInputs`, `executionOrderFor` in
+`repository-source-compiler.ts`). Input wiring matches a node's `### Requires`
+field names against upstream `### Ensures` outputs; an unmatched field becomes
+a `caller` input. This is name-equality wiring; the richer semantic-equivalence
+and shape-hint matching in the Forme doctrine is the pinned ProseScript
+compiler's responsibility.
+
+### Prose VM
+
+The Prose VM is the execution semantics (`skills/open-prose/prose.md`). When an
+agent runs OpenProse, it is not merely describing a VM. It performs the VM by
+mapping the spec to host tools, spawning real sessions, writing real artifacts,
+and evaluating real contracts.
+
+For a single service:
+
+1. Snapshot the invoked source.
+2. Bind caller inputs.
+3. Spawn one session with the service contract, inputs, workspace, output
+   obligations, and any allowed memory.
+4. Wait for declared outputs.
+5. Copy declared outputs to public bindings.
+6. Return the ensured result and record the run.
+
+For a system:
+
+1. Run Forme to produce or load the compiled manifest.
+2. Create a durable run envelope.
+3. Execute graph nodes in topological order, parallelizing independent nodes.
+4. Pass bindings by pointer.
+5. Keep each service's scratch in its own workspace.
+6. Publish only declared outputs.
+7. Record the VM log, bindings, sources, and manifest.
+
+The default filesystem backend creates:
+
+```text
+runs/{run-id}/
+  root.prose.md
+  sources/
+  forme.manifest.json
+  workspace/
+  bindings/
+  vm.log.md
+  agents/
+```
+
+The separation matters:
+
+| Directory | Meaning |
+| --- | --- |
+| `sources/` | Immutable source snapshots for the run |
+| `workspace/` | Private scratch and outputs per service |
+| `bindings/` | Public interface visible to downstream services |
+
+OpenProse specifies four state backends, each with a doc under
+`skills/open-prose/state/`: filesystem (`filesystem.md`, the default and
+normative reference), in-context (`in-context.md`, for small ephemeral runs),
+SQLite (`sqlite.md`), and PostgreSQL (`postgres.md`). SQLite and PostgreSQL are
+documented as experimental durable alternatives that keep the run envelope but
+move events and data-plane bindings into database records.
+
+> **Audit note — the VM is host-embodied.** The Prose VM is not a TypeScript
+> implementation in this repository. Execution is performed by the selected
+> agent harness embodying the semantics in `prose.md`. The CLI forwards
+> `prose run`/`prose test` to the harness; it does not itself spawn service
+> sessions or copy bindings. The deterministic code's role is compile, IR
+> validation, status reading, and serve dispatch — see the CLI subsection.
+
+### ProseScript
+
+Contract Markdown is declarative. ProseScript is the pinning layer
+(`skills/open-prose/prosescript.md`).
+
+Use ProseScript when order, loops, branching, retries, parallelism, or exact
+call choreography matters:
+
+````markdown
+### Execution
+
+```prose
+let findings = call researcher
+  topic: topic
+
+let report = call writer
+  findings: findings
+
+return report
+```
+````
+
+ProseScript supports `call`, `parallel`, `for`, `loop`, `if`, `choice`,
+`try/catch/finally`, `throw`, `agent`, `session`, `resume`, blocks, and
+pipeline-style operations. In current Contract Markdown, public interfaces
+belong to `### Requires`, `### Ensures`, and `### Services`; embedded
+ProseScript should not redeclare them. When `### Execution` is present it is a
+Level 3 pin: Forme still validates contracts and extracts the call graph, but
+the VM follows the written order.
+
+### Responsibility Runtime
+
+Responsibility Runtime is the continuity layer for repositories that need
+standing goals to remain true over time
+(`skills/open-prose/responsibility-runtime.md`).
+
+The stack is:
+
+| Layer | Role |
+| --- | --- |
+| Responsibility | What must remain true over time |
+| Reactor | Evented reconciliation model |
+| Forme | Fulfillment wiring |
+| Prose VM | One bounded activation that judges, fulfills, retries, or escalates |
+
+A `kind: responsibility` file is semantic and normative. It defines:
+
+- `### Goal`: the invariant.
+- `### Continuity`: how time qualifies the obligation.
+- `### Criteria`: what satisfactory fulfillment means.
+- `### Constraints`: what must remain bounded or prohibited.
+- `### Tools`: declared host capabilities (`cli:`/`mcp:`) — a **required**
+  section, even when `(none)`.
+- `### Fulfillment`: optional hint naming a system or service.
+
+A `kind: gateway` file describes ingress when inference would be unsafe:
+schedules, local HTTP routes, webhooks, provider events, and emitted
+responsibility trigger ids.
+
+The Reactor loop is:
+
+1. A timer, HTTP route, webhook, manual request, source change, queue, or other
+   event wakes the system.
+2. A bounded judge activation evaluates the responsibility as `up`,
+   `drifting`, `down`, or `blocked`.
+3. Status is written under `state/responsibilities/{id}/latest.json` and
+   appended to `status.jsonl`.
+4. Unhealthy status produces deduped pressure.
+5. Pressure launches an ordinary fulfillment, retry, or escalation activation.
+
+Current live serve support includes local cron and HTTP adapters
+(`tools/cli/src/prose/repository-serve-reactor-adapters.ts`,
+`repository-cron.ts`, `repository-serve-daemon.ts`). Queues, file watches,
+provider subscription setup, webhook authentication, and automatic manifest
+reload are explicitly later phases (stated in `responsibility-runtime.md`).
+Judge activations use the bundled
+`skills/open-prose/runtime/judge-responsibility.prose.md` service. Pressure
+records (`responsibility-pressure.ts`, `responsibility-pressure-dispatch.ts`)
+are deduped by responsibility fingerprint, status, source-status timestamp,
+activation class, and activation id.
+
+### Repository IR v0
+
+`prose compile` lowers source under an OpenProse root into generated repository
+IR. Markdown remains the durable authoring surface; IR is disposable compiled
+intent consumed by deterministic infrastructure. The IR v0 contract is
+`skills/open-prose/compiler/ir-v0.md`; the TypeScript types and validator are
+`tools/cli/src/prose/repository-ir.ts`.
+
+The v0 top-level shape is:
+
+```json
+{
+  "kind": "openprose.repository-ir",
+  "version": 0,
+  "sources": [],
+  "responsibilities": [],
+  "triggers": [],
+  "activations": [],
+  "formeManifests": [],
+  "diagnostics": []
+}
+```
+
+The canonical output files are:
+
+| File | Meaning |
+| --- | --- |
+| `dist/manifest.next.json` | Fresh compile output |
+| `dist/manifest.active.json` | Manifest consumed by `prose serve` |
+
+These are the `NEXT_REPOSITORY_IR_PATH` and `ACTIVE_REPOSITORY_IR_PATH`
+constants in `repository-ir.ts`. Promotion from next to active is explicit
+(by convention `cp dist/manifest.next.json dist/manifest.active.json`).
+
+IR records include:
+
+| Record | Meaning |
+| --- | --- |
+| `sources[]` | Discovered source files: root-relative `path`, `kind`, optional `name` |
+| `responsibilities[]` | `id`, `sourcePath`, `goal`, `continuity[]`, `criteria[]`, `constraints[]`, `tools[]`, optional `fulfillment` |
+| `triggers[]` | Concrete `cron`, `http`, or `manual` trigger registrations keyed to a responsibility id |
+| `activations[]` | `judge`, `fulfillment`, `retry`, or `escalation` intent |
+| `formeManifests[]` | Structured runtime wiring for systems |
+| `diagnostics[]` | `info`/`warning` messages with optional source paths (a written manifest may not contain `error`-severity diagnostics) |
+
+> **Audit note — `prose compile` runs a deterministic compiler too.** The spec
+> describes `prose compile` as forwarding to a pinned ProseScript compiler
+> (`skills/open-prose/compiler/index.prose.md`) and then deterministically
+> *validating* the model-produced JSON. That is accurate but incomplete for
+> the current code. `runCompileCommand` (`tools/cli/src/commands/compile.ts`)
+> *also* ships a complete deterministic TypeScript source-compiler,
+> `compileRepositorySource` (`repository-source-compiler.ts`), which discovers
+> every `.prose.md` under the source root and emits a full valid
+> `manifest.next.json` — responsibilities, triggers, activations, and Forme
+> manifests — purely from the Markdown. The CLI uses it as a fallback:
+> `writeSourceCompiledRepositoryIrIfMissing` writes the deterministic IR when
+> the harness produced none, and `shouldAcceptNonzeroCompiledManifest`
+> accepts a valid deterministic IR even when the harness exits non-zero. So
+> the current `prose compile` has *two* compilers — the model-run ProseScript
+> program and a deterministic TypeScript one — and the deterministic one is
+> exercised by the compiler fixtures (`tests/open-prose/compiler/expected/`).
+> The Ideal commits the compiler to be a model-run Prose service (Tenet 2);
+> the current code has a deterministic fallback that does the same lowering.
+
+Important compiler doctrine (from `responsibility-runtime.md` and `ir-v0.md`):
+
+- Discover every `.prose.md` under the source root.
+- Infer only when the source graph is clear; the deterministic compiler infers
+  fulfillment when exactly one system (or, absent systems, one service) is
+  present, and warns when multiple systems are plausible.
+- Warn instead of guessing timing, fulfillment, or wiring.
+- Do not invent provider auth, queue names, routes, payload schemas, or
+  subscription setup.
+- Write `manifest.next.json` only after the IR shape is valid.
+
+Repository IR v0 is **frozen and source-derived**: it is a function of the
+`*.prose.md` source and nothing else. The Reactor harness's policy artifact,
+token-truth receipts, forecasts, and decisions are **sibling runtime state**
+owned by `@openprose/reactor` — not IR fields and not new source syntax. See
+Part III §3 and [02-ReactorHarness.md](./02-ReactorHarness.md)
+("The two compiles").
+
+### CLI
+
+The CLI package is `@openprose/prose-cli`, version `0.14.0` at the audited
+state (`tools/cli/package.json`). It is an Oclif TypeScript package published
+as the `prose` binary.
+
+Its two jobs are:
+
+1. Turn user-facing commands into canonical OpenProse prompts for agent
+   harnesses.
+2. Host deterministic local runtime pieces for repository IR, status, and
+   trigger serving.
+
+Current local deterministic commands (have a dedicated `Command` class in
+`tools/cli/src/commands/`):
+
+| Command | Role |
+| --- | --- |
+| `prose help` | Oclif help |
+| `prose doctor` | Inspect or install selected provider skill targets |
+| `prose compile` | Run the (preflight + harness + deterministic-fallback) compile, then validate generated IR |
+| `prose status` | Read active IR and runtime receipts locally |
+| `prose serve` | Serve active IR with local cron and HTTP adapters |
+
+Current forwarded commands (defined as `ForwardCommandDefinition` entries in
+`commands/index.ts`):
+
+| Command | Role |
+| --- | --- |
+| `prose run` | Run a service or structurally complete system |
+| `prose test` | Execute `kind: test` contracts |
+| `prose lint` | Validate source structure and contract consistency |
+| `prose preflight` | Check dependencies and environment |
+| `prose inspect` | Inspect a completed run |
+| `prose install` | Install and pin dependencies |
+| `prose examples` | List or run bundled examples |
+| `prose upgrade` | Migrate legacy source/layout conventions |
+| `prose write` | Generate validated OpenProse source from rough English or pseudo-Prose |
+
+> **Audit note — `prose write` is a new command (v0.14.0).** `prose write`
+> and the `std/ops/prose-author` contract were added in `0.14.0` (see
+> `CHANGELOG.md`). In-harness it is interactive by default and may ask
+> targeted `ask_user` questions after a read-only landscape scan and
+> shape/root inference; the shell CLI wrapper is non-interactive, forwards
+> argv/stdin with `interactive: false`, and returns `unresolved-intent`
+> rather than guessing. It is part of the current language tooling and is
+> absent from the Ideal section.
+
+Harness selection uses `--harness` or `PROSE_HARNESS`. The documented harnesses
+are `codex-sdk`, `claude-sdk`, and `mock`; `codex-sdk` is the default
+(`env.PROSE_HARNESS || "codex-sdk"` in `tools/cli/src/commands/base.ts`).
+
+`prose serve` loads `dist/manifest.active.json`, validates it, registers local
+cron timers and HTTP routes, exposes `GET /_openprose/health`
+(`repository-serve-daemon.ts`), and dispatches accepted events into ordinary
+`prose run` activations. HTTP triggers return `202 Accepted` before
+long-running agent work completes.
+
+### Dependencies
+
+OpenProse dependencies are git-native and disk-only at runtime
+(`skills/open-prose/deps.md`).
+
+Canonical dependency identifiers use explicit git hosts:
+
+```text
+github.com/openprose/prose/packages/std/evals/inspector
+gitlab.com/alice/research/tools/summarizer
+git.company.com/team/internal-system
+```
+
+Two first-party shorthands exist:
+
+| Shorthand | Expands to |
+| --- | --- |
+| `std/...` | `github.com/openprose/prose/packages/std/...` |
+| `co/...` | `github.com/openprose/prose/packages/co/...` |
+
+`prose install` populates `<openprose-root>/deps/` and writes
+`<openprose-root>/prose.lock`. Runtime resolution reads installed dependencies
+from disk. Missing dependency identifiers should fail with a message telling
+the user to run `prose install`.
+
+### Standard Library
+
+`packages/std/` is the standard library. It is not just helper text; it is a
+library of OpenProse contracts written in the language itself.
+
+| Category | Contents (audited file count) |
+| --- | --- |
+| `roles/` | 10 atomic role services: `classifier`, `critic`, `extractor`, `formatter`, `planner`, `researcher`, `router`, `summarizer`, `verifier`, `writer` |
+| `patterns/` | 19 reusable coordination patterns: `assumption-miner`, `blind-review`, `coherence-probe`, `contrastive-probe`, `dialectic`, `ensemble-synthesizer`, `fallback-chain`, `fan-out`, `guard`, `map-reduce`, `oversight`, `pipeline`, `proposer-adversary`, `race`, `ratchet`, `refine`, `retry-with-learning`, `stochastic-probe`, `worker-critic` |
+| `ops/` | Operational systems: `diagnose`, `lint`, `preflight`, `profiler`, `status`, `wire`, plus `prose-author` (the `prose write` backing contract, with its test suite) |
+| `delivery/` | Human gate, email, Slack, webhook, HTML rendering, and file writing |
+| `memory/` | Project and user memory services |
+| `evals/` | `contract-grader`, `cross-run-differ`, `eval-calibrator`, `inspector`, `platform-improver`, `prose-contributor`, `regression-tracker`, `system-improver` |
+
+> **Audit note — std additions since the prior spec.** The prior Part II
+> listed `ops/` as `lint, preflight, wire, status, diagnose, profiler` and
+> `evals/` without `prose-contributor`. The current `ops/` also contains
+> `prose-author.prose.md` (the backing contract for `prose write`, shipped
+> with eight `*.test.prose.md` files), and the current `evals/` also contains
+> `prose-contributor.prose.md`. The pattern and role inventories above are
+> the audited file listing.
+
+The `roles` README describes roles as the atoms. Patterns are the molecules:
+they define slots, config, invariants, and delegation algorithms that systems
+instantiate. The eval and ops libraries make the feedback loop explicit: a run
+can be inspected, graded against contracts, compared across runs, diagnosed,
+profiled, and used to propose source or platform improvements.
+
+### Company-As-Prose Package
+
+`packages/co/` is a first-party but domain-shaped package. It sits beside
+`std`, not inside it.
+
+`std` is use-case agnostic. `co` is an opinionated starter kit for operating a
+company as an OpenProse-native repository. The current public contracts are:
+
+| Contract | Role |
+| --- | --- |
+| `co/services/agent-readiness` | Probe a company's website for agent-discoverability and plain-HTML readiness |
+| `co/systems/company-repo-checker` | Verify a company-as-prose repo matches shared layout and contract expectations |
+| `co/evals/agent-readiness`, `co/evals/company-repo-checker` | Evaluations for the package services/systems |
+
+The package explicitly avoids OpenProse, Inc. private business logic. It is
+generic company-operations scaffolding. As audited, `co/` contains exactly one
+service, one system, and two eval contracts — a small, focused package.
+
+### Examples
+
+The examples under `skills/open-prose/examples/` divide into two groups.
+
+**Native OpenProse repositories** — full responsibility-runtime examples, each
+with `src/`, `dist/`, `runs/`, `state/`, `deps/`, and `prose.lock`:
+
+| Example | Standing goal |
+| --- | --- |
+| `stargazer-outreach` | Keep high-intent GitHub stargazers enriched and ready for thoughtful follow-up |
+| `incident-briefing-room` | Keep an incident channel current with sourced status, impact, and next actions |
+| `customer-risk-radar` | Keep customer risk visible before renewals or escalations surprise the team |
+| `release-readiness` | Keep a release candidate ready with evidence, risks, notes, and rollback context |
+| `vendor-renewal-watch` | Keep vendor renewals prepared before auto-renewal or negotiation windows close |
+| `research-inbox-triage` | Keep a research inbox deduplicated, prioritized, and converted into action |
+| `content-performance-loop` | Keep content performance learnings flowing into next editorial actions |
+| `compliance-evidence-tracker` | Keep audit evidence fresh, reviewed, and gap-aware |
+
+Each of these eight repositories follows the shared lifecycle:
+
+```bash
+prose compile
+cp dist/manifest.next.json dist/manifest.active.json
+prose serve
+```
+
+and each demonstrates the current architecture: a responsibility defines the
+standing goal, a gateway provides time/event ingress, a fulfillment system
+composes services, and project-scoped memory updates durable ledgers. All
+eight responsibility source files carry a valid `id:` frontmatter field.
+
+**Minimal feature demos** — smaller examples that each isolate one language
+feature:
+
+| Example | Demonstrates |
+| --- | --- |
+| `declared-skills` | `### Skills` resolution and the `skill_unresolved` diagnostic |
+| `declared-tools` | `### Tools` resolution and the `tool_unresolved` diagnostic |
+| `auto-pocock` | A non-interactive 12-service system adapting an external skill workflow |
+| `flat-tokens` | A Reactor-runtime (`packages/reactor`) token-accounting demo — Reactor-harness material, not language material; see [02-ReactorHarness.md](./02-ReactorHarness.md) |
+
+### Tests And Release
+
+The current repository has several layers of validation:
+
+| Layer | Coverage |
+| --- | --- |
+| Contract smoke fixtures | `tests/open-prose/smoke/` — 10 `*.prose.md` fixtures: single service, caller input, auto-wiring, inline services, explicit wiring, ProseScript execution, errors/strategies, `kind: test`, local pattern instantiation |
+| Compiler fixtures | `tests/open-prose/compiler/` — expected repository IR (`expected/empty`, `expected/stargazer`, `expected/ambiguous-fulfillment`) and invalid IR shapes (`invalid/malformed-forme`, `invalid/malformed-responsibility`, `invalid/missing-version`) plus source fixtures including a `missing-criteria` invalid responsibility |
+| CLI tests | `tools/cli/tests/` — 26 `*.test.ts` files across `cli/`, `prose/`, `harnesses/`, `skills/`, `tools/`, `install/`, `package/` |
+| IR validation tests | Source paths, cron/http/manual triggers, judge-activation rules, fulfillment/Forme consistency, diagnostics — exercised against `repository-ir.ts` |
+| Responsibility tests | Status records, pressure records, dedupe, freshness, activation routing |
+| CI workflows | `.github/workflows/` — CLI release checks, real harness smoke, skill install smoke, OpenProse smoke, plugin manifest validation, release publishing |
+
+The release process uses one release train. Skill metadata, plugin metadata,
+CLI npm package, package lock, and tarball installer share the same `X.Y.Z`
+version (`.version-bump.json`, `.plugin-meta.json`). The protected release
+workflow verifies CLI/package/plugin surfaces, publishes `@openprose/prose-cli`,
+and creates a GitHub Release.
+
+### Mental Model
+
+> **Audit note.** This mental model is reported as the *current taught* model.
+> The Ideal (Part I) and the Roadmap (Part III §1) call for inverting it so
+> the responsibility, not the system, is the headline. It is preserved here as
+> an accurate record of what the skill currently teaches.
+
+OpenProse is best understood as typed, inspectable agent software:
+
+- A prompt is useful for one-off work.
+- A `*.prose.md` contract is useful when the work has roles, handoffs,
+  retries, memory, tests, or a receipt.
+- A `kind: system` is a dependency graph of service contracts.
+- Forme is the semantic container that wires the graph.
+- The Prose VM is the agent-session runtime that performs the graph.
+- ProseScript is how authors pin choreography when declaration is not enough.
+- Responsibility Runtime is how a repository keeps standing goals true across
+  bounded runs instead of pretending one agent session should live forever.
+- `std` and `co` are proof that OpenProse programs can package reusable
+  behavior like code.
+
+### Glossary
+
+| Term | Meaning |
+| --- | --- |
+| Activation | One bounded VM run, often launched by `prose run` or `prose serve` |
+| Binding | A public declared input or output artifact |
+| Contract Markdown | The canonical `*.prose.md` source format |
+| Forme | Semantic dependency-injection container for systems |
+| Gateway | Ingress declaration compiled into trigger registrations |
+| OpenProse root | Root directory containing `src`, `dist`, `runs`, `state`, `deps`, and lock/env files |
+| Pattern | Reusable coordination algorithm instantiated by a system |
+| Pressure | Runtime feedback created when a responsibility is unhealthy |
+| Prose Complete | Host capability threshold for running OpenProse |
+| Prose VM | Execution semantics embodied by the agent host |
+| ProseScript | Imperative choreography language inside `### Execution` and pattern `### Delegation` |
+| Repository IR | Generated JSON manifest consumed by deterministic runtime infrastructure |
+| Responsibility | Standing goal that must remain true over time |
+| Reactor | Evented reconciliation model for responsibilities |
+| Service | Atomic execution boundary: one contract, one session, one workspace |
+| System | Composition boundary implemented as a graph of services/systems/pattern instances |
+
+---
+
+## Part III — Roadmap (the Delta)
+
+The gap between Part I and Part II is **almost entirely doctrine, not syntax.**
+The finding across this doc, the Harness doc, and the Pattern doc is
+that the ideal language needs **no new `*.prose.md` syntax** — the six kinds,
+the canonical sections, and the header hierarchy already express everything,
+with one bounded exception: composition pins a reserved `responsibility`
+typed-input (the same mechanism as `run`/`run[]`), so the supply-chain edge is
+kernel-verifiable rather than prose-asserted (§3).
+What must change is which model the skill *teaches as default*, and how thinly
+two sections are currently documented relative to the load they bear.
+
+### 1. Invert the taught mental model (the central item)
+
+The "Mental Model" and the "Directly runnable?" framing in Part II are
+**system-first**. They are correct for bounded work and wrong as the default.
+The climb:
+
+- Rewrite the mental model responsibility-first: the responsibility is the
+  program; the gateway is ingress; the system is one beat of the loop;
+  Forme/VM/ProseScript are substrate. Keep the system-centric model explicitly
+  as the **N=0 (no-continuity) special case**, not as the headline.
+- Reframe "Directly runnable?" so `kind: responsibility` being *served* rather
+  than *run* reads as "continuously reconciled" — the most load-bearing
+  authored object, not a lesser artifact.
+- Route standing-goal language ("keep X true," "make sure Y stays current") in
+  `SKILL.md` to responsibility authoring **before** system wiring.
+
+These are enumerated precisely in
+[03-ReactorPattern.md](./03-ReactorPattern.md) Part III §1–§3 and
+§6–§7; that doc is the authoritative checklist. This section exists so the
+language doc itself records the obligation rather than silently depending on
+the Pattern doc.
+
+### 2. Strengthen `### Continuity` and `### Criteria` doctrine
+
+The Ideal-level semantic contract for these two sections now lives in Part I
+("What the responsibility's two semantic sections mean") — they are no longer
+deferred to an out-of-corpus file for *meaning*. What remains owed to
+`contract-markdown.md` is the *granular authoring how-to* (worked examples,
+lint-able expectations), framed as one-line definitions that point at Part I
+rather than re-deriving the semantics. Detail in Pattern doc Part III §4–§5.
+
+### 3. Boundary with the Reactor harness
+
+The language has **one** compile: `prose compile` (source → repository IR v0),
+source-derived, re-run when source changes. The Reactor harness adds a
+**second, distinct** compile — policy-compile (contract + receipt history →
+a token-free policy registry), history-derived, re-run when the policy's own
+falsification predicate trips. Same doctrine (a model authors; deterministic
+code validates and executes the artifact), different trigger, input, lifetime,
+and output. The full statement — why they cannot be merged, the lifecycle
+asymmetry, and the agentic-author sequencing — lives in
+[02-ReactorHarness.md](./02-ReactorHarness.md) ("The two
+compiles"); it is not restated here.
+
+The language-side commitments are only these, and they bound what the harness
+may do without changing the language:
+
+- **Repository IR v0 is frozen and source-derived.** The policy artifact,
+  token-truth receipts, forecasts, and Reactor decisions are **sibling runtime
+  state owned by `@openprose/reactor`** — not new IR fields and not new
+  `*.prose.md` syntax. The policy-registry artifact's format is the harness's
+  to specify, tracked as Harness open item I.5
+  ([02-ReactorHarness.md](./02-ReactorHarness.md), "Open
+  specification items"); this disclaimer is the language side of that seam.
+- **The bounded-activation agent SDK stays an adapter.** The `--harness`
+  surface in Part II (`codex-sdk`/`claude-sdk`/`mock`) carries no Reactor
+  control logic; the harness's model-gateway is a separate socket. Detail in
+  the Harness doc.
+- **Stable content identity is an `### Ensures` convention, not a schema.** The
+  identity a sense service returns rides on existing `### Ensures` / `### Memory`
+  surfaces; the harness memoizes on it but the language adds no field, type, or
+  section for it. Its normalization convention is tracked as Pattern open item
+  1, gated on Harness receipt-schema research (open item I.1).
+- **Composition pins a reserved typed-input, not a new section.** A
+  `kind: responsibility` may declare a reserved `responsibility` input in
+  `### Requires` that pins an upstream id-or-path + contract revision +
+  acceptable signer set — the same typed-input mechanism as `run`/`run[]`,
+  resolved by the source-compile, kernel-verifiable, and explicitly **not** a
+  Forme wiring edge. It is source-derived authoring surface, not
+  policy-registry/sibling state.
+
+### 4. Converge the two compilers, or document the split deliberately
+
+Part II's audit found that `prose compile` currently ships **two** compilers:
+the pinned model-run ProseScript program
+(`skills/open-prose/compiler/index.prose.md`) and a deterministic TypeScript
+source-compiler (`tools/cli/src/prose/repository-source-compiler.ts`) used as a
+fallback. The Ideal commits the compiler to be a Prose service the model runs
+(Tenet 2: intelligence in the model, deterministic code only validates). The
+deterministic fallback does real lowering — including fulfillment inference and
+Forme-manifest construction — which is more than validation.
+
+The roadmap item is a deliberate decision, not a silent drift: either (a) the
+deterministic compiler is reframed as *only* a structural validator and the
+model-run compiler becomes the sole lowering path, or (b) the deterministic
+compiler is acknowledged in the Ideal as a permitted, semantics-free
+mechanical lowering (name-equality wiring, no judgment) that coexists with the
+model-run compiler for ambiguous graphs. This doc's Ideal currently assumes
+(a); the code currently does (b). Resolving which the language commits to is
+owed work.
+
+### Definition of done for the language layer
+
+- The mental model and runnable framing are responsibility-first; the
+  system-first model survives only as the explicitly labeled N=0 case.
+- `SKILL.md` routes standing-goal language to responsibility authoring first.
+- `contract-markdown.md` documents `### Continuity` as forecast/memo input and
+  `### Criteria` decidability with the undecidable-`blocked` doctrine.
+- No new syntax is introduced; every change is doctrine, docs, or routing.
+- The IR-vs-sibling-state boundary is stated and cross-linked, not implied.
+- The two-compiler relationship is resolved into a single committed doctrine.

--- a/spec/02-ReactorHarness.md
+++ b/spec/02-ReactorHarness.md
@@ -1,0 +1,1537 @@
+# OpenProse Reactor Harness
+
+###### A Reactor-class harness for evented reconciliation of AI-maintained world state.
+
+The OpenProse corpus divides labor exactly, and each document maps to what
+ships:
+
+- [01-Language.md](./01-Language.md) — **the Language & Framework**, bundled as
+  the **SKILL**: syntax, kinds, sections, compile model, std/co, CLI surface.
+- [02-ReactorHarness.md](./02-ReactorHarness.md) — **this
+  document, the Reactor Harness**, bundled as the **CLI/Server**: the runtime
+  control architecture — the loop, invariants, kernel, memoization, forecast,
+  receipts, composition. It names the architectural class underneath
+  continuous outcomes and answers _what the runtime must do_.
+- [03-ReactorPattern.md](./03-ReactorPattern.md) — **the
+  Reactor-Native Authoring Pattern**, **SKILL-bundled but harness-governed**:
+  how to write `*.prose.md` so this harness's mechanisms engage. It bridges
+  the Language doc and this doc.
+- **Internal decision log** — not shipped: the dialectic that produced this
+  revision. This document is the clean public statement and does not carry the
+  dialectic.
+- [00-Tenets.md](./00-Tenets.md) — **the constitution**. When any
+  document tensions with a tenet, the tenet wins.
+
+`ContinuousOutcomes.md` is out-of-scope ideation, not part of the runtime spec.
+
+This file has three parts, kept structurally distinct so the document cannot
+silently rot the way an earlier revision did:
+
+1. **Ideal** — the Reactor-class harness as it *should* be. The vision; frozen.
+2. **Current** — a code-grounded snapshot of what the `openprose/prose`
+   repository *actually implements today*, named down to modules, types, and
+   test counts. Mechanically re-derivable from the code.
+3. **Roadmap (the Delta)** — what bridges Current → Ideal before OpenProse
+   publicly launches the term with a technical report.
+
+`Ideal − Current = Roadmap`. Part I never claims something shipped; Part II
+never aspires.
+
+---
+
+## I. Ideal Reactor-Class Harness
+
+### What it is like to use one
+
+Start from the lived loop, not the machinery. The architecture is the
+consequence of this promise, not the thing itself.
+
+> You write one sentence of durable intent and what makes it true. Then you
+> walk away — there is no session to babysit. The system interrupts you on
+> exactly two conditions: it needs a judgment only a human can make, or an
+> input or permission only you can grant. Otherwise it is silent. Everything it
+> did, you can verify afterward from a trail you never had to ask for — and you
+> can take that trail and that sentence and run them somewhere else.
+
+Four beats: **author**, **walk away**, **interrupted only when genuinely
+needed**, **verifiable and exitable trail**.
+
+One honesty note belongs in the promise itself: interruptions **front-load
+during authoring and asymptote toward silence**. "Walk away" is the steady
+state, not the first hour. Saying so is what makes the rest credible — a
+contract is at its most ambiguous the moment it is written, and the system's
+most valuable early output is often "this sentence is not yet decidable, here
+is why."
+
+Everything below is the answer to a single question asked of each beat: _what
+does this beat require the runtime to do?_
+
+### The responsibility
+
+A responsibility is a standing goal, written as durable intent. It is not a
+task, script, or single run. It is a statement that should remain true:
+
+```text
+The release candidate is ready to ship.
+Important customer risks are surfaced before renewal meetings.
+The incident channel has a current, accurate briefing.
+Compliance evidence is fresh enough for the next audit.
+```
+
+The contract is authored in `*.prose.md` per `00-Tenets.md` Tenet 1.
+Nothing else carries semantic weight; compiled IR, projections, and read models
+are derived views.
+
+### The canonical loop
+
+Each event is a reason to reconcile the modeled world state. An event may be a
+timer tick, webhook, queue message, file change, source change, manual request,
+judge drift, fulfillment completion, or retry outcome.
+
+```text
+event
+  -> bounded judge or fulfillment activation
+  -> durable status and evidence
+  -> Reactor decision
+  -> projected state
+  -> scheduled judge, fulfillment, retry, escalation, or quiescence
+```
+
+The harness is "Reactor-class" when the policy for that loop is explicit,
+typed, replayable, and shared across hosts. The model judges and fulfills
+inside bounded activations; continuity lives in durable state, never in a
+long-running session.
+
+The distinction from a normal agent loop is the whole point.
+
+A normal agent loop asks:
+
+```text
+What should I do next?
+```
+
+A Reactor-class harness asks:
+
+```text
+Given this responsibility, this event, the latest observations, and the prior
+decisions, what reconciliation action is now justified?
+```
+
+That turns agent behavior from a running conversation into an inspectable state
+transition.
+
+### The unification thesis
+
+The loop above is the **base case**. The full architecture is one mechanism
+applied recursively:
+
+> **Model-authored policy, compiled to a token-free deterministic registry,
+> executed with memoization, forecast-gated scheduling, and confidence-gated
+> depth.**
+
+This single mechanism, seen from different sides, is the whole of Part I.
+Two recursions wrap the base case:
+
+- **Policy over time.** The control policy itself — cadence, hysteresis band
+  shapes, escalation thresholds — is _authored by the model_, then _compiled_
+  into a deterministic, replayable, token-free artifact that runs hot for a
+  window. The mechanism is **Popperian**: the compiled policy ships _its own
+  falsification predicate_ — the conditions, stated at author time, under which
+  it admits it is wrong (observed drift exceeds its predicted curve; escalation
+  precision falls below its claimed threshold; cost per maintained
+  responsibility trends past its stated budget). The deterministic kernel is a
+  dumb evaluator of that predicate against the receipt log, plus a **tiny fixed
+  backstop that does not trust the predicate to be honest** (max policy age,
+  min recompile interval, max calibration divergence, and
+  rollback-to-last-known-good — a fresh policy that trips its own predicate
+  faster than its predecessor auto-reverts). No model call decides whether to
+  recompile: the model only authored the tripwire; the kernel checks whether it
+  fired. This is the existing OpenProse compile step made continuous. The model
+  owns _intelligence_ (policy authorship); determinism owns only _execution_ of
+  model-authored policy. Tenet 2 is honored, not violated: a dumb fast
+  mechanism with intelligent slow parameters. The original "Reactor decides
+  from typed state" is the special case where the policy is fixed. The
+  meta-loop has its own hysteresis so it does not recompile too eagerly, and
+  policy artifacts get the same receipts and replay that responsibilities get
+  (open items I.2, I.4).
+
+- **Responsibilities over a graph.** A signed, content-addressed receipt is
+  already a perfect evidence token. "B depends on A" means B's judge consumes
+  A's latest receipt as an evidence source, identical to consuming a webhook.
+  **The dependency graph is the evidence graph.** The original
+  single-responsibility loop is the N=1 case.
+
+You do not need to re-understand the core loop. You need to understand that it
+is the base case of these two recursions. Everything else is presentation.
+
+### The two compiles
+
+OpenProse compiles twice. The two share one *doctrine* but are not one
+*operation*; conflating them silently breaks audit, replay, and adaptivity.
+
+| | Source-compile | Policy-compile |
+| --- | --- | --- |
+| Fires when | the author changed intent | the world drifted from what the policy predicted (the falsification predicate tripped) |
+| Input | `*.prose.md` source only | contract **+ accumulated receipt history** |
+| Question | "what did the author declare?" | "given the declaration *and everything observed*, what is the cheapest correct way to maintain it?" |
+| Output | repository IR (structural lowering) | the token-free policy registry the kernel executes |
+| Lifetime | until source changes again | until the predicate trips or the backstop fires |
+| Correctness test | fidelity to source (deterministic validation) | calibration against reality (the falsification predicate) |
+
+They cannot be merged, for three independent reasons. **Audit/replay:** "the
+verdict changed because the author rewrote the criteria" and "the cadence
+changed because calibration degraded" are different histories that must replay
+against different recorded artifacts (invariant 8, Tenet 5). **Lifetime:** IR
+is valid until source changes (perhaps months); the policy artifact until the
+predicate trips (perhaps hours); one artifact cannot carry two validity clocks.
+**Determinism boundary:** source→IR is a fidelity problem the CLI checks
+deterministically; contract+history→policy is optimization under uncertainty
+with no single correct answer, checked by the falsification predicate.
+
+The lifecycle asymmetry is the proof they are distinct:
+
+```text
+t0     author writes contract  → SOURCE-compile → IR
+                                → POLICY-compile (cold start) → seed policy
+t0–30  no source edits; IR byte-identical all month
+t12    judge calibration degrades       → predicate trips → POLICY-compile  (IR untouched)
+t19    cost-per-maintained over budget  → predicate trips → POLICY-compile  (IR untouched)
+       —— 30 days: SOURCE-compile 0×, POLICY-compile 2× ——
+t31    author sharpens a criterion → SOURCE-compile → new IR + revision
+                                    → may cascade → POLICY-compile
+```
+
+Source-compile can cascade into policy-compile; policy-compile never causes
+source-compile; policy-compile fires many times between source edits. Two
+operations with different invocation counts over the same window are not one
+operation. The mental model: source-compile is the **compiler** (source →
+bytecode; changes only when source changes); policy-compile is the
+**profile-guided / JIT optimizer** (re-optimizes from the observed runtime
+profile when the workload drifts). Mapped exactly: IR = bytecode, the receipt
+log = the runtime profile, the policy registry = JIT-optimized code, the
+falsification predicate = the deopt guard. Same toolchain, different stages,
+both essential. The unification is at the doctrine layer (the thesis above),
+deliberately; the operations stay two — as `map` and `filter` share a pattern
+but are never collapsed into one function.
+
+**Safety line.** *Both* compiles emit a **static artifact consumed and
+validated by deterministic code** — the language is never on the execution or
+safety path. A model authors; code validates the artifact; the kernel executes
+it; the fixed backstop catches a bad artifact regardless of how it was
+authored. This is the same safe pattern the existing source compiler already
+uses (model-run, CLI-validated), applied a second time.
+
+**The policy author is an agent, and its representation is sequenced.** Policy
+authoring is inherently agentic: it must explore the receipt history
+dynamically, not consume a one-shot stuffed context. That agent-ness is
+non-negotiable from day one. Its *launch representation*, however, lives behind
+the static-artifact boundary and is deliberately sequenced so the
+safety-critical bootstrap does not depend on an unproven self-referential
+layer:
+
+1. **v0.1** — agentic author launched via the proven agent-session adapter;
+   dynamic receipt-history exploration; cold start is a contract-only prior
+   (the static seed). Code owns trigger evaluation, artifact validation,
+   backstop, and rollback; the agent owns exploration and authorship.
+2. **v0.2** — the same agent, now recurring: the kernel's falsification
+   predicate triggers recompile; rollback-to-last-known-good and calibration
+   scoring are active. Still adapter-launched.
+3. **v0.3+** — once the Prose VM is proven, migrate the launch representation
+   to a first-class OpenProse `kind: responsibility` ("the control policy for
+   X stays current and well-calibrated") fulfilled by an agentic
+   `kind: system`. Artifact format, kernel, and backstop are unchanged, so the
+   migration is no-throwaway — the recursion closing on itself, and the end
+   state that most proves the thesis.
+
+Invariants across all three steps: the author is a real exploratory agent from
+day one; it emits a static artifact validated by code; the language is never
+on the execution or safety path; the representation lives behind the artifact
+boundary — the same agent-SDK-adapter seam ratified in *Architecture* below.
+
+### Quiescence
+
+The headline behavior, and the clearest proof of the thesis:
+
+> A normal agent loop's cost scales with wall-clock time. A Reactor's cost
+> scales with surprise — plus a forecast-amortized plan-audit floor
+> calibration drives toward, but never to, zero (see *The plan-completeness
+> audit*).
+
+Quiescence is not the absence of behavior; it is three explicit behaviors,
+ordered by how much they save:
+
+1. **Don't act.** Status is `up`; no fulfillment. The trivial case.
+2. **Don't check now.** Forecast says drift probability stays low until time
+   _T_; the next judge is scheduled at _T_ and the runtime sleeps. Zero tokens
+   between, except the forecast-paced plan-audit floor (see *The
+   plan-completeness audit*): provable quiescence is zero tokens *between
+   forecast-paced plan audits*, not zero tokens on a static world.
+   (= don't re-render until a dependency changes.)
+3. **Don't check deeply.** When a check is due, run the cheapest sufficient
+   judge; escalate depth only on uncertainty or stakes. (= don't re-render the
+   whole tree, only the subtree that changed.)
+
+The rigorous core is **memoization**: a verdict is keyed by the hash of its
+inputs (contract revision + evidence receipts + dependency receipts). Unchanged
+hash → the verdict is reused at zero token cost — `React.memo` semantics applied
+to judgment.
+
+**The completeness law.** A hash is only safe if it captures every input that
+could change the verdict — the classic cache-invalidation trap, whose failure
+is silent (confident staleness). The law that makes the hash complete _by
+construction_: **shallow judging executes a compiled, stable evidence plan** —
+the set of sources to consult is a function of the contract revision, authored
+by the model at policy-compile time, not improvised per cycle. Only **deep**
+(escalated) judging may roam; roaming that discovers a new dependency forces a
+policy recompile that adds it to the plan. The memo key is therefore complete
+relative to the current compiled plan, and plan-incompleteness is surfaced
+through the deep-escalation-and-recompile path, never silently ignored. This
+also protects the cost thesis: a judge that re-roamed every cycle would keep
+the memo key unstable on a static world, collapse the hit rate, and kill "cost
+scales with surprise" while every correctness test still passed.
+
+**The plan-completeness audit.** The completeness argument above has a known
+gap: deep roaming is the only path that discovers a missing dependency, yet
+deep is gated on shallow confidence, and a memo key built from an _incomplete_
+plan is stable-by-omission — it manufactures confidence and suppresses the
+escalation that would expose its own incompleteness. Confident staleness is
+otherwise merely relocated from the verdict to the plan. The law therefore
+requires a **second forecast clock, paced on plan age rather than evidence
+age**, that injects a synthetic input forcing a **deep, roaming revalidation
+whose trigger is independent of the shallow judge's confidence**. This is the
+same synthetic-input mechanism that makes silence safe against the
+missing-webhook problem, retargeted from "the world changed without an event"
+to "the plan may be incomplete without an escalation." When the plan-age clock
+crosses threshold the runtime escalates regardless of shallow confidence; the
+roam either confirms the plan complete (resetting the clock, recording a
+receipt whose `surprise_cause` is `forecast-recheck` with `recheck_kind:
+plan-age`) or discovers a dependency and forces a policy recompile.
+The clock is itself a model-authored, calibration-scored policy parameter (a
+falsification-predicate input under _The two compiles_), not a fixed
+heartbeat: domains with cheap stable identities and low semantic drift earn
+long audit intervals; semantic-drift domains are paced tighter.
+
+The safety watch-out: memoizing on a stale input hash means the system could
+quiesce confidently while the world changed silently because no event fired
+(the missing-webhook problem). The defense is forecast: time since the last
+true check raises drift probability even with zero events, and crossing the
+forecast threshold injects a **synthetic input change** that breaks the memo.
+Forecast's real job is to manufacture the minimum necessary re-render when the
+world will not announce that it changed. That is what makes silence _safe_
+rather than _negligent_.
+
+### Core invariants
+
+These are the constitution. Each survives the negation test: negate it and the
+result is no longer a Reactor-class harness. Items that fail that test (a
+negation that still yields a Reactor-class harness, only a worse-designed one)
+are design defaults and live in **Architecture**, not here.
+
+1. **Markdown is intent.** The source contract is the durable semantic object.
+   Negate it and intent lives in a hidden surface — Tenet 1 broken.
+2. **Policy is model-authored, compiled, and shared.** Reactor decisions are
+   produced by one compiled policy artifact, identical on every host. Negate it
+   and two hosts interpret policy independently — forked semantics.
+3. **Adapters are the only reason hosts differ.** A clone and a long-lived
+   deployment diverge only because storage, sandbox, signer, or connector
+   adapters differ. Negate it and the loop has forked — Tenet 1 broken.
+4. **Activations are bounded.** No continuity depends on one long-running model
+   session. Negate it and it is an agent loop, not a Reactor.
+5. **Cost scales with surprise.** A normal agent loop's cost scales with
+   wall-clock time; a Reactor's cost scales with surprise plus a
+   forecast-amortized plan-audit floor. Stated as a
+   falsifiable challenge: **for every token, name the surprise.** Negate it and
+   the differentiator is gone. Four backing commitments make this testable:
+   - **No fixed-interval work.** The Reactor core spends zero tokens between
+     scheduled checks. Forecast _replaces_ polling — polling is "I don't know
+     when"; forecast is "I computed when." Where a source cannot push, polling
+     is pushed to a gateway adapter and is itself forecast-paced, never a
+     heartbeat.
+   - **Memoization is real.** Unchanged input hash → reused verdict, provably
+     zero judge tokens, recoverable from the fresh-vs-reused token ratio in the
+     receipt.
+   - **Depth is variable and confidence-gated.** Cheapest sufficient judge by
+     default; ensemble only on uncertainty or stakes.
+   - **Every token traces to a surprise-cause** ∈ {real input change,
+     forecast-manufactured recheck, escalation}. The plan-completeness audit
+     is a forecast-manufactured recheck paced on plan age, not a fourth
+     cause; its tokens are the forecast-amortized plan-audit floor, not a
+     counterexample to the claim.
+6. **The judge fails safe.** Given the judge's calibrated confidence,
+   uncertainty escalates rather than acts; conflicting evidence lowers
+   confidence rather than averaging it away. "Calibrated confidence" means
+   confidence whose calibration is measured, not assumed; an unvalidated or
+   degraded confidence signal forces escalate-by-default, never quiesce (see
+   _Failure model_, degraded-calibration mode). An uncalibrated confidence
+   signal (no authored or accrued anchor) forces escalate-by-default
+   *indefinitely*; calibration may be *earned* via accrued exogenous labels
+   and is a property a responsibility can reach over time, not only a
+   precondition — the gate is satisfiable in principle by every
+   responsibility, never unsatisfiable-by-default. Negate it and a confidently
+   wrong judge produces confidently wrong action — the class's safety claim is
+   void.
+7. **Receipts are content-addressed.** Consumers verify evidence instead of
+   trusting the producer's claim. The receipt is simultaneously the audit unit, the
+   composition unit, and the exit unit. Negate it and Tenets 5 and 6 break at
+   once.
+8. **State is replayable and exitable.** Given the same contract, event,
+   durable state, and adapter outputs, the Reactor decision is reproducible —
+   and the contract with its trail can leave for another harness. This is not
+   "reproducible for us"; it is "exitable by you" (Tenet 6). Negate it
+   and there is no fork-as-exit and no audit.
+
+Demoted to design default (Architecture, not constitution): coarse status,
+pressure-as-projection, tiered projection. Each is a strong default that can
+change without breaking the class. Tiered projection is retained as a hard
+privacy requirement in **Failure model**, not as a class-defining invariant.
+
+### Precedence stack
+
+When invariants tension, this ordering decides:
+
+```text
+correctness  >  safety  >  cost  >  interrupt-minimization
+```
+
+Interrupt-minimization is a downstream ergonomic property, not a pillar. If
+minimizing interrupts ever conflicts with failing safe, safety wins — the
+system interrupts even though it would rather be silent. "Rare interruption" is
+a target, not a constraint other invariants bend around.
+
+### Architecture
+
+Each layer earns its place as the answer to "what does a beat require?"
+
+| Layer              | Role                                                                                                                                                 | Serves beat                  |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Responsibility     | The standing goal: what must remain true                                                                                                             | author                       |
+| Contract Markdown  | The durable human- and agent-readable source                                                                                                         | author                       |
+| Gateway            | Concrete event ingress: schedules, webhooks, queues, files, manual requests; forecast-paced polling only where a source cannot push                  | walk away                    |
+| Compiler           | Lowers semantic Markdown into deterministic IR                                                                                                       | author                       |
+| Policy compile     | Model authors control policy; compiled to a token-free registry; recompiled when the policy itself drifts                                            | walk away                    |
+| Storage            | Holds responsibilities, revisions, observations, runs, decisions, forecasts, receipts, projections                                                   | exitable trail               |
+| Judge              | Bounded sensing activation; variable depth; emits status **and a calibrated confidence** (ensemble disagreement is the uncertainty signal)           | interrupted only when needed |
+| Reactor            | Typed policy execution deciding the next reconciliation action; fails safe under uncertainty                                                         | interrupted only when needed |
+| Forecast           | Load-bearing: manufactures the minimum necessary re-render when the world will not announce change; injects the staleness clock as a synthetic input | walk away                    |
+| Fulfillment        | Bounded actuation; the only place world-mutation is allowed                                                                                          | walk away                    |
+| Cost / token-truth | Local, deterministic, free token receipts; fresh-vs-reused recoverable                                                                               | verifiable trail             |
+| Truth oracles      | One pluggable socket, two distinct concepts (see Failure model)                                                                                      | verifiable trail             |
+| Projection         | Owner, subscriber, public, and local views                                                                                                           | exitable trail               |
+| Receipt            | Content-addressed proof; carries `as_of`, `next_forecast_recheck`, and a judge-authored blocked reason + recommended fix target                       | verifiable / exitable trail  |
+| Composition        | The dependency graph is the evidence graph                                                                                                           | author / verifiable trail    |
+| Adapters           | Filesystem, Postgres, sandbox, connector, signer, event sinks                                                                                        | walk away                    |
+
+The most important boundary is between semantic intelligence and harness
+machinery:
+
+```text
+Markdown source defines intent.
+Skill and interpreter docs define semantics.
+The model authors policy; the compiler lowers it into IR.
+The harness serves IR and runs the compiled policy.
+Runs interpret and act inside bounded activations.
+The Reactor reconciles. Receipts attest.
+```
+
+**Two adapter seams, never merged.** The bounded-activation **agent SDK**
+(`codex-sdk`, `claude-sdk`, …) is an adapter and nothing more: no Reactor
+control logic ever lives inside it — the kernel, memoization, forecast, and
+policy execution are the package's, not the activation runtime's. Distinct
+from it is the **model-gateway socket** (OpenRouter as the batteries-included
+default; direct Anthropic/OpenAI first-class), which serves raw multi-provider
+inference. It is the *inference substrate* the agentic activations draw on —
+the judge ensemble's multi-provider votes and calibration, and the inference
+consumed by the agentic policy author (which is itself launched via the
+agent-SDK seam and explores receipt history dynamically, never a one-shot
+call — see *The two compiles*). Keeping
+the two seams separate is what makes the policy-author migration in *The two
+compiles* free: the launch representation can move from an adapter call to an
+OpenProse responsibility without touching the artifact, the kernel, or the
+backstop. This is invariant 3 doing load-bearing work, not a convenience.
+
+Design defaults that are not constitutional: status is coarse (`up`,
+`drifting`, `down`, `blocked` route maintenance); pressure is a projection that
+wakes work, not a second policy engine; projection is tiered.
+
+The `blocked` status carries a judge-authored, natural-language reason **and a
+recommended fix target**. "The sentence itself is undecidable — criterion X has
+no observable referent" is an expected, high-value verdict, routed to the
+contract author (Tenet 2). It is _not_ a new deterministic status; the four
+coarse statuses stay minimal, and the differentiation lives in the judge's
+diagnosis, not an enum. This is the flagship instance of "interrupt only when a
+human is genuinely needed," not error handling.
+
+**Interrupt taxonomy.** An interrupt is a typed Reactor decision with its own
+receipt, never a generic action — there are no "just FYI" pings. Its cause is
+one of exactly three: `needs-judgment` (a call only a human can make,
+including the undecidable-contract case above and the
+`calibration-unattainable` case from the failure model), `needs-input` (a credential,
+permission, or disambiguation only the human can grant), or `contract-declared`
+(escalation the author wrote into the contract, e.g. "page me if this goes
+down"). The model **never invents an interrupt**: it self-initiates only for
+the first two; `contract-declared` paging is user-authorized, not model-chosen.
+The lived-experience promise's "exactly two conditions" refers to
+self-initiated interrupts; contract-declared paging is the user's own rule
+firing. Per the precedence stack, interrupt-minimization yields to safety.
+
+### Failure model
+
+The architecture must be safe when its own intelligence is unreliable. Two
+independent layers:
+
+- **Judge-quality layer.** Epistemically sound LLM-as-judge: the judge knows
+  its observations are partial; inter-model consensus across model classes and
+  sizes (critic, dialectic, K-consensus, fan-out) raises quality. Its real
+  output is not just a verdict but a confidence signal. **Ensemble spread is
+  the confidence estimator only in the regime where it is measured to be
+  calibrated.** Calibration is not assumed; it is continuously measured against
+  the bring-your-own-correctness-truth anchor and recorded as a receipt. While
+  the measured spread→error relationship meets the calibration bar, no separate
+  estimator is needed. When the bar is not met — including the no-anchor
+  cold-start case — the judge enters **degraded-calibration mode** (defined
+  below) and may not use low spread as a license to skip escalation:
+  correlated models sharing training lineage can be confidently jointly wrong,
+  so low spread is treated as evidence of confidence only after it has been
+  shown to track error on this responsibility's anchor.
+  **Ensemble diversity is a correctness requirement, not a tuning option.**
+  Temperature/sampling diversity does not decorrelate shared training-data and
+  RLHF blind spots and does not count toward the diversity floor: an ensemble
+  qualifies as diverse only if it spans ≥2 model families from ≥2 providers and
+  crosses a size boundary; the calibration receipt records the realized
+  family/provider/size mix, and a single-family ensemble is automatically
+  degraded-calibration regardless of measured spread. Judge ensembling is a
+  model-gateway-socket concern, never an agent-SDK concern — it cannot be
+  satisfied by the same model run through two agent adapters.
+- **Degraded-calibration mode.** When measured calibration is below bar,
+  calibration evidence is stale, or the diversity floor is unmet, the
+  variable-depth judge degrades safely and the precedence stack governs:
+  (1) **escalate-by-default** — low spread no longer authorizes the cheap path;
+  default depth becomes the escalated ensemble, inverting quiescence behavior 3
+  for that responsibility; (2) **weight the anchor** — where a correctness
+  anchor exists its label overrides low-spread agreement for the affected
+  verdict class, and anchor↔ensemble disagreement is itself a `blocked`
+  interrupt routed to the author; (3) **widen the ensemble** — add an
+  out-of-family provider via the model-gateway socket before trusting
+  agreement; (4) if none of (1)–(3) is available, the responsibility runs in
+  **bounded degraded-calibration mode**: escalate-by-default is the steady
+  state and confidence is reported *uncalibrated* in every receipt — never a
+  silent confident `up`. This mode is **not terminal-by-construction**: it is
+  exited when accrued anchor labels (see *Truth oracles*) meet the calibration
+  bar. (4b) It becomes a terminal `blocked` — reason `calibration-unattainable`,
+  a `needs-judgment` interrupt routed to the author — only when
+  escalate-by-default itself cannot run (no diverse ensemble obtainable): the
+  system can neither self-assess nor safely escalate. The cost regression from
+  escalate-by-default is the _correct_ outcome under correctness > safety >
+  cost.
+- **Reactor-safety layer.** Independent of judge quality: given that
+  confidence, the control policy fails safe (invariant 6). The asymmetry
+  between a wrong fulfillment and a wrong inaction is made explicit per
+  responsibility — some fail loud, some fail quiet.
+
+The judge is **not a fixed circuit, it is a variable-depth circuit**: cheap
+single judge by default, escalate to ensemble only when uncertain or when
+stakes or forecast warrant. This is simultaneously the failure-model answer and
+the cost answer.
+
+**Truth oracles — one socket, two distinct concepts.** A single pluggable
+socket pattern (an external oracle the OSS _calls_ but never _owns_; null-safe
+degradation; results flow back as receipt-attached projections) serves two
+semantically orthogonal concepts that are **never merged in prose or types**:
+
+- **Bring-your-own-correctness-truth.** Answers "was the verdict right?" Not
+  merely a fallback — when present it is a **calibration anchor**: periodically
+  score the ensemble against it to measure and correct ensemble bias over time;
+  the scoring is itself a receipt. The anchor may be *authored* (the BYO
+  oracle) or *accrued*. Accrued labels come from two exogenous sources: human
+  confirm/refute responses to a `needs-judgment` calibration spot-check, and
+  independently observed fulfillment outcomes. Ensemble-internal agreement —
+  including deeper re-judgment — is **not** an anchor source: it measures
+  coherence, not correctness, and is explicitly excluded. Accrued labels feed
+  the same calibration scorer and receipt as an authored anchor; calibration
+  grade is recorded (`authored` | `accrued` | `none`).
+- **Bring-your-own-cost-truth.** Answers "what did it cost?" Token-truth is
+  recorded locally and deterministically; dollarization is a projection applied
+  by a pluggable price oracle. The OSS package is fully functional with no
+  price oracle ("not configured" is a clean, non-deceptive null state, same
+  honesty bar as the null-signer). Dollarization is a pluggable price-oracle
+  projection, never a receipt field; a managed aggregation service is out of
+  scope of this specification.
+
+Bad correctness-truth corrupts judgments; bad cost-truth corrupts economics but
+not correctness. Same plumbing, different shapes, different consumers, different
+failure meanings.
+
+**Cost is a first-class Reactor input, not a dashboard.** Token-truth receipts
+feed the forecasted marginal value of the next check; the Reactor trades judge
+depth against budget on that basis. Cost is read by the variable-depth judge
+when deciding whether to escalate, and by the meta-loop when deciding whether a
+recompile is worth its tokens. It is an input to control, not an after-the-fact
+report.
+
+**Privacy is a failure mode.** Secrets, emails, private URLs, and customer
+payloads must not leak from judge rationale into subscriber or public
+projections. Tiered projection is the safeguard: owner and local views may be
+rich; subscriber and public views are explicit, narrowed contracts, not ad hoc
+response filtering. A privacy leak is treated as a safety failure, not a
+cosmetic one — this is the hard requirement referenced from **Core invariants**
+where tiered projection was demoted from the constitution.
+
+### Metaphor
+
+Lead with React, and not for palatability — after the unification thesis it is
+the _rigorous_ model, with literal mappings:
+
+| React                          | Reactor                                                             |
+| ------------------------------ | ------------------------------------------------------------------- |
+| render                         | the compile / policy-derivation step                                |
+| committed output               | the deterministic schedule + threshold registry                     |
+| re-render                      | recompile, triggered by a dependency change, not a clock            |
+| partial reconciliation         | quiescence; only changed subtrees re-judge                          |
+| memoization / dependency array | input-hash verdict reuse                                            |
+| render vs. effect              | judge (pure: world → status) vs. fulfill (commit-phase side effect) |
+| composition / lifting state up | responsibilities consuming each other's receipts                    |
+
+Kubernetes' controller is a _weaker_ version of the same idea —
+reconcile-to-desired-state with no render/commit split, no memoization, no
+composition. It is a subset; a one-line footnote acknowledges the lineage.
+
+The metaphor is **explicitly bounded**. React renders are synchronous, cheap,
+and the tree does not mutate mid-render; Reactor "renders" are expensive,
+asynchronous, and the world mutates underneath them. So React owns the
+**structural** dimension; **control-systems** language (forecast, hysteresis)
+owns the **time/cost** dimension. Two metaphors, each owning exactly one
+dimension. Three seams are where they meet, stated as resolution rules:
+
+1. **Memoization vs. forecast.** On a quiet input, React says "skip"; control
+   systems says "drift probability rose, re-check." Resolution: forecast
+   injects the staleness clock as a **synthetic input** into the memo key, so
+   "no real change but forecast says recheck" becomes a hash change. Control
+   systems _feeds_ React; it does not override it. This is what makes silence
+   _safe_ rather than _negligent_.
+2. **Pure render vs. side-effecting world.** Judge stays pure (world → status);
+   all world-mutation is quarantined in fulfillment (the commit phase), or the
+   render-purity claim breaks.
+3. **Synchronous tree vs. asynchronous world.** A verdict is always `as_of` a
+   timestamp, never "now." Every receipt carries `as_of`; that is where
+   control-systems time-awareness patches React's frozen-tree assumption.
+
+### Composition
+
+It needs **no new primitive**. "B depends on A" = B's judge consumes A's latest
+receipt as evidence, identical to a webhook. Three consequences make it native,
+not a bolt-on:
+
+- **Propagation reuses memoization exactly.** A's new receipt is an input-hash
+  change for B → B re-judges; if B is unchanged, propagation stops. The
+  dependency graph reconciles by the same memoized partial-render mechanism as
+  a single responsibility, recursively.
+- **Cost amortizes for free.** A is judged once; N dependents reuse A's
+  receipt. Dependency-graph amortization falls out of the architecture.
+- **Fork/exit composes.** The edge is "consume receipt at content-address /
+  responsibility-ref" — a reference, not a hidden binding. Public
+  responsibilities become composable public goods (Tenets 5, 6 land on
+  one object).
+
+Three genuine collisions, with their resolutions:
+
+1. **Cycles** (A→B→A). Detection is a graph property: deterministic and cheap;
+   it belongs in the small fixed kernel.
+2. **Cross-boundary trust.** B must verify A's receipt signature _and_ contract
+   revision. A public A's owner can silently change semantics, so the
+   dependency edge must **pin a contract revision and an acceptable signer
+   set**, or composition becomes a supply-chain attack. This is where Tenet 5's
+   "verify, don't trust" does real load-bearing work.
+3. **Transitive staleness.** A quiesced A may hand B a stale-but-true-looking
+   receipt. Each receipt's `freshness` block carries `as_of` and
+   `next_forecast_recheck`. The rule by which B combines its own `as_of` with
+   each consumed receipt's `freshness` to decide whether its inputs are fresh
+   enough is **not at the judge's discretion and not a fixed kernel
+   constant**: it is a **model-authored policy parameter recorded in the
+   policy registry** — the *transitive-freshness function* — alongside
+   cadence, hysteresis, and the plan-audit clock as a falsification-predicate
+   input under *The two compiles*. The kernel is its dumb evaluator. The
+   conservative default the model authors against, and the backstop the
+   kernel enforces regardless of the authored function, is: *B's inputs are
+   stale, and B must refetch or block, if any consumed receipt's
+   `next_forecast_recheck` is at or before B's evaluation `as_of`.* The model
+   may author a *looser* bound only where the contract's freshness criterion
+   justifies it and the falsification predicate scores that looseness against
+   observed downstream drift; never looser than the kernel backstop. For a
+   chain A→B→C this composes by construction: each hop applies its own
+   recorded function to its own consumed receipts, every one replayable
+   against a pinned policy revision. Freshness is therefore transitive **and
+   explicit in the schema and the policy registry** — never a discretionary
+   per-cycle judgment (invariant 8, Tenet 6).
+
+### Open specification items
+
+Deferred by design — named here so they are tracked, not invented or silently
+dropped:
+
+1. **Receipt schema — v0 pinned; provider-normalization sub-object deferred.**
+   The receipt schema is **pinned at v0** (`openprose.receipt`, `v: 0`): a
+   content-addressed `core` (responsibility id, pinned contract revision, event
+   cause ∈ {real-input, forecast-recheck, escalation} (a `forecast-recheck`
+   additionally carries `recheck_kind ∈ {evidence-age, plan-age}` so the
+   plan-audit floor is sliceable from ordinary forecast rechecks without a
+   fourth top-level cause), memo key, evidence input
+   ids, `as_of`, role ∈ {judge, fulfill, summarize, policy-compile}) hashed
+   under a named algorithm; a `sig` block where `scheme: "none"` with a
+   `null_reason` is a first-class, non-deceptive state alongside an optional
+   signer adapter; a `verdict` carrying one of the four coarse statuses, calibrated
+   confidence with its derivation method plus calibration grade
+   (`authored` | `accrued` | `none`) and label source, and a judge-authored
+   `blocked` reason + fix target + interrupt cause; a `freshness` block
+   carrying `as_of`, `next_forecast_recheck`, and — on a receipt produced by a
+   B that consumed upstream receipts — `transitive_freshness_policy_ref` (the
+   policy revision whose transitive-freshness function was applied) and
+   `consumed_freshness_evaluated` (per consumed receipt, its
+   `next_forecast_recheck` and the kernel's staleness outcome ∈ {`fresh`,
+   `stale-refetched`, `stale-blocked`}); a `composition` block whose `consumed_receipts`
+   each pin upstream content-hash, contract revision, and acceptable signer
+   set, plus a kernel-set cycle-checked flag; and a `cost` block where
+   token-truth is sliceable along provider, model, role, tags, responsibility,
+   run, and time, with `tokens.fresh` vs `tokens.reused` and a `surprise_cause`
+   making the cost-scales-with-surprise and memoization proofs recoverable from
+   a single receipt. Tags are not optional metadata; they are what lets cost be
+   sliced after the fact. **The only deferred element is the contained
+   `cost.provider_norm` sub-object** — cache-write vs cache-read price, TTL, and
+   minimum-cacheable thresholds normalized across Anthropic/OpenAI/Gemini/Grok
+   — which awaits the unrun provider/model matrix and carries its own
+   independent `schema` version so provider research changes that sub-object
+   alone, never the receipt shape. Dollarization remains a pluggable
+   price-oracle projection, never a receipt field; a managed aggregation
+   service is out of scope of this specification. This deferral is
+   non-blocking: the v0.1/v0.2 policy-author milestones and the composition,
+   supply-chain, and exit/export claims depend only on pinned fields.
+2. **The deterministic kernel.** Specified in principle (see _The unification
+   thesis_ and _Quiescence_): a dumb evaluator of the policy's
+   model-authored falsification predicate, plus a tiny fixed backstop (max
+   policy age, min recompile interval, max calibration divergence, warmup
+   length, rollback comparison) and cycle detection. The backstop constants are
+   pinned conservative-by-default and tuned empirically: **max policy age** — a
+   hard ceiling forcing recompile/revalidation regardless of predicate state
+   (seed: 30 days); **min recompile interval** — anti-thrash floor and
+   meta-loop hysteresis (seed: 1 hour); **max calibration divergence** —
+   observed drift exceeding the policy's predicted curve by ≥2×, or escalation
+   precision falling materially below the policy's claimed threshold, forces
+   recompile; **max calibration-evidence age** — if the correctness anchor has
+   not scored the ensemble within this age, calibration is presumed stale and
+   degraded-calibration mode engages (see _Failure model_). **Rollback-
+   comparison definition:** _last-known-good_ is the most recent policy that
+   completed its full warmup without tripping its own falsification predicate;
+   a fresh policy `P_n` auto-reverts to `P_{n-1}` if `P_n` trips its own
+   predicate in **fewer judged activations** (event-volume-normalized, not
+   wall-clock) than `P_{n-1}` took to first trip its own. All constants are
+   policy-registry-recorded and replayable; tightening them is a backstop
+   change, not a policy recompile. **No-anchor soundness additions:** (B1) for
+   a responsibility with no correctness anchor, `max policy age` is replaced by
+   `max policy age (no-anchor)` — seed 7 days — because the anchor-derived arms
+   (calibration divergence, calibration-evidence age, rollback) are inert in
+   that regime. (B2) Independent of the policy's falsification predicate and of
+   any model-authored clock, the kernel forces a deep, roaming revalidation at
+   a fixed cadence (`max-unforced-deep-interval`, seed 7 days,
+   event-volume-normalized); if its verdict materially contradicts the
+   shallow-policy history the kernel records a `backstop-divergence` receipt
+   and forces recompile — supplying the observed-vs-predicted term an
+   anchorless calibration check otherwise lacks. (B3) A policy artifact is
+   rejected at validation if its falsification predicate references no live
+   observable (no anchor, no calibration-divergence input, nor — for a
+   no-anchor responsibility — the B2 contradiction signal): a predicate
+   falsifiable against nothing is malformed, not valid. B2+B3 ship together;
+   B1 is the interim fallback. These are fixed kernel constants the model may
+   not lengthen.
+3. **Calibration cadence.** How often the ensemble is scored against
+   bring-your-own-correctness-truth is unspecified.
+4. **Meta-loop hysteresis.** "Do not recompile policy too eagerly" is a
+   principle, not yet a parameter.
+5. **Policy-registry artifact format.** The token-free deterministic registry
+   the kernel executes is owned by `@openprose/reactor` (not IR, not
+   `*.prose.md` syntax — see [01-Language.md](./01-Language.md) Part III §3). Its
+   lifecycle, trigger, input, and correctness test are specified in _The two
+   compiles_; its **on-disk format/schema is deferred**. Like the receipt
+   schema (item 1) it is expected to be largely deducible — a versioned static
+   artifact, validated by deterministic code, replayable, receipted, carrying
+   the model-authored falsification predicate and the policy parameters
+   (cadence, hysteresis band shapes, escalation thresholds, the plan-audit
+   clock from _The completeness law_). It must meet the same "static artifact
+   consumed and validated by deterministic code" safety bar as the receipt.
+   Penciling a v0 here is a tracked follow-up and is not believed to be a
+   blocker.
+6. **Accrued-anchor calibration bar.** How many exogenous labels (human
+   spot-check confirmations or observed fulfillment outcomes), over what
+   window, at what agreement, lifts a no-anchor responsibility out of
+   bounded degraded-calibration mode, and the spot-check sampling cadence,
+   is unspecified. Distinct from item 3 (which governs *authored*-anchor
+   scoring cadence and presumes an anchor exists); cross-reference both ways.
+
+### Where it excels
+
+The reusable judgment is in the properties, not a list of domains. Reactor-class
+harnesses are strongest when:
+
+- the goal is a **state to maintain**, not a one-shot deliverable;
+- events arrive over time from multiple sources;
+- the world state is partly ambiguous and requires judgment;
+- the system must avoid duplicate or thrashing actions;
+- the value of acting depends on freshness, confidence, risk, or cost;
+- the user needs an audit trail for why an action happened;
+- the implementation may change while the declared intent stays stable;
+- multiple models may perform differently across judging, fulfillment, and
+  summarization.
+
+Weak fits: one-off report writing; pure batch transforms; low-stakes throwaway
+prompts; deterministic jobs that need no judgment; workflows where every step
+is already known and stable; tasks where public receipts or durable state add
+more friction than value. OpenProse can still run one-shot services; they are
+just not the canonical case.
+
+Three costs are now structurally irreducible and must be stated honestly. **A
+plan-revalidation tax:** provable quiescence is "zero tokens _between
+forecast-paced plan audits_," not "zero tokens on a static world." The honest
+claim is _cost scales with surprise plus a forecast-amortized plan-audit
+floor_ — the floor pushed arbitrarily low (never to zero) by calibration, as
+a plan that has survived N audits unchanged earns a longer interval. **A
+no-cheap-hash domain boundary:** where deciding "did the semantically relevant
+content change" essentially _is_ the judgment (research novelty, regulatory
+drift, competitive framing), no cheap-and-complete identity exists; the system
+stays correct and safe (forecast still manufactures the recheck) but loses the
+cost differentiator and degrades gracefully to forecast-cadence cost. Reactor
+excels where a cheap stable identity exists; semantic-only-drift domains are a
+documented boundary, not a hidden failure. **A no-anchor calibration tax:** a
+responsibility with no authored correctness anchor runs permanently
+escalate-by-default until it accrues enough exogenous labels (human spot-check
+or observed fulfillment outcome) to earn calibration. Like the no-cheap-hash
+boundary this is a stated, deliberate correctness > cost trade, not a hidden
+failure; some responsibilities (projection-only, slow-feedback, spot-check
+declined) never accrue labels and remain in this mode by design.
+
+One worked example, kept here because it demonstrates the thesis better than
+any other — the world mutates with every message, so cost must scale with
+surprise, not time:
+
+#### Incident Briefing Room
+
+```text
+Goal: The incident channel has an accurate current briefing.
+Continuity: Recheck on incident messages, status-page changes, and every 15 minutes while active.
+Criteria: impact, timeline, owner, next action, and customer-facing status are current.
+Fulfillment: summarize new facts, ask for missing owner input, update the briefing.
+```
+
+The modeled world changes with every message. The desired output is not "answer
+once"; it is "keep the briefing true" while spending tokens only on what
+actually changed. Additional worked examples are catalogued in Part II.
+
+---
+
+## II. Current — What the Code Implements Today
+
+This section is a **code audit**, not a status memo. It describes the
+`openprose/prose` repository (`main`, HEAD `52724ed`, tag
+`reactor-v0.1.0`) as it stands: the
+`@openprose/reactor` package, the `@openprose/reactor-cradle` evaluation
+harness, and the `@openprose/prose-cli` Reactor path. Every claim names a
+module, type, or test count and is re-derivable from the tree. Where the code
+does not yet reach the Ideal, the Conformance Ledger says so.
+
+> **One package, not the package the older spec named.** Earlier revisions of
+> this document described a shared `@openprose/responsibility` package and a
+> `platform/`-rooted layout. **Neither exists in the public repository.** The
+> runtime wave deleted `@openprose/responsibility`; the typed Reactor authority
+> is now `@openprose/reactor`, a greenfield package built directly against
+> Part I. The CLI depends on it as `"@openprose/reactor": "workspace:*"`. All
+> module paths below are real and rooted at the repository, not at a private
+> `platform/` tree.
+
+### Repository surface
+
+| Surface | What exists today |
+| --- | --- |
+| Reactor package | `packages/reactor/` — `@openprose/reactor`, version `0.1.0`, MIT, zero runtime dependencies, published to npm with provenance. Thirteen subpath exports: `receipt`, `cost`, `kernel`, `evidence-plan`, `memo`, `forecast`, `sdk`, `reactor`, `judge`, `adapters`, `policy`, `composition`, `projection`. |
+| Cradle package | `packages/reactor-cradle/` — `@openprose/reactor-cradle`, the evaluation/eval-double harness: synthetic worlds, baselines, scenario runner, provider-parity, live-spike recorders. Depends on `@openprose/reactor`. |
+| CLI | `tools/cli/` — `@openprose/prose-cli`. Commands: `prose compile`, `prose serve`, `prose status`, plus `prose doctor`. The serve path imports `@openprose/reactor` directly. |
+| Other workspace packages | `packages/std`, `packages/co` (Language-side, out of scope for this document). |
+| State layout | The CLI writes package-owned Reactor state under the OpenProse root (`state/reactor/`), plus per-responsibility projections under `state/responsibilities/{id}/`. The repository ships no Postgres adapter. |
+| Agent hosts | The CLI carries `claude-sdk`, `codex-sdk`, and `mock` harnesses (`tools/cli/src/harnesses/`). |
+
+Test counts, run against HEAD `52724ed` via each package's documented
+`pnpm … test` (typecheck + `node --test` over built `dist`, or `vitest` for
+the CLI):
+
+- **`@openprose/reactor`** — **155 tests, all passing.** 19 spec source
+  modules under `packages/reactor/src/*/__tests__/`.
+- **`@openprose/reactor-cradle`** — **121 tests, all passing.** 32 test files,
+  including 10 `*.integration.test.ts` scenarios (B1–B7, C2, C5, E1, E2, W7).
+- **`@openprose/prose-cli`** — **284 tests across 26 files, all passing.**
+
+This is unit-, contract-, and integration-verified substrate. It is **not yet
+an empirical proof of the category thesis**: the cost-scales-with-surprise
+numbers below are produced by deterministic replay against synthetic worlds and
+recorded cassettes, not by live multi-provider judging at scale.
+
+### Receipt v0 — `packages/reactor/src/receipt/`
+
+The receipt schema of *Open specification item I.1* is **implemented and
+pinned**. `RECEIPT_SCHEMA = "openprose.receipt"`, `RECEIPT_VERSION = 0`,
+`RECEIPT_HASH_ALGORITHM = "sha256"`. `ReceiptV0` carries the six blocks the
+Ideal specifies — `core`, `sig`, `verdict`, `freshness`, `composition`,
+`cost` — plus `content_hash`.
+
+- **Content addressing is real.** `computeReceiptContentHashV0` canonicalizes
+  the payload (sorted keys, `undefined` rejected, non-finite numbers rejected)
+  and SHA-256-hashes it; `createReceiptV0` self-verifies on construction and
+  throws on any malformed input. `verifyReceiptV0` recomputes the hash and
+  rejects a mismatch, unpinned keys, or a wrong shape.
+- **`core`** carries `event_cause ∈ {real-input, forecast-recheck,
+  escalation}`; a `forecast-recheck` is required to carry
+  `recheck_kind ∈ {evidence-age, plan-age}` and any other cause is forbidden
+  from carrying it — the plan-audit floor is sliceable without a fourth
+  top-level cause, exactly as the Ideal requires. `role ∈ {judge, fulfill,
+  summarize, policy-compile}`.
+- **`sig`** — the null signer is a first-class, non-deceptive state.
+  `NullReceiptSignatureV0` is `{scheme: "none", null_reason}`;
+  `createNullSignerReceiptSignatureV0` stamps reason
+  `"no-signer-adapter-configured"`. A non-null `AdapterReceiptSignatureV0`
+  shape is *typed* but **rejected at validation**: `validateSignature` pushes
+  the error *"non-null signatures are not supported in receipt v0.1; null
+  signer is the only honest v0.1 state."* Cryptographic signing is Roadmap.
+- **`verdict`** — one of the four coarse statuses; `confidence` with `value`,
+  `derivation_method`, `calibration_grade ∈ {authored, accrued, none}`, and
+  `label_source`; a `blocked` block (required iff status is `blocked`) with
+  `reason`, `fix_target`, `interrupt_cause ∈ {needs-judgment, needs-input,
+  contract-declared}`.
+- **`freshness`** — `as_of`, `next_forecast_recheck`,
+  `transitive_freshness_policy_ref`, and `consumed_freshness_evaluated` (per
+  consumed receipt: `receipt_hash`, `next_forecast_recheck`,
+  `staleness_outcome ∈ {fresh, stale-refetched, stale-blocked}`). When
+  receipts are consumed the transitive-freshness policy ref and a
+  per-consumed-receipt evaluation are *required* by `validateComposedFreshness`.
+- **`composition`** — `consumed_receipts` each pinning
+  `upstream_content_hash`, `contract_revision`, and a non-empty
+  `acceptable_signer_set`; plus a `cycle_checked` boolean.
+- **`cost`** — token-truth: `provider`, `model`, `role`, `tags`,
+  `responsibility_id`, `run_id`, `as_of`, `tokens.{fresh,reused}`, and
+  `surprise_cause`. Sliceable by every dimension the Ideal names.
+- **The single deferral matches the Ideal.** `cost.provider_norm` is an
+  optional sub-object validated only for a `schema` string. Its full
+  cross-provider normalization (cache-write/read price, TTL, minimum-cacheable
+  thresholds) is the one deferred element of I.1 — present as a typed slot,
+  unfilled.
+- **Inspection / proof surface.** `inspectReceiptProofV0` and
+  `ReceiptProofInspectionV0` give a non-throwing audit view; `serializeReceiptV0`
+  emits canonical bytes.
+
+Receipt module: 15 test groups in `receipt/__tests__/receipt.test.ts`.
+
+### The deterministic kernel — `packages/reactor/src/kernel/`
+
+The kernel of *Open specification item I.2* is **implemented**, including the
+B1/B2/B3 no-anchor additions.
+
+- **`KERNEL_BACKSTOPS`** pins the seed constants from I.2 exactly:
+  `maxPolicyAgeMs` 30 days, `maxPolicyAgeNoAnchorMs` 7 days,
+  `minRecompileIntervalMs` 1 hour, `maxCalibrationDivergenceMultiplier` 2,
+  `maxUnforcedDeepIntervalMs` 7 days.
+- **`KERNEL_MAY_NEVER`** is a 14-entry frozen list of prohibitions (the kernel
+  may never author judgment, call a model to decide a backstop, lengthen a
+  backstop, quiesce on missing safety-critical inputs, emit confident `up`
+  under degraded calibration, …). A test —*"may-never list preserves W2
+  prohibitions as executable contract checks"* — keeps it load-bearing.
+- **Predicate evaluator.** `evaluatePredicate` is a dumb evaluator of a typed
+  `KernelPredicateExpression` (`equals`, `not-equals`,
+  `greater-than-or-equal`, `less-than`, `and`, `or`, `not`) against
+  `KernelFacts`. Its three-valued `PredicateOutcome` —
+  `not-tripped | tripped | indeterminate` — fails closed: a malformed
+  expression or a missing fact is `indeterminate`, never silently false.
+- **`evaluateBackstops`** is gated by a `ValidatedKernelPolicyArtifactToken`
+  (a branded, frozen token only `validateKernelPolicyArtifact` can mint —
+  raw policy artifacts cannot reach the evaluators). It fails *closed*: a
+  missing calibration-evidence seed, missing warmup seed, or missing
+  no-anchor deep baseline each produce a backstop outcome rather than silence.
+- **B1/B2/B3.** `validateKernelPolicyArtifact` **rejects** a policy whose
+  falsification predicate references no live observable (B3), and **requires**
+  a no-anchor policy to ship a `backstop_divergence_predicate` that itself
+  references a live observable (B2). `evaluateBackstopDivergencePredicate`
+  evaluates only the validated, frozen predicate and emits a content-addressed
+  `force-policy-recompile` safety receipt when it trips. The no-anchor 7-day
+  forced-deep cadence (B2) and 7-day no-anchor policy-age ceiling (B1) are
+  enforced in `evaluateBackstops`.
+- **Rollback.** `compareRollback` decides
+  `rollback | keep-current | no-last-known-good` strictly by *judged-activation
+  count* — `JudgedActivations` is a branded integer; a test asserts wall-clock
+  duration is never used.
+- **Cycle detection** — `detectReceiptCycles` is a deterministic DFS over
+  content-addressed receipt edges, order-independent, failing closed on
+  malformed edges.
+- **Fail-safe receipts.** `createKernelSafetyReceipt`,
+  `resolvePersistentIndeterminate` (a bounded-`indeterminate` →
+  `needs-judgment` primitive), and the divergence path all emit real receipt
+  v0 entries with `verdict.status = "blocked"` and zero tokens.
+
+Kernel module: 19 test groups in `kernel/__tests__/kernel.test.ts`.
+
+### Memoization — `packages/reactor/src/memo/`
+
+The memoization core of *Quiescence* is **implemented as a primitive**.
+
+- **`computeMemoKeyV0`** hashes a normalized `MemoKeyInputV0` —
+  `contract_revision` + a deduplicated, sorted set of `evidence_receipts` +
+  sorted `dependency_receipts` — under schema `openprose.memo-key`, `v: 0`.
+  The key is complete relative to its declared inputs by construction.
+- **`InMemoryMemoStoreV0`** is namespaced by
+  `(policy_artifact_namespace, policy_artifact_revision)` — a policy recompile
+  changes the namespace and so cannot reuse a stale verdict.
+- **`createMemoHitReceiptV0`** emits a receipt with
+  `cost.tokens = {fresh: 0, reused: <prior total>}` and provider `memo` —
+  the fresh-vs-reused proof the Ideal calls for. A memo hit is provably
+  zero fresh judge tokens.
+- The runtime (`reactor/index.ts`) uses this primitive: on an unchanged
+  evidence hash a forecast evidence-age recheck produces a memo-hit receipt
+  with `fresh = 0`.
+
+Memo module: 5 test groups in `memo/__tests__/memo.test.ts`.
+
+### Forecast-gated scheduling — `packages/reactor/src/forecast/`
+
+`evaluateForecastScheduleV0` is **implemented**. It carries a
+`ForecastScheduleStateV0` with two independent clocks —
+`next_evidence_recheck` and `next_plan_recheck` — exactly the *second
+forecast clock* the plan-completeness audit requires. When neither clock is
+due it returns `outcome: "sleep"` with zero token-bearing receipts; when a
+clock crosses it returns `manufacture-recheck` with synthetic
+`forecast-recheck` receipts tagged `recheck_kind`. The `adversarial-silent`
+reason path (no real input observed yet a clock crossed) is distinguished from
+the ordinary `forecast-clock-crossed` reason. Forecast is the
+synthetic-input mechanism that makes silence safe.
+
+Forecast module: 4 test groups in `forecast/__tests__/forecast.test.ts`.
+
+### Compiled evidence plan — `packages/reactor/src/evidence-plan/`
+
+The *completeness law* — shallow judging executes a compiled, stable evidence
+plan; only deep roaming may discover new sources — is **implemented**.
+`executeShallowEvidencePlan` walks a `CompiledEvidencePlan`'s declared sources
+and fails safe (a kernel safety receipt) if a required source has no collector
+or produces an unverifiable receipt. `reconcileDeepRoam` returns
+`force-recompile` when deep roaming discovers a source outside the compiled
+plan — plan-incompleteness is surfaced through recompile, never silently
+swallowed. The memo key cannot be patched in place; this is enforced by
+construction.
+
+Evidence-plan module: 7 test groups.
+
+### The judge — `packages/reactor/src/judge/`
+
+The judge is **partially implemented and explicitly bounded to shallow depth.**
+`runShallowJudgeV0` calls the model-gateway adapter for a single shallow
+verdict and returns a `ReceiptVerdictV0` plus token-truth usage. **It throws
+`"not-implemented-in-v0.1"` for `depth: "ensemble"`.** The variable-depth,
+multi-provider, calibration-scored judge ensemble of the *Failure model* —
+the diversity floor, degraded-calibration ladder, ensemble-spread confidence
+estimator — is **not implemented as a runtime judging path**. Every shallow
+verdict is emitted with `calibration_grade: "none"` and label source
+`no-anchor-v0.1`. Ensemble judging exists only as the recorded K1 calibration
+cassettes in the Cradle (see *Evaluation harness* below).
+
+Judge module: 1 test group.
+
+### The Reactor runtime — `packages/reactor/src/reactor/` and `sdk/`
+
+`createReactor` (in `sdk/`) returns a `ReactorSdkV0` handle —
+`{adapters, ingest, tick, receipts, registry, export}` — and is the public
+runtime entry. `createRuntimeReactorV0` wires the modules into a real loop:
+
+- **`ingest(event)`** normalizes a typed turn (`real-input`,
+  `forecast-recheck`, `escalation`), selects evidence from the compiled plan,
+  verifies dependency receipts and runs cycle detection, looks up the memo
+  store, invokes the shallow judge on a miss, and appends a verified receipt.
+- **`tick(as_of)`** is the bounded scheduler: it reads the forecast schedule,
+  manufactures due rechecks, and runs the policy recompile/rollback loop.
+- **Cold start** authors a policy on the first real input:
+  `authorPolicyArtifactV0` is invoked **once** through the agent-SDK adapter,
+  the artifact is validated, and revision `1` is persisted before any judging.
+- **Export/import.** `export()` builds a `ReactorExitBundleV0` —
+  contract revision, active policy artifact bytes, all receipts, dependency
+  pins, runtime registry, memo namespace binding — and
+  `importReactorExitBundleV0` hydrates a fresh reactor from it. A test
+  confirms an imported runtime-produced log produces the *same next
+  deterministic receipt hash* as the original: replay/exit is real for the
+  shipped path.
+
+Reactor module: 23 test groups; SDK module: 18.
+
+### Policy — `packages/reactor/src/policy/`
+
+The policy layer is **implemented as a one-shot cold-start author plus the
+recompile/rollback decision machinery; the recurring two-timescale loop is
+partial.**
+
+- **`authorPolicyArtifactV0`** runs a two-step agentic exchange
+  (history-query, then author-artifact) through the agent-SDK adapter — the
+  exploratory-agent shape of *The two compiles* v0.1.
+- **`validatePolicyArtifactV0`** validates the authored artifact against
+  schema `openprose.reactor.policy-artifact`, `v: 0`.
+- **`derivePolicyDriftFactsV0`**, **`evaluatePolicyDriftV0`**,
+  **`planPolicyRecompileV0`**, **`executePolicyRecompileV0`**, and
+  **`planPolicyRollbackV0`** implement the drift-detection, recompile, and
+  rollback decision functions. They are exercised by `policy-drift`,
+  `policy-recompile`, and `policy-rollback` tests (5 + 6 + 5 groups) and by
+  the Cradle `recompile`, `rollback`, `policy-drift`, and `policy-replay`
+  integration scenarios.
+- **Partial**: the runtime cold start authors policy revision `1` once. The
+  *recurring* model-authored recompile-on-drift loop — the predicate tripping
+  in production and re-invoking the author over accumulated history — is the
+  v0.2 milestone of *The two compiles*; the decision functions exist and are
+  unit/integration tested, but they are not yet driven by a live standing
+  loop.
+- The `transitive_freshness_function` is a model-authored policy parameter
+  with a `DEFAULT_TRANSITIVE_FRESHNESS_FUNCTION_V0`, recorded in the registry.
+
+### Composition — `packages/reactor/src/composition/`
+
+Composition-via-receipts is **implemented**. `verifyUpstreamReceiptDependencyPinV0`
+fails closed on supply-chain mismatches (content hash, contract revision, or
+signer outside the pinned set). `evaluateTransitiveFreshnessV0` applies the
+recorded transitive-freshness function with the kernel-backstop default
+(`stale-blocked` at the forecast boundary), honors a stricter authored
+minimum, and records `stale-refetched` replacements.
+`computeDownstreamComposedMemoKeyV0` and `planCompositionPropagationV0`
+make a dependent re-judge on an upstream receipt change and stop on a memo
+hit — propagation reuses memoization exactly. The Cradle E1/E2 integration
+tests compose an A/B/C chain through receipt pins, prove one upstream receipt
+amortizes across N downstream memo-hit propagations, and exercise
+fork/exit carry-over.
+
+Composition module: 15 test groups.
+
+### Projection — `packages/reactor/src/projection/`
+
+Tiered projection (the *Privacy is a failure mode* requirement) is
+**implemented**. `projectReceiptV0` and `projectReceiptProofV0` emit
+`owner | subscriber | public` projections under schema
+`openprose.reactor.receipt-projection`, `v: 0`. Owner projections may carry
+rich verdict data; subscriber and public projections are explicit narrowed
+contracts, not ad-hoc filtering. The CLI wires `prose status
+--tier=owner|subscriber|public` over this surface, and a secret-injection
+test proves secret-shaped tags and rationale do not reach subscriber/public
+output.
+
+Projection module: 7 test groups.
+
+### Cost / token-truth — `packages/reactor/src/cost/`
+
+The cost-thesis verification surface is **implemented**.
+`ALLOWED_SURPRISE_CAUSES_V0` pins the three causes;
+`validateReceiptSurpriseAttributionV0` and
+`evaluateSurpriseAttributionCompleteV0` check that every token-bearing receipt
+names a surprise cause; `evaluateFlatSpendUnderStaticV0` checks that spend
+stays flat under a static world. These are the deterministic helpers the
+*cost scales with surprise* invariant is tested against.
+
+### Adapters — `packages/reactor/src/adapters/`
+
+Eight adapters ship, all injected with no hidden defaults (the SDK fails
+closed if a slot is missing): `clock-system` (system + fixed clocks),
+`storage-fs`, `storage-memory`, `model-gateway-record-replay`,
+`agent-sdk-passthrough` (passthrough + null), `sandbox-null`,
+`connector-static`, `event-sink-memory`. The signer adapter is *typed only*
+as `NullReceiptSignatureV0` — there is no cryptographic signer adapter and no
+Postgres storage adapter in the repository. The two adapter seams of the
+Ideal are present and distinct: the **agent-SDK seam**
+(`ReactorAgentSdkAdapterV0`, used by the policy author) and the
+**model-gateway socket** (`ReactorModelGatewayAdapterV0`, used by the judge).
+
+### The Cradle — `packages/reactor-cradle/`
+
+The Cradle is the **evaluation harness**: synthetic worlds, baselines, and
+scenario runner that the cost thesis is measured through. It is not part of
+the shipped runtime.
+
+- **Synthetic worlds** (`world/`, `scenario/`) — `static`,
+  `periodic-surprise`, and `adversarial-silent` profiles; a static world
+  rejects material source changes rather than manufacturing surprise.
+- **Baselines** (`baselines/`) — `no-memo` and `naive-loop` controls plus a
+  `cost-thesis` summary builder. **These are controls, not shipped runtime
+  modes.**
+- **W7 static-world run** (`__tests__/w7-static-cost.integration.test.ts`) —
+  drives a real `createReactor` handle through a static scenario and reads
+  `reactor.receipts()`. Observed token shape: bootstrap real-input
+  `fresh = 41`; evidence-age rechecks `fresh = 0` with positive reused
+  tokens; plan-age audit floor `fresh = 5`. The C5 cost-thesis summary row is
+  **runtime-produced** at `46:46` (fresh:reused) for the Reactor, against
+  the same-unit `92:0` simulated no-memo and `92:0` naive-loop controls.
+- **C5 event-changing run** — Reactor `74:74` runtime-produced, no-memo
+  `148:0` simulated, naive-loop `148:0` control.
+- **K1 live calibration cassette** — `spikes/fixtures/k1-live-recorded.json`
+  is one recorded OpenRouter ensemble spanning
+  `google/gemini-3.1-flash-lite-preview`,
+  `mistralai/mistral-small-3.2-24b-instruct`, and
+  `qwen/qwen-2.5-72b-instruct` (provider + family + size diversity),
+  accepted by the K1 evaluator. This is *recorded calibration evidence*, not
+  a live runtime variable-depth ensemble judging path.
+- **Provider parity** (`provider-parity/`) — two named provider/model paths
+  produce byte-identical policy-artifact bytes with fail-closed provider
+  drift. This is *recorded* provider parity, not live provider support.
+
+### CLI Reactor path — `tools/cli/src/prose/`
+
+`prose serve` is no longer an agent-interpreted Reactor; it runs the
+`@openprose/reactor` package as the typed authority. The bridge
+(`responsibility-reactor.ts`, `repository-serve-reactor-adapters.ts`,
+`repository-serve.ts`, `repository-serve-daemon.ts`) converts local
+responsibility status into Reactor inputs, calls `createReactor`, and mirrors
+compact projections under `state/reactor/` and
+`state/responsibilities/{id}/`. It implements the operational scars:
+crash-window replay (restart after a post-pressure-claim/pre-fulfillment
+crash converges within one cycle), durable pressure dispatch claims,
+restart recovery for scheduled work, and duplicate-trigger dedupe (two
+identical triggers → exactly one Reactor receipt, one pressure record, one
+fulfillment dispatch — surviving distinct HTTP receive timestamps via a
+normalized `triggerDedupeKey`).
+
+> **Note — the CLI cold-start policy is a fixed seed, not yet the package
+> author.** `responsibility-reactor.ts` pins
+> `RESPONSIBILITY_REACTOR_POLICY_REVISION = "1"` and builds the cold-start
+> input itself. The package-level agentic `authorPolicyArtifactV0` is wired
+> and tested in `@openprose/reactor`'s own runtime path, but the CLI's serve
+> loop currently supplies a deterministic cold-start seed. Driving the CLI's
+> serve loop through the agentic author is Roadmap.
+
+### Conformance Ledger
+
+Part I states the invariants as an unqualified north star. This ledger is
+where reality is honest, audited against HEAD `52724ed`. **v0.1 is
+released**: both packages are public on npm at `0.1.0` with provenance, and the
+ledger reports the shipped surface rather than a release candidate.
+
+| Invariant | State | Code-grounded current reality |
+| --- | --- | --- |
+| 1. Markdown is intent | **Conformant** | `*.prose.md` is the sole semantic source. The kernel never interprets source — it consumes a pinned `contract_revision` content hash (`ReceiptCoreV0.contract_revision`). No second authored surface. |
+| 2. Policy is model-authored, compiled, shared | **Conformant for the package runtime; CLI seed is bounded** | `validateKernelPolicyArtifact` + `evaluateBackstops` execute model-authored, validated policy artifacts; cold start invokes `authorPolicyArtifactV0` once through the agent-SDK adapter and persists revision `1`. The tick path runs the recompile/rollback loop (`planAndMaybeExecutePolicyRecompileAfterTick`) and tests prove recompile, min-interval delay, self-trip rollback, and fail-safe missing bytes. The CLI serve adapter still supplies a deterministic cold-start seed instead of invoking the package author path; that is a host-adapter gap, not an absent runtime mechanism. |
+| 3. Adapters are the only reason hosts differ | **Partial — recorded provider parity** | The SDK injects all eight adapters with no hidden defaults and fails closed on a missing slot (verified). The Cradle records two named provider/model paths producing byte-identical policy-artifact bytes with fail-closed provider drift. This is *recorded* parity, not live multi-provider support or cross-storage CI parity. |
+| 4. Activations are bounded | **Conformant** | Continuity lives in durable registry + receipt state read by `tick`/`ingest`; there is no long-running model session anywhere in the runtime. |
+| 5. Cost scales with surprise | **Measured v0.1 with controls** | The W7/C5 Cradle scenarios drive a real `createReactor` handle and read runtime-produced receipts. Static Reactor/no-memo/naive-loop = `46:46` / `92:0` / `92:0`; event-changing = `74:74` / `148:0` / `148:0`. No-memo and naive-loop are controls, not shipped modes. Surprise attribution is enforced per token-bearing receipt by `cost/`. Not yet proven under live multi-provider load. |
+| 6. The judge fails safe | **Partial + one live K1 cassette** | Kernel fail-safe is substantially built and verified: fail-closed seed semantics, three-valued predicate outcomes, bounded-`indeterminate` → `needs-judgment`, every blocked/fail outcome a content-addressed receipt, and uncalibrated non-blocked model verdicts are rewritten to `blocked`/`needs-judgment` rather than emitting a silent confident `up`. **But `runShallowJudgeV0` throws `not-implemented-in-v0.1` for ensemble depth** — the variable-depth, diverse-ensemble, calibration-scored judge is not a runtime path. One live-recorded OpenRouter K1 cassette is accepted by the evaluator. |
+| 7. Receipts are content-addressed | **Conformant for v0 + null-signer** | Receipt v0 content-addressing is real and verified (canonical SHA-256, self-verifying construction, `evidence_input_ids` content-addressed). Tiered projection ships with a passing secret-injection test. **Caveat:** the signing path is null-only by design — a non-null signature is typed but validation-rejected; `cost.provider_norm` is a deferred sub-object. |
+| 8. State is replayable and exitable | **Conformant for the shipped path** | `export()` / `importReactorExitBundleV0` round-trip a runtime-produced log; an imported reactor produces the same next deterministic receipt hash. The CLI adds crash-window replay and duplicate-trigger idempotency. **Caveat:** cross-storage-adapter parity (filesystem vs. an absent Postgres) is not yet a CI gate. |
+
+### What the tests prove — and do not
+
+**Proven today:** `@openprose/reactor` builds, packs, imports, and passes 155
+deterministic tests; the Cradle passes 121; the CLI passes 284. The receipt
+schema, kernel, memoization primitive, forecast scheduler, evidence plan,
+composition, projection tiers, and export/import all have real, passing
+coverage. The CLI runs the package as its Reactor authority and survives the
+crash-window and duplicate-trigger operational scars. The cost-scales-with-
+surprise numbers are runtime-produced against synthetic worlds.
+
+**Not yet proven:** that Reactor-class is the best architecture for target
+domains; that the harness outperforms simpler baselines on real workloads;
+that variable-depth ensemble judging works (it is unimplemented at v0.1);
+that the recurring policy recompile loop holds under live drift; that model
+families behave differently inside the harness under live inference; that
+public projections and receipts are launch-grade; that responsibilities
+converge over long real horizons.
+
+### Honest current limits
+
+- `@openprose/reactor` and `@openprose/reactor-cradle` are published at
+  `0.1.0` with npm provenance. In-repo development still uses workspace links.
+- The variable-depth ensemble judge is **unimplemented** — `runShallowJudgeV0`
+  throws on `depth: "ensemble"`. Calibration grade is always `none` on shipped
+  verdicts.
+- The recurring two-timescale policy loop ships in the package runtime; the CLI
+  serve adapter's cold-start path is still a deterministic seed and does not yet
+  invoke the package policy author.
+- Cross-adapter/replay parity is a local proof, not a required CI gate. There
+  is **no Postgres adapter** in the repository.
+- Cryptographic signing is unimplemented by design; the null signer is the
+  only honest v0.1 state and a non-null signature is validation-rejected.
+- `cost.provider_norm` is a typed but unfilled deferral (Open item I.1).
+- The model matrix (Anthropic/OpenAI/Gemini/Grok) has not been run; baselines
+  and ablations beyond the W7/C5 cost rows are not collected; long-horizon
+  simulations are not a standard suite.
+- The technical report is maintained separately in `openprose/docs`; this
+  directory is the public spec anchor for the release.
+
+> The implementation is a real, tested v0.1 substrate that justifies the
+> category thesis as an architecture. The category should launch publicly
+> only after the evaluation and evidence suite — variable-depth judging, the
+> live model matrix, the recurring policy loop, long-horizon convergence —
+> makes the claim difficult to dismiss.
+
+### Responsibility catalog
+
+Part I keeps one worked example (the Incident Briefing Room); these are the
+others, retained as a catalog. They ship as runnable example contracts under
+`skills/open-prose/examples/`.
+
+- **Release readiness** — `Goal:` the release candidate is ready to ship;
+  check before every planned release and when release evidence changes;
+  criteria are tests pass, rollback exists, blockers resolved, notes current.
+- **Customer risk radar** — `Goal:` renewal risks for named customers are
+  surfaced before account reviews; check weekly and on support/CRM/product
+  signal change; the value is a maintained risk view, not one classification.
+- **Compliance evidence tracker** — `Goal:` required control evidence is
+  current enough for the next audit; benefits directly from receipts and
+  tiered projection (rich owner evidence, sanitized public proof).
+- **Research inbox triage** — `Goal:` new research leads are classified and
+  routed each workday; makes model differences visible (some classify better,
+  some are cheaper for routine fulfillment).
+
+The boundary with the Language is explicit from both sides: repository IR v0
+is frozen and source-derived, while the policy artifact, token-truth receipts,
+forecasts, and decisions are sibling runtime state owned by
+`@openprose/reactor` — not IR fields and not `*.prose.md` syntax (see
+[01-Language.md](./01-Language.md) Part II "Repository IR v0" and Part III §3).
+
+---
+
+## III. Roadmap — the Delta from Current to Ideal
+
+`Ideal − Current = Roadmap`. This is the honest gap: what bridges the v0.1
+substrate of Part II to the Reactor-class harness of Part I, and what must
+ship before OpenProse publicly launches the term with a technical report.
+Turn the Reactor-class harness from a plausible, tested architecture into a
+published technical claim.
+
+### Launch Standard
+
+Do not publicly launch "Reactor-class harness" until three artifacts ship
+together:
+
+1. A release-quality open source CLI using `@openprose/reactor`.
+2. A technical report defining the class, architecture, baselines, and results.
+3. A reproducible eval suite that lets others inspect the claim.
+
+The bar:
+
+```text
+Can we credibly say this architecture is novel, simple, high quality, based on
+proven systems patterns, and empirically useful for event-based high-complexity
+rerenders of modeled world state — and that its cost scales with surprise, not
+time?
+```
+
+### Required Engineering Work
+
+#### 1. Publish And Pin The Shared Package
+
+Public npm release; provenance; packed `dist`; exact version pin from the CLI;
+CI verification that the installed package matches the expected hash; release
+workflow that fails if local source and published package diverge. This is the
+minimum proof the published package and local source match.
+
+#### 2. Make Cross-Adapter / Replay Parity A Gate
+
+The same package over the same fixtures produces byte-identical policy outputs
+across storage adapters (filesystem vs. optional Postgres) and across replays,
+where adapters are not supposed to differ. Required parity fixtures:
+
+- healthy responsibility stays quiet
+- drifting responsibility schedules fulfillment
+- down responsibility escalates after budget exhaustion
+- blocked responsibility requests human review or escalation
+- forecast pulls judge earlier
+- hysteresis prevents flip-flop
+- duplicate webhook does not duplicate pressure
+- stale status is rejected or fenced
+- contract revision change fences old decisions
+- **policy recompile produces a byte-identical registry from identical history**
+- **memoized verdict reuse spends zero judge tokens**
+
+Required CI, not a best-effort script.
+
+#### 3. Complete The Local Harness As A Public Product Surface
+
+- clear `prose serve` startup logs for active responsibilities and triggers
+- `prose status` view of latest status, Reactor decision, forecast, pending
+  pressure, scheduled judge, **and per-token surprise attribution**
+- deterministic local state layout docs
+- example repositories runnable from a fresh clone
+- local failure messages explaining missing tools, missing IDs, invalid status,
+  stale claims, malformed decisions, **and undecidable contracts**
+- a first-class **export/exit** surface (the contract and its trail leave
+  cleanly — invariant 8, Tenet 6)
+- release preflight that checks examples, package imports, and docs
+
+The public developer should run one example and immediately understand why this
+is not just cron plus prompt — ideally by watching token spend stay flat while
+nothing changes.
+
+#### 4. Harden Receipts And Projections
+
+- content-addressed judge and decision receipts
+- local receipt inspection
+- a receipt proof surface for inspection and verification
+- owner/subscriber/public projection contracts
+- privacy tests that inject secrets and PII into judge rationale and prove they
+  do not leak to public views (tiered projection is enforced here)
+- event payloads that use real receipt hashes, not signature placeholders
+- null-signer is the default and explicit; cryptographic signing is an
+  optional pluggable signer adapter for cross-trust-domain non-repudiation
+- receipts carry `as_of` and `next_forecast_recheck`; dependency edges pin
+  contract revision and acceptable signer set (composition supply-chain safety)
+- token-truth fields finalized after provider research (open item I.1)
+
+### Required Evaluation Suite
+
+A research instrument, not only a test suite.
+
+#### Existing Evals To Keep
+
+package unit; runtime loop; storage adapter; judge protocol; CLI repository IR;
+CLI serve and status; status and pressure; package bridge; release preflight;
+package pin verification; negative architecture tests.
+
+#### Novel Reactor Evals To Add
+
+| Eval                             | Question                                                                                                                                               |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Reconciliation correctness       | Does the Reactor choose the oracle next action from event, status, history, budget?                                                                    |
+| Forecast quality                 | Does forecast scheduling catch likely drift earlier without excessive checks?                                                                          |
+| Oscillation resistance           | Does hysteresis avoid flip-flopping under noisy judge outputs?                                                                                         |
+| Duplicate event idempotency      | Do repeated webhooks/queue/timer ticks produce one action?                                                                                             |
+| Crash recovery                   | Does restart converge after status, decision, or pressure-dispatch interruption?                                                                       |
+| Capability blocking              | Does missing tool/connector state become `blocked`, not hallucinated success?                                                                          |
+| Privacy projection               | Do secrets, emails, private URLs, customer payloads stay out of public views?                                                                          |
+| Contract revision fencing        | Do old decisions stop applying after source changes?                                                                                                   |
+| Long-horizon maintenance         | Does state hold over simulated 7, 30, 90 day timelines?                                                                                                |
+| Adversarial evidence             | Does conflicting/malicious evidence reduce confidence or escalate?                                                                                     |
+| **Cost scales with surprise**    | Can every token be attributed to a surprise-cause; does spend stay flat under no change?                                                               |
+| **Variable-depth correctness**   | Does the judge escalate depth only when uncertain/high-stakes, and downgrade when confident?                                                           |
+| **Policy recompile correctness** | Does the model-authored policy recompile on policy drift, and does the meta-loop stay stable (no recompile thrash, rollback to last-known-good works)? |
+| **Composition propagation**      | Does a dependent re-judge only when an upstream receipt changes; does cost amortize across N dependents?                                               |
+| **Supply-chain pinning**         | Does a dependent reject an upstream receipt whose contract revision or signer is not pinned?                                                           |
+| **Calibration anchor**           | Does scoring the ensemble against bring-your-own-correctness-truth measurably reduce ensemble bias?                                                    |
+| **Undecidable contract**         | Does the judge emit an undecidable diagnosis on an unjudgeable contract, routed to the author?                                                         |
+| Human-review boundary            | Does the runtime ask for review when autonomy would be unsafe?                                                                                         |
+
+Each eval emits machine-readable results and a human-readable report.
+
+#### Baselines
+
+- naive single-agent loop
+- cron-only judge and fulfillment loop
+- workflow DAG with retries but no Reactor
+- model-interpreted Reactor doctrine without package policy
+- Reactor without forecast
+- Reactor without hysteresis
+- Reactor without receipts
+- Reactor without durable pressure claims
+- **Reactor without memoization (cost scales with time)**
+- **Reactor without variable-depth judging (fixed ensemble)**
+- **Reactor without policy recompile (fixed policy)**
+- **Reactor without composition (islands)**
+
+The best result is precise, not triumphal:
+
+```text
+Forecast improves freshness in event-sparse domains.
+Memoization makes cost scale with surprise, not time.
+Variable-depth judging preserves accuracy at lower cost.
+Hysteresis reduces unnecessary fulfillment under noisy judgment.
+Durable decisions and claims improve crash recovery and idempotency.
+Receipts improve auditability without changing task quality.
+Composition amortizes cost across dependents.
+Model choice changes judge accuracy more than Reactor correctness.
+```
+
+### Model Matrix
+
+Target families: Anthropic, OpenAI, Gemini, Grok. Test premium and cheaper
+models. The point is model fit by role, not leaderboard quality.
+
+| Role        | What To Measure                                                             |
+| ----------- | --------------------------------------------------------------------------- |
+| Judge       | status accuracy, evidence quality, calibration, blocked correctness         |
+| Fulfillment | restoration rate, overreach rate, output quality, cost                      |
+| Summarizer  | projection safety, concision, evidence preservation                         |
+| End-to-end  | convergence rate, cycles to restoration, cost per maintained responsibility |
+
+Metrics: status accuracy and F1; Brier/calibration error for confidence; action
+optimality vs oracle Reactor decisions; convergence rate; duplicate action
+rate; escalation correctness; privacy leak rate; cost per maintained
+responsibility; **fraction of tokens attributable to a surprise-cause**;
+latency to restoration; receipt completeness; human review pass rate.
+
+Questions: which models are best judges; best fulfillers; which cheaper models
+safely replace expensive ones after confidence is high; where the Reactor
+compensates for weaker models; where model quality still dominates; **where
+ensemble disagreement is a well-calibrated uncertainty signal**.
+
+The matrix runs through **both** seams — the bounded-activation agent-session
+adapter and the model-gateway socket — so the adapter boundary stays honest
+permanently and the policy-author migration path is exercised, not assumed.
+
+### Public Case Studies
+
+1. release readiness
+2. incident briefing room
+3. customer risk radar
+4. compliance evidence tracker
+5. vendor renewal watch
+6. research inbox triage
+7. content performance loop
+
+Each includes: source responsibility and gateway contracts; synthetic or
+sanitized event stream; expected oracle status trajectory; model outputs;
+Reactor decisions; forecasts; pressure records; receipts; final projections;
+cost and latency summary (including surprise attribution); baseline comparison.
+Runnable from the CLI.
+
+### Technical Report Outline
+
+Written after the evals, not before.
+
+1. **Problem**: AI agents are bad at long-lived responsibility maintenance.
+2. **Category**: Definition of Reactor-class harnesses.
+3. **Prior Patterns**: React reconciliation (lead), control systems (time/cost
+   dimension), with event sourcing, dataflow, controllers, workflow engines,
+   CQRS / read models, and actor systems as footnoted lineage.
+4. **OpenProse Design**: lived loop; the unification thesis; two-timescale
+   policy; variable-depth judging; forecast-gated quiescence; composition;
+   receipts; projections; adapters.
+5. **Implementation**: `@openprose/reactor`, CLI/server, storage,
+   optional signing, cross-adapter/replay parity.
+6. **Evaluation Methodology**: fixtures, domains, baselines, metrics, model
+   matrix.
+7. **Results**: cost-scales-with-surprise, model differences, ablations,
+   convergence, latency, idempotency, crash recovery, privacy.
+8. **Case Studies**: selected responsibilities and timelines.
+9. **Limitations**: connector coverage, judge reliability, prompt sensitivity,
+   public receipt maturity, cost curves, human review, open items I.1–I.6.
+10. **Future Work**: learned forecast policies, automatic model routing,
+    deeper dependency-graph amortization. (A public responsibility market is
+    out of scope of this specification.)
+
+Sober. Make a strong claim, then show the evidence and the limits.
+
+### Definition Of Done For Launch
+
+- `@openprose/reactor` is public, pinned, and verified.
+- The CLI release imports the package and passes release preflight from a clean
+  install.
+- Backend and CLI parity fixtures are required CI, including policy-recompile
+  and memoization parity.
+- At least five public examples run locally from a fresh clone.
+- The eval suite includes conventional tests, Reactor evals (including
+  cost-scales-with-surprise, variable depth, policy recompile, composition),
+  baselines, and model matrix results.
+- The technical report includes measured results, not only architectural prose.
+- Receipts and projections are honest about the null-signer default vs. an
+  optional signer adapter; export/exit works.
+- Public examples avoid leaking private or sensitive evidence.
+- The docs define when to use a Reactor-class harness and when not to.
+- Open items I.1–I.6 are either closed or explicitly scoped as future work.
+- A technically skeptical reader can reproduce enough of the claim to trust it.
+
+The release sentence:
+
+> OpenProse is a Reactor-class harness for maintaining AI-authored
+> responsibilities over time: it reconciles declarative goals against events,
+> durable observations, forecasts, typed decisions, and auditable receipts —
+> and its cost scales with surprise, not time.
+
+That is a category worth naming.

--- a/spec/03-ReactorPattern.md
+++ b/spec/03-ReactorPattern.md
@@ -1,0 +1,794 @@
+# OpenProse Reactor Pattern
+
+###### How to write OpenProse for a Reactor-class harness — the language layer beneath evented reconciliation.
+
+The OpenProse corpus divides labor exactly, and each document maps to what
+ships:
+
+- [01-Language.md](./01-Language.md) — **the Language & Framework**, bundled as
+  the **SKILL**: syntax, kinds, sections, compile model, std/co, CLI surface.
+- [02-ReactorHarness.md](./02-ReactorHarness.md) — **the Reactor
+  Harness**, bundled as the **CLI/Server**: the runtime control architecture
+  (loop, invariants, kernel, memoization, forecast, receipts, composition). It
+  answers _what the runtime must do_.
+- [03-ReactorPattern.md](./03-ReactorPattern.md) — **this
+  document, the Reactor-Native Authoring Pattern**: **SKILL-bundled but
+  harness-governed**. Where the Harness doc says what the runtime does, this
+  says **what the author writes** so the runtime can do it. It bridges the
+  Language doc and the Harness doc and is the definitive guide to writing
+  `*.prose.md` for a Reactor-class harness.
+- **Internal decision log** — not shipped: the dialectic that produced the
+  Harness doc; the clean public statements live in the specs above and this
+  document does not repeat the dialectic.
+- [00-Tenets.md](./00-Tenets.md) — **the constitution**. When any
+  document tensions with a tenet, the tenet wins.
+
+The relationship is the same as the one between a language reference and an
+effective-style guide. The harness doc tells you the machine has memoization,
+forecast-gated quiescence, variable-depth judging, and receipt composition.
+This doc tells you how to write contracts so those mechanisms actually engage
+instead of degrading to "cron plus a prompt."
+
+This document is organized in three parts, mirroring the rest of the spec:
+
+1. **Ideal** — the Reactor-native authoring pattern as it should be. This is
+   the authored vision; it is frozen.
+2. **Current** — a code-grounded snapshot of how much of the pattern the
+   `openprose/prose` runtime actually realizes at `v0.1` (`0.1.0`), with
+   real module paths. This section is mechanically re-derivable from the code.
+3. **Roadmap (the Delta)** — the honest gap between Current and Ideal,
+   incorporating this document's own open items.
+
+`Ideal − Current = Roadmap`. The three are kept distinct so this document can
+never again claim shipped what is not, or aspire in the same breath it reports.
+
+The single most important principle, stated once up front so the rest is read
+in its light:
+
+> **The Reactor paradigm does not change OpenProse syntax. It inverts which
+> kind is the program.** Every section, kind, and keyword the pattern needs
+> already exists. What changes is doctrine: the responsibility is the
+> top-level authored object, the system is a fulfillment detail, and two
+> contract sections (`### Continuity`, `### Criteria`) acquire a cost and
+> decidability obligation they did not visibly carry before.
+
+---
+
+## I. Ideal — The Reactor-Native Authoring Pattern
+
+### The inversion
+
+`01-Language.md`'s "Mental Model" reads, in order: a prompt for one-off work, a
+contract for roles/handoffs, a `kind: system` is a dependency graph, Forme
+wires it, the VM performs it, and — last — Responsibility Runtime keeps
+standing goals true. That ordering is **system-first**. It is correct for
+bounded work and wrong for the Reactor.
+
+In the Reactor-native pattern the ordering inverts:
+
+```text
+The responsibility is the program.
+The gateway is how the world reaches it.
+The fulfillment system is an implementation detail of one beat of the loop.
+Services, patterns, Forme, and the VM are the substrate the fulfillment
+  system happens to be built from.
+```
+
+The harness doc states this as "the single-responsibility loop is the base
+case." The authoring consequence: **you do not start by writing a system. You
+start by writing one sentence of durable intent and what makes it true.** The
+system, if any, is derived from the responsibility, not the other way around.
+
+This reframes a table in `01-Language.md` that currently misleads on intent. The
+"Directly runnable?" column says `service: Yes`, `system: Yes`,
+`responsibility: No`. Technically accurate — a responsibility is _served_, not
+_run_. But it implies the responsibility is a lesser, non-executable artifact.
+In the Reactor-native pattern the responsibility is the **most** load-bearing
+authored object; "not directly runnable" means "continuously reconciled," which
+is the entire point, not a limitation.
+
+### The canonical contract set
+
+A Reactor-native unit of work is not a file. It is a small, fixed set of files
+with distinct jobs that map one-to-one onto harness layers:
+
+| File | `kind:` | Harness layer it feeds | What the author is really writing |
+| --- | --- | --- | --- |
+| The standing goal | `responsibility` | Responsibility / Contract Markdown | One decidable sentence + what makes it true |
+| Event ingress | `gateway` | Gateway | How and when the world is allowed to wake the loop |
+| Fulfillment | `system` (`persist: project`) | Fulfillment | The one beat where world-mutation is permitted |
+| Sense | `service` inside the system | Judge evidence | A read-only observation that emits a stable content identity |
+| Verdict | `service` inside the system | Judge | Cheapest-sufficient judgment + a calibrated confidence |
+| Ledger | `service` (`persist: project`) | Storage / Receipt (approx.) | The durable trail and the composition edge |
+
+The responsibility is normative and semantic. Everything else is derived
+infrastructure. A reader who understands only the responsibility understands
+the program; the rest is _how_, and is allowed to change without the intent
+changing — which is exactly the harness doc's invariant 8 ("state is
+replayable and exitable") expressed at authoring time.
+
+### Authoring derived from the invariants
+
+Each harness invariant produces a concrete, checkable authoring rule. This
+table is the spine of the pattern; the prose after it only elaborates.
+
+| Harness invariant | Authoring rule it imposes |
+| --- | --- |
+| 1. Markdown is intent | The responsibility carries all semantic weight. Never push intent into the fulfillment system's prose, a prompt, or a tool config. If it matters, it is in `### Goal`/`### Criteria`/`### Constraints`. |
+| 2. Policy is model-authored, compiled, shared | Do not hand-write cadences, hysteresis, or escalation thresholds as imperative ProseScript. Express them as **semantic intent** in `### Continuity`/`### Constraints`. The harness compiles policy; the author states the policy's _shape_, not its registry. |
+| 3. Adapters are the only reason homes differ | Author no host-specific logic in contracts. Declare needs in `### Tools`/`### Environment` by name only. The same contract must run local and cloud. |
+| 4. Activations are bounded | Never write a fulfillment system that assumes it keeps running. No "while true," no in-session waiting for the next event. Continuity lives in the ledger, not in a session. |
+| 5. Cost scales with surprise | Write `### Continuity` so "did anything material change?" is **cheaply decidable**, and decompose the system so the sensing service emits a **stable content identity** the harness can memoize on. Also name the **plan-audit horizon** — the max no-escalation interval before a forced deep revalidation (recorded as a `forecast-recheck`/`plan-age` recheck). This is the rule authors most often violate. |
+| 6. The judge fails safe | Write `### Criteria` with **observable referents**. When a criterion has no referent, the correct verdict is "undecidable" — design for that as a welcome output, not an error. |
+| 7. Receipts are content-addressed | Make the ledger the explicit, structured trail: `as_of`, last-input identity, decision, evidence pointers. Treat it as the audit/composition/exit unit, not a scratch log. |
+| 8. State is replayable and exitable | Keep all durable truth in the responsibility + ledger, in plain Markdown/structured records. A reader must be able to take the contract and its trail to another harness. |
+
+### Rule 1 — `### Goal` is one decidable sentence
+
+A goal is a state that should remain true, written so a judge can render a
+verdict on it. Not a task ("triage the inbox"), not a deliverable ("produce a
+report"), but an invariant ("the research inbox is deduplicated, prioritized,
+and converted into action").
+
+The test: could a competent judge, given evidence, say `up` / `drifting` /
+`down` about this sentence? If the sentence describes an _activity_ rather than
+a _state_, rewrite it until it describes a state. The harness doc's
+front-loaded-then-silent promise depends on this: the most valuable early
+output is "this sentence is not yet decidable, here is why," and that output is
+only possible if the sentence was _trying_ to be decidable.
+
+### Rule 2 — `### Continuity` is written for forecast and memoization
+
+This is the rule that separates a Reactor-native contract from cron-plus-prompt,
+and the one the current skill underspecifies.
+
+`### Continuity` is not "how often to run." It is the author's contribution to
+two harness mechanisms the author does **not** write directly:
+
+- **Forecast** (the harness manufactures the minimum necessary recheck when the
+  world will not announce change). The author's job is to name the **freshness
+  referents**: what makes this goal go stale, how fast, and what external
+  signal — if any — announces a change. "New stargazers within one business
+  day" tells the harness the staleness clock; "outreach history prevents
+  duplicate contact unless new evidence" tells it the memo-breaking condition.
+- **Memoization** (unchanged input hash → reused verdict, zero tokens). The
+  author cannot write the hash, but the author _decides whether one is
+  cheaply computable_. Write Continuity so that "nothing material changed"
+  corresponds to **a stable, cheaply observed identity** — a content hash of
+  the watched artifacts, a max-timestamp, a revision number. If the only way to
+  know whether anything changed is to do the full expensive judgment, you have
+  written a contract whose cost scales with time, not surprise.
+
+Concretely, a good `### Continuity` answers: what events legitimately wake this;
+what the staleness horizon is when no event fires; what condition makes a prior
+verdict no longer reusable; and what divergence is _expected and should be
+preserved rather than reconciled away_ (the policy-over-time recursion — an
+ideal layer is allowed to drift from a plan layer, and that drift is signal).
+
+It must also answer two questions the completeness law now makes load-bearing.
+First, the **plan-audit horizon**: how long a _no-escalation_ run may continue
+before a forced deep revalidation, independent of the shallow judge's
+confidence — the author's input to the harness's plan-age clock (Harness, _The
+completeness law_). Second, **whether a cheap stable identity exists at all**:
+if "did the semantically relevant content change" cannot be decided more
+cheaply than the judgment itself, the author must say so explicitly; the
+harness then runs this responsibility at forecast cadence, not surprise
+cadence. Silently writing such a contract as if memoization applies is not a
+correctness break — forecast still makes it safe — but it is a false cost
+promise, and the honest form declares the forecast-cadence shape deliberately,
+exactly as projection-only is a deliberate amputation rather than a degenerate
+Reactor.
+
+### Rule 3 — `### Criteria` uses observable referents; undecidable is welcome
+
+Every criterion must point at something a judge can observe. "Notes are
+current" is undecidable without a referent; "the release notes file's last
+commit is newer than the latest merged PR touching `src/`" is decidable.
+
+When a criterion genuinely has no observable referent, the Reactor-native
+author does **not** patch around it. The correct behavior is for the judge to
+return `blocked` with a natural-language reason "criterion X has no observable
+referent" and a recommended fix target (the contract author). This is the
+flagship interrupt of the entire architecture — the single highest-leverage
+thing the system can say. Author criteria _expecting_ this verdict on the first
+few activations; that front-loading is the promise, not a defect.
+
+Do not encode an "undecidable" status. The four coarse statuses (`up`,
+`drifting`, `down`, `blocked`) are the control vocabulary; undecidability is a
+judge-authored reason attached to `blocked`, lives at the English layer, and
+must never become an enum in a contract. `calibration-unattainable` is a
+second judge-authored `blocked` sub-reason of the same family: authors of
+high-stakes no-anchor responsibilities should *expect a front-loaded
+calibration spot-check interrupt* — the asymptote-toward-silence promise
+applied to calibration, not just decidability.
+
+### Rule 4 — `### Constraints` draws the actuation boundary
+
+`### Constraints` is where the author quarantines world-mutation. The
+render/commit split from the harness doc's React metaphor (judge is pure:
+world → status; fulfillment is the only commit-phase side effect) is enforced
+at authoring time here.
+
+Two boundary shapes recur:
+
+- **Full Reactor.** Fulfillment may mutate the world (send the email, update
+  the briefing, write the register). `### Constraints` bounds _how_ (rate,
+  scope, prohibited actions, "leave the final send to a human").
+- **Projection-only Reactor.** The author forbids all world-mutation except
+  writing the projection itself. This is a legitimate, common shape: an
+  observe-only overseer, a dashboard that must stay true, an audit that watches
+  but never touches. It uses the judge and projection half of the architecture
+  and deliberately amputates the fulfillment/escalation arm. Say so explicitly:
+  "the only writable surface is &lt;the projection&gt;; never modify, signal, or
+  write into the observed system."
+
+A projection-only contract is not a degenerate Reactor. It keeps every cost and
+audit property; it simply declines the reconcile-the-world payoff. Authors
+should choose it deliberately, not back into it.
+
+### Rule 5 — the fulfillment system is decomposed for memoization and variable depth
+
+The fulfillment `kind: system` is where authors most often write the
+anti-pattern: one big service that re-derives everything every time. The
+Reactor-native decomposition is fixed and small:
+
+1. **Sense** — a read-only service that observes the world and returns,
+   alongside the observation, a **stable content identity** (hash, max-ts,
+   revision). This identity is what makes harness memoization possible. Mark it
+   `persist: project` only if it needs the prior identity to diff.
+2. **Judge** — a service that takes the sensed evidence and emits a coarse
+   status **and a calibrated confidence**. Cheapest sufficient form by default.
+3. **Escalate (conditional)** — a deeper judgment, instantiated as a pattern
+   (`std/patterns/fan-out`, `dialectic`, `oversight`), invoked **only** when the
+   shallow judge is uncertain or stakes/forecast warrant. Variable depth is an
+   authoring decision: a `choice`/`if` in `### Execution` that gates the
+   expensive path on the shallow judge's confidence.
+4. **Fulfill or project** — the single permitted effect, bounded by
+   `### Constraints`.
+5. **Ledger** — a `persist: project` service that records the receipt-shaped
+   trail and advances the last-seen identity.
+
+The `### Execution` block wires this so that an unchanged content identity
+**short-circuits before the expensive judge** (the author's expression of
+quiescence behavior 2), and the deep path is gated on confidence (behavior 3).
+The author writes the gates; the harness owns the memo and the forecast.
+
+### Rule 6 — composition is consuming an upstream trail, not a new primitive
+
+"Responsibility B depends on responsibility A" needs no new syntax. B's judge
+consumes A's latest ledger record (the current stand-in for A's
+content-addressed receipt) as an evidence source — identical to consuming a
+webhook or a file. Three authoring obligations make this safe:
+
+- **Reference, don't embed.** B's contract names A's responsibility id / ledger
+  location as a declared input, not a copied value.
+- **Pin revision and trust.** B's `### Criteria` must state which revision of A
+  it accepts and, for cross-trust-domain composition, an acceptable signer set. Unpinned
+  composition is a supply-chain attack; the author closes that hole, not the
+  runtime.
+- **Carry freshness — semantically, not imperatively.** State B's freshness
+  tolerance for upstream inputs as *intent* in `### Continuity`/`### Criteria`
+  (e.g. "A may be up to one business day stale; older than that, treat B as
+  `drifting` pending a refresh"). The transitive-freshness *function* is
+  harness-side, model-authored, and recorded in the policy registry; the
+  author supplies its *shape* the same way they supply cadence shape, never a
+  hand-written staleness comparison in `### Execution`. An upstream's
+  calibration grade (`authored`/`accrued`/`none`) is part of what B weighs —
+  an uncalibrated upstream is a supply-chain caveat the author pins, parallel
+  to revision/signer.
+
+This is how the three-layer overseer (below) consumes "the plan" — it is a
+composition edge, not a special case.
+
+### Patterns that are Reactor-native
+
+The std pattern library is use-case agnostic, but a subset maps directly onto
+harness layers and should be the author's default vocabulary:
+
+| Pattern | Reactor-native role |
+| --- | --- |
+| `oversight` | Separates actor / observer / arbiter — the canonical projection-only or fail-safe judge shape |
+| `fan-out`, `dialectic`, `ensemble-synthesizer` | Variable-depth escalation; instantiate only on the uncertain branch |
+| `guard` | Precondition gate before an expensive judge or a world-mutating fulfillment |
+| `worker-critic`, `proposer-adversary` | Fulfillment with a built-in fail-safe check before commit |
+| `map-reduce`, `fan-out` | Sensing a wide world cheaply, in parallel, before judging |
+
+The judge being "a variable-depth circuit, not a fixed circuit" (harness
+failure model) is, at the authoring layer, exactly: _instantiate an ensemble
+pattern behind a confidence gate, not unconditionally._
+
+### A worked example: the three-layer overseer
+
+A long-running external agent session (here, a Codex run building an eval set
+across many subagent waves) must be observed but never interrupted. The author
+wants three maintained world-state layers — observed ground truth, the plan
+being executed, the overseer's evolving ideal — and three pairwise delta
+projections, rendered richly, kept true as the world mutates constantly.
+
+This is structurally the harness doc's Incident Briefing Room with a different
+channel, and it is a near-perfect Reactor fit precisely because the naive
+implementation (a swarm of subagents that watches forever) is the
+cost-scales-with-time anti-pattern the Reactor exists to kill.
+
+**The responsibility** (the whole program):
+
+```markdown
+---
+name: codex-eval-build-oversight
+kind: responsibility
+id: 067NC4KG01RG50R40M30E20918
+---
+
+### Goal
+
+A three-layer world model — observed ground truth, the plan being executed,
+and the overseer's evolving ideal — and the three pairwise delta projections
+are current and accurate with respect to the unfolding eval-set build.
+
+### Continuity
+
+- Re-judge on worktree changes and planning-directory changes.
+- While the observed session is active, a forecast-paced fallback recheck so a
+  silent worktree does not mean a silent overseer.
+- Quiesce hard when no material change crosses the layers: an unchanged
+  observation identity reuses the prior projection at zero render cost.
+- The ideal layer is expected to diverge from the plan over time; divergence
+  is preserved as signal and is never reconciled toward the plan.
+
+### Criteria
+
+- Six artifacts reflect the latest material state: three layer views (truth,
+  plan, ideal) and three delta views (plan↔truth, ideal↔plan, ideal↔truth).
+- Deltas are rendered spatially and from multiple dimensions, not as prose
+  lists.
+- The plan layer pins the plan revision it was synthesized against; stale-plan
+  deltas are labeled, never silently mixed.
+- When the build's true state is not yet decidable from observable artifacts,
+  the judge says so and routes that to the human — it does not fabricate a
+  delta.
+
+### Constraints
+
+- NEVER modify, pause, signal, or write into the observed session, its
+  worktree, or the planning directory. Observation is strictly read-only.
+- The only writable surface is the six projection artifacts.
+- Deep enrichment is bounded and escalated only on judge uncertainty or a
+  large delta — never on every event.
+
+### Tools
+
+- cli:git
+- cli:fs-read
+
+### Fulfillment
+
+Prefer the local `oversight-projection` system.
+```
+
+**The gateway** (event ingress; honest current limit noted inline):
+
+```markdown
+---
+name: codex-build-signals
+kind: gateway
+---
+
+### Schedule
+
+- every 3 minutes while the observed session is active
+  # forecast-paced poll; replace with a worktree file-watch when serve
+  # supports file-change ingress
+
+### Receives
+
+- Manual: refresh
+
+### Emits
+
+- codex-eval-build-oversight.evidence-change
+
+### Payload
+
+Pass changed paths (or "scheduled sweep") as activation context. The
+fulfillment system must hash-diff and quiesce when nothing material changed.
+```
+
+**The fulfillment system** (projection-only; the `### Execution` block is where
+quiescence and variable depth are authored):
+
+```markdown
+---
+name: oversight-projection
+kind: system
+---
+
+### Services
+
+- `observe-ground-truth`
+- `read-plan`
+- `judge-materiality`
+- `evolve-ideal`
+- `synthesize-deltas`
+- `render-projection`
+
+- name: deep-survey
+  pattern: std/patterns/fan-out
+  with:
+    delegate: worktree-prober
+
+### Requires
+
+- `activation_event`: changed paths, scheduled sweep, or manual refresh
+
+### Ensures
+
+- `projection_update`: the six rendered artifacts and a ledger receipt
+
+### Runtime
+
+- `persist`: project
+
+### Execution
+
+```prose
+let truth = call observe-ground-truth
+  activation_event: activation_event
+# returns a content identity; the harness memoizes on it.
+# Unchanged identity => prior projection reused, zero render. (quiescence 1+2)
+
+let plan = call read-plan
+  activation_event: activation_event
+
+let verdict = call judge-materiality
+  truth: truth
+  plan: plan
+
+if verdict is quiescent:
+  return verdict.prior_projection      # don't act, don't render
+
+let evidence = truth
+choice verdict.depth:
+  option "shallow":
+    evidence = truth
+  option "deep":
+    let probes = call deep-survey      # gated escalation, not a watcher
+      target: verdict.uncertain_regions
+    evidence = merge truth with probes
+
+let ideal = call evolve-ideal
+  truth: evidence
+  prior_ideal: verdict.prior_ideal     # allowed to diverge from plan
+
+let deltas = call synthesize-deltas
+  truth: evidence
+  plan: plan
+  ideal: ideal
+
+let projection_update = call render-projection
+  truth: evidence
+  plan: plan
+  ideal: ideal
+  deltas: deltas
+
+return projection_update
+```
+```
+
+`observe-ground-truth` and `render-projection` carry `persist: project` with a
+`### Memory` ledger storing `last_observation_identity`, `as_of`, and
+`pinned_plan_revision` — the current stand-in for content-addressed receipts
+and the composition edge to the plan. `judge-materiality` is the variable-depth
+judge: cheap identity-diff by default, `### Shape` delegating to a critic only
+when uncertain. `render-projection`'s `### Constraints` forbids any write
+outside the six artifacts — the authored expression of the amputated
+fulfillment arm.
+
+### Anti-patterns
+
+Each is the natural non-Reactor instinct and why it breaks an invariant:
+
+- **Writing a `kind: system` first and a responsibility as an afterthought.**
+  Inverts the model; the system becomes the source of intent (breaks
+  invariant 1).
+- **A fulfillment system with a `loop until done` that waits for events
+  in-session.** That is a long-running agent loop, not bounded activations
+  (breaks invariant 4).
+- **A sense service that returns the observation but no content identity.**
+  The harness cannot memoize; cost scales with time (breaks invariant 5). This
+  is the most common and most expensive mistake.
+- **A contract whose only "did anything change" test is the full judgment,
+  written as if it memoizes.** Not an invariant-5 _correctness_ break (forecast
+  still makes it safe) but a false cost claim. The Reactor-native form names
+  the absence of a cheap identity in `### Continuity` and accepts
+  forecast-cadence cost deliberately — exactly as projection-only is a
+  deliberate amputation, not a degenerate Reactor.
+- **Hard-coding cadence/hysteresis/escalation as imperative ProseScript.**
+  Steals policy from the model-authored, compiled layer (breaks invariant 2).
+- **An unconditional ensemble in `### Execution`.** Fixed-depth judging;
+  removes the cost lever (breaks invariant 5).
+- **Consuming another responsibility's value by copying it into the contract.**
+  Not a verifiable, revision-pinned reference; a supply-chain hole (breaks
+  invariants 6/7).
+- **"Swarm of subagents that continuously watches."** The cron-plus-prompt
+  shape the Reactor replaces. The Reactor-native form is: events wake a cheap
+  judge; the swarm is the gated deep path, not the steady state.
+
+### Precedence for authors
+
+When authoring rules tension, follow the harness precedence stack:
+
+```text
+correctness  >  safety  >  cost  >  interrupt-minimization
+```
+
+If a decidable, safe contract requires more interrupts during authoring,
+accept the interrupts. If making a contract cheaper would make it unsafe (a
+shallow judge on a high-stakes goal), pay the cost. Silence is a target, never
+a constraint the other rules bend around.
+
+---
+
+## II. Current — What the Runtime Realizes at v0.1
+
+This section is a code-grounded audit of `openprose/prose` `main`
+(`0.1.0`, tag `reactor-v0.1.0`, packages `@openprose/reactor` and
+`@openprose/reactor-cradle`).
+It states which elements of Part I's pattern the runtime actually realizes,
+and how. It is mechanically re-derivable from the code; treat any drift
+between this section and the code as a bug in this section.
+
+The previous edition of this section assumed a `@openprose/responsibility`
+package backing "both CLI and API." **That package does not exist.** The
+runtime spine that realizes the Reactor shipped instead as
+`@openprose/reactor` (`packages/reactor/`), with a deterministic test and
+evidence harness `@openprose/reactor-cradle` (`packages/reactor-cradle/`).
+Both are published stable OSS packages at `0.1.0`.
+
+### What "the skill" vs "the runtime" means here
+
+Part I is an authoring pattern: it concerns what an author writes in
+`*.prose.md`. The headline finding holds and is unchanged — **the
+Reactor-native pattern requires no new syntax.** Every section, kind, and
+keyword Part I uses is existing OpenProse surface; `01-Language.md`'s Current
+section is the authority on the authoring surface and is not re-audited here.
+
+What this section audits is the other half: the **harness runtime** that the
+pattern is written _toward_. Part I's promised payoffs — provable quiescence,
+forecast-manufactured rechecks, memoization, variable-depth judging, verifiable
+composition — are runtime mechanisms. `@openprose/reactor` is the package that
+realizes them. The audit below reports how far it has gone.
+
+### The runtime spine, by Part I element
+
+| Pattern element (Part I) | Realized at v0.1? | Where, and how |
+| --- | --- | --- |
+| The canonical loop — ingest → judge → receipt | **Yes** | `packages/reactor/src/reactor/index.ts` `createRuntimeReactorV0` exposes `ingest`/`tick`/`receipts`/`registry`. `ingestTypedTurn` runs the loop: select planned evidence → check memo → run the shallow judge → append a content-hashed `judge` receipt. |
+| Three turn kinds — real input, forecast recheck, escalation | **Yes** | `ReactorRealInputTurnV0`, `ReactorForecastRecheckTurnV0`, `ReactorEscalationTurnV0` (`reactor/index.ts`). Escalation turns produce `blocked-escalation-receipt`s; the scheduler manufactures `forecast-recheck` turns. |
+| Quiescence — unchanged input short-circuits before the expensive judge | **Yes (memo-hit)** | `ingestTypedTurn` computes a memo key (`computeMemoKeyV0`, `packages/reactor/src/memo/`) over contract revision + evidence content hashes + dependency memo refs. On a reusable match it appends a `memo-hit-receipt` and **never invokes the judge** — zero model tokens. Exercised end-to-end by the cost thesis (see below). |
+| Memoization — content-addressed verdict reuse | **Yes** | `memo/index.ts`: `InMemoryMemoStoreV0`, `createMemoHitReceiptV0`, `createMemoizedVerdictEntryV0`. The runtime memoizes on a stable content identity supplied as evidence `content_hash` — the author-side "stable content identity" obligation of Rule 5 has a real consumer. |
+| Forecast — manufactured rechecks when the world is silent | **Yes** | `packages/reactor/src/forecast/index.ts` `evaluateForecastScheduleV0` computes due rechecks; `reactor/index.ts` `tickRuntimeScheduler` drives them. Two recheck kinds exist: `evidence-age` and `plan-age`. `plan-age` is the runtime form of Rule 5's plan-audit horizon. |
+| The shallow judge — coarse status + confidence | **Yes** | `packages/reactor/src/judge/index.ts` `runShallowJudgeV0` invokes the model-gateway adapter and returns one of the four statuses (`up`/`drifting`/`down`/`blocked`) plus a `ReceiptConfidenceV0`. `blocked` carries `reason`/`fix_target`/`interrupt_cause` — the Rule-3 undecidable-as-`blocked` doctrine is the receipt schema's actual shape. |
+| Variable-depth judging — escalate to an ensemble on uncertainty | **No (stub)** | `runShallowJudgeV0` accepts `depth: "shallow" \| "ensemble"`, but `depth === "ensemble"` **throws `not-implemented-in-v0.1`**. The runtime performs shallow judging only. Cradle carries one live-recorded ensemble-spread cassette (`spikes/k1-ensemble-spread.ts`) as recorded evidence, not a live runtime path. |
+| Receipts — content-addressed, verifiable | **Yes** | `packages/reactor/src/receipt/index.ts`: `openprose.receipt v0`, `createReceiptV0`, `verifyReceiptV0`, canonical sha256 hashing, `inspectReceiptProofV0`. Receipt roles are `judge \| fulfill \| summarize \| policy-compile`. |
+| Fulfillment — the world-mutating commit beat | **No (role only)** | `fulfill` exists as a `ReceiptRoleV0` enum value and as a kernel `KERNEL_MAY_NEVER` prohibition ("mutate the world or perform fulfillment side effects" — `kernel/index.ts`). There is **no fulfillment executor** in the runtime: the runtime produces judge/forecast/memo/escalation receipts, not world-mutating effects. The full-Reactor "send the email" arm is not yet a runtime path. |
+| Projection — owner / subscriber / public tiers | **Yes** | `packages/reactor/src/projection/index.ts`: `projectReceiptV0`, `projectReceiptProofV0`, tiers `owner`/`subscriber`/`public`. This realizes the privacy-as-failure-mode safeguard at the receipt level. |
+| Composition — consuming an upstream trail, revision-/signer-pinned | **Yes (verification), partial (signing)** | `packages/reactor/src/composition/index.ts`: `verifyUpstreamReceiptDependencyPinV0`, `evaluateTransitiveFreshnessV0`, `planCompositionPropagationV0`, `computeDownstreamComposedMemoKeyV0`. `ingestTypedTurn` verifies dependency receipts and runs `detectReceiptCycles` (`kernel/index.ts`), blocking on a cycle. Pins verify against contract revision and signer posture. The signer itself is the **null signer** (`createNullSignerReceiptSignatureV0`) — `{ scheme: "none" }` — so cross-trust-domain cryptographic signing is not yet real. |
+| The kernel — fixed-circuit safety, backstops, rollback | **Yes** | `packages/reactor/src/kernel/index.ts`: `evaluatePredicate`, `evaluateBackstops`, `compareRollback`, `detectReceiptCycles`, `createKernelSafetyReceipt`, plus `KERNEL_BACKSTOPS` and the 14-item `KERNEL_MAY_NEVER` list. Predicate-tripped reconciliation has a real, deterministic kernel. |
+| Policy — model-authored, compiled, recompiled, rolled back | **Yes in the package runtime; host adapters vary** | `packages/reactor/src/policy/index.ts` (≈2.6k lines): `authorPolicyArtifactV0`, `validatePolicyArtifactV0`, `planPolicyRecompileV0`, `executePolicyRecompileV0`, `planPolicyRollbackV0`. `tickRuntimeScheduler` runs the policy loop after a tick (`planAndMaybeExecutePolicyRecompileAfterTick`). The **two compiles** — the contract compile and the policy recompile — are both present in the package runtime: policy is authored by the agent-SDK adapter, validated by a kernel artifact validator, recompiled on drift, and rolled back on self-trip. The CLI serve adapter still uses a deterministic cold-start seed, so this row is runtime-realized but not fully exposed by every host. |
+| Cost accounting — flat spend under a static world | **Yes** | `packages/reactor/src/cost/index.ts`: `validateReceiptSurpriseAttributionV0`, `evaluateFlatSpendUnderStaticV0`, token-truth checks. Every receipt carries a `cost` block with `tokens.fresh`/`tokens.reused`. |
+| State export / exit — replayable, portable | **Yes (partial)** | `packages/reactor/src/sdk/exit-bundle.ts` + `importReactorExitBundleV0`: the SDK can export and re-import an exit bundle. This is the runtime form of invariant 8; it is a first export surface, not a full cross-harness migration tool. |
+
+### The cost thesis is measured, not asserted
+
+Part I's whole economic claim — "cost scales with surprise, not time" — has a
+runnable, package-backed demonstration. The `flat-tokens` example
+(`skills/open-prose/examples/flat-tokens`, driven from packed tarballs) runs
+four `createReactor().ingest()` turns against a static world and prints
+`tokens.fresh=46`, `tokens.reused=46`, `ratio=46:46`: after the first real
+judge, identical input yields memo-hit receipts at zero fresh tokens. The
+Cradle C5 summary contrasts this with two same-unit deterministic controls — a
+no-memo control at `92:0` and a naive-loop control at `92:0`
+(`packages/reactor-cradle/src/baselines/`). The memoization arm of Rule 5 is
+not a promise; it is observed.
+
+### What the Cradle exercises
+
+`@openprose/reactor-cradle` is the deterministic test harness, not a second
+runtime. It carries 121 tests, including roughly ten labelled integration
+scenarios (`packages/reactor-cradle/src/__tests__/`): `b1` scheduler tick,
+`b2` auto-recompile, `b3` auto-rollback, `b4` cycle detection, `b7` transitive
+freshness, `c2` hands-free, `c5` event-changing cost thesis, `e1`/`e2`
+composition, `w7` static-cost. `@openprose/reactor` itself carries 155 unit
+tests across receipt, kernel, memo, forecast, composition, policy, projection,
+judge, cost, and the reactor loop. The canonical loop, quiescence, forecast,
+the kernel, policy recompile/rollback, and composition all have integration
+coverage; ensemble judging and fulfillment do not, because they are not
+implemented.
+
+### The pattern's authoring rules against the runtime
+
+Part I states each rule as an unqualified north star. This is where authoring
+reality is honest: every rule is **writable today** (no syntax is missing),
+but several lean on runtime mechanisms whose realization is partial.
+
+| Authoring rule | Writable? | Runtime backing at v0.1 |
+| --- | --- | --- |
+| 1. Intent lives in the responsibility | Yes | Fully supported; an authoring concern, no runtime dependency. |
+| 2. Policy stated semantically, not as ProseScript | Yes | The author writes intent in `### Continuity`/`### Constraints`; the model-authored policy compile/recompile/rollback loop is **real** in `policy/index.ts` and runs after each tick. The author's semantic statement has a live consumer. |
+| 3. No host-specific contract logic | Yes | `### Tools`/`### Environment` are name-only by design; the runtime is adapter-injected (`ReactorAdaptersV0`, `sdk/index.ts`) with no hidden defaults. |
+| 4. Bounded activations | Yes | Idiomatic; `ingest`/`tick` are bounded turns by construction. The anti-pattern is author error, not a runtime gap. |
+| 5. Written for memoization / variable depth | Partial | The memoization half is **real and measured** (memo-hit path, cost thesis). The variable-depth half is **not** — `ensemble` depth throws `not-implemented-in-v0.1`. An author who gates a deep path in `### Execution` is writing forward-compatible intent the runtime does not yet execute. |
+| 6. Composition via referenced upstream trail | Partial | Dependency-receipt verification, transitive freshness, cycle detection, and composed memo keys are all real (`composition/index.ts`). Cryptographic signing is **null-signer only** — pin the revision now; cross-trust-domain signing awaits a non-null signer adapter. |
+| 7. Ledger as receipt/audit/exit unit | Partial | The receipt schema (`openprose.receipt v0`) is real, content-addressed, verifiable, and projectable. `as_of`, `next_forecast_recheck`, and content-addressing are runtime fields, not hand conventions. Exit-bundle export/import exists but is a first surface. |
+| 8. Replayable and exitable | Partial | The runtime is deterministic and replay-tested (Cradle replay/parity suites); `exit-bundle.ts` exports and re-imports state. A full cross-harness migration surface is not yet built. |
+
+### Honest current limits for authors
+
+- **No fulfillment executor.** The runtime judges and records; it does not yet
+  mutate the world. The full-Reactor shape from Rule 4 is authorable but its
+  commit beat is not a runtime path at v0.1. The **projection-only Reactor**
+  shape is the one whose every component (sense → judge → receipt → projection)
+  has runtime backing — it is, today, the most fully realized Reactor shape.
+- **Variable-depth judging is a stub.** `depth: "ensemble"` throws. Gate the
+  deep path in `### Execution` for forward compatibility, but expect the
+  runtime to take the shallow branch until ensemble judging ships.
+- **File-watch gateways are not in live serve.** Serve supports cron and HTTP
+  ingress; queues, file watches, and provider subscriptions are later phases.
+  The worktree/planning-dir example must use a forecast-paced `### Schedule`
+  today and note the intended file-watch form.
+- **Composition is verified but null-signed.** Dependency-receipt verification,
+  revision pinning, transitive freshness, and cycle detection are real;
+  cryptographic signing is the null signer (`{ scheme: "none" }`). Pin the
+  revision in `### Criteria` now; cross-trust-domain composition awaits a
+  non-null signer adapter.
+- **The CLI path is local and deterministic.** It proves package/CLI
+  integration, receipt production, and projection — not production ingress or
+  hosted fulfillment quality.
+
+> The pattern is fully writable today. Its memoization, forecast, kernel,
+> policy-loop, composition-verification, projection, and receipt payoffs are
+> **realized in `@openprose/reactor` v0.1** and, for the cost thesis,
+> measured. Its variable-depth and world-mutating-fulfillment payoffs are
+> **not yet runtime paths**. Author to the ideal; do not claim the runtime
+> already reaches what this section marks "No" or "Partial."
+
+---
+
+## III. Roadmap — The Delta
+
+`Ideal − Current = Roadmap`. The gap is of two kinds: **documentation and
+doctrine changes** to the OpenProse skill that make the Reactor-native pattern
+the taught default, and **runtime work** in `openprose/prose` that closes the
+"No"/"Partial" rows of the Current audit. Neither changes OpenProse syntax.
+
+### A. Skill documentation and doctrine
+
+These make the Reactor-native pattern the _taught default_ rather than an
+advanced corner.
+
+1. **Invert the Mental Model in `01-Language.md`.** The "Mental Model" section
+   lists Responsibility Runtime last, as a continuity addendum to a
+   system-centric model. Rewrite it responsibility-first: the responsibility
+   is the program; the gateway is ingress; the system is one beat of the loop;
+   Forme/VM/ProseScript are the substrate. Keep the system-centric model as the
+   bounded-work special case, explicitly labeled as the N=0 (no continuity)
+   case of the Reactor base case.
+2. **Reframe the "Directly runnable?" table.** Add a column or footnote
+   distinguishing _run_ (bounded) from _serve_ (reconciled). State plainly that
+   `kind: responsibility` being "not directly runnable" means "continuously
+   reconciled" and is the **intended top-level authored object** for any
+   standing goal — not a lesser artifact.
+3. **Add Reactor-native routing to `SKILL.md`.** "First 90 Seconds" routes
+   "Run a `.prose.md` service or system" as the default and Responsibility
+   Runtime as a specialist path. Add a recognition signal — "make sure X stays
+   true," "keep Y current," "watch Z and maintain a view" → **author a
+   responsibility + gateway first**, derive the system second — and a
+   first-class route that loads `responsibility-runtime.md` and this pattern
+   before `forme.md`/`prose.md`, not after.
+4. **Promote the authoring rules into `guidance/authoring.md`.** Add a
+   "Reactor-Native Authoring" section porting Part I's eight rules as a
+   checklist, with the memoization rule (Rule 5) called out as the one authors
+   most often violate, and the sense-service-must-emit-a-content-identity
+   requirement stated as a lint-able expectation.
+5. **Strengthen `### Continuity` / `### Criteria` doctrine in
+   `contract-markdown.md`.** State that `### Continuity` is the author's input
+   to forecast and memoization (name the freshness referents and the
+   memo-breaking condition; make "nothing changed" cheaply observable) and that
+   `### Criteria` must use observable referents, with "undecidable" framed as
+   an expected, high-value `blocked` reason routed to the author — never an
+   enum.
+6. **Add a canonical Reactor-native example.** The examples set demonstrates
+   full Reactors (stargazer, incident, compliance). Add a **projection-only**
+   example — an observe-but-never-touch overseer like the three-layer
+   Codex-build overseer — to teach the amputated-fulfillment shape, the
+   composition-via-ledger edge, and the forecast-paced-schedule-as-file-watch
+   stand-in. It is the clearest teaching case for "cost scales with surprise,
+   not the watched system's activity," and — per the Current audit — the
+   Reactor shape whose every component already has runtime backing.
+7. **Document the projection-only Reactor as a first-class shape.** Both
+   `responsibility-runtime.md` and `concepts/reactor.md` should name
+   projection-only (judge + projection, no fulfillment) as a deliberate,
+   supported shape with its own `### Constraints` idiom, not an incomplete
+   Reactor. It is a recurring real use case (audits, overseers, dashboards),
+   currently undocumented, and — because the runtime has no fulfillment
+   executor yet — the most fully realized Reactor shape at v0.1.
+
+#### Definition of done for the authoring layer
+
+- `01-Language.md` Mental Model is responsibility-first; the runnable table no
+  longer implies responsibilities are lesser artifacts.
+- `SKILL.md` routes standing-goal language to responsibility authoring before
+  system wiring.
+- `guidance/authoring.md` carries the eight Reactor-native rules as a
+  checklist, with the content-identity requirement explicit.
+- `contract-markdown.md` documents `### Continuity` as forecast/memo input and
+  `### Criteria` decidability with the undecidable-`blocked` doctrine.
+- A projection-only example ships and runs from a fresh clone.
+- Every Part I rule that the Current audit marks "Partial"/"No" is
+  cross-referenced to the runtime audit so authors are never told the runtime
+  delivers what it does not.
+
+### B. Runtime work — closing the Current audit's gaps
+
+These items bridge the runtime from its v0.1 state to Part I. They are the
+substantive "No"/"Partial" rows of Section II.
+
+1. **Variable-depth ensemble judging.** `runShallowJudgeV0` rejects
+   `depth: "ensemble"` with `not-implemented-in-v0.1`. The runtime must gain a
+   real ensemble path so the confidence-gated deep branch authors write in
+   `### Execution` actually executes. Cradle's K1 ensemble-spread cassette is
+   the recorded-evidence precursor.
+2. **A fulfillment executor.** `fulfill` is a receipt role and a kernel
+   prohibition, not a runtime path. The full-Reactor commit beat — the bounded,
+   `### Constraints`-governed world-mutation step — must be built before the
+   "send the email" shape is more than authorable.
+3. **A non-null signer adapter.** Composition verification is real but signed
+   with the null signer (`{ scheme: "none" }`). Cross-trust-domain
+   composition — Rule 6's acceptable-signer-set pinning — needs a real signer
+   adapter to be cryptographically meaningful rather than revision-pinned only.
+4. **File-watch and richer gateway ingress.** Live serve is cron + HTTP;
+   queues, file watches, and provider subscriptions are later phases. Until
+   then the worktree/planning-dir pattern uses a forecast-paced `### Schedule`.
+5. **A first-class export/exit and cross-harness migration surface.**
+   `exit-bundle.ts` exports and re-imports state; invariant 8's full promise —
+   carry the contract and its trail to another harness — needs a hardened
+   migration surface.
+6. **Postgres parity.** Cradle release parity exercises memory and filesystem
+   storage rows; Postgres is marked future.
+
+### C. Open authoring items
+
+Deferred by design, tracked so they are neither invented nor dropped:
+
+1. **Content-identity convention.** The *existence* of the obligation is stated
+   in [01-Language.md](./01-Language.md) Part I (a sense service may return a
+   stable content identity as an `### Ensures` output) and now has a real
+   runtime consumer (the memo key is computed over evidence content hashes).
+   Only the *convention* — the exact shape of the identity (hash of what,
+   normalized how) — is deferred here, pending the harness receipt-schema
+   research (harness open item I.1).
+2. **Composition reference syntax — resolved.** "B depends on A" is authored as
+   a reserved `responsibility` typed-input in `### Requires` (the same
+   mechanism as `run`/`run[]`), pinning upstream id-or-path + contract
+   revision + acceptable signer set; see [01-Language.md](./01-Language.md)
+   Part III §3. Kernel-verifiable, not a Forme edge. The prose-ledger reference
+   is the pre-receipt-schema stand-in until the receipt `composition` block
+   lands — and the runtime's `composition/index.ts` is the consumer of that
+   block once it does.
+3. **Policy-shape vocabulary.** How an author states hysteresis _shape_ ("this
+   signal is noisy → widen the band") — and, equally, upstream freshness
+   tolerance ("A may be one business day stale") — semantically, in a way the
+   model-authored policy compile can consume, is principle-only (harness open
+   item I.4). The policy compile that would consume it is real
+   (`policy/index.ts`); the author-facing vocabulary is not yet specified.
+4. **Projection-tier authoring.** Owner / subscriber / public projection
+   contracts (the privacy-as-failure-mode safeguard) have no authoring section
+   yet; the runtime tiers exist (`projection/index.ts`) but contract-level
+   authoring of them is ad hoc per fulfillment system.
+
+> `02-ReactorHarness.md` says what the machine must do.
+> `03-ReactorPattern.md` says what to write so it does it. The pattern is
+> fully writable now; its memoization, forecast, kernel, policy-loop,
+> composition-verification, and projection payoffs are realized in
+> `@openprose/reactor` v0.1 today. Its variable-depth and fulfillment payoffs
+> are roadmap. Author to the ideal, document the climb honestly.

--- a/spec/04-Evals.md
+++ b/spec/04-Evals.md
@@ -1,0 +1,483 @@
+# OpenProse Reactor Evals
+
+###### How to prove a Reactor-class harness's category claim survives a hostile expert.
+
+The OpenProse corpus divides labor exactly, and each document maps to what
+ships:
+
+- [01-Language.md](./01-Language.md) — **the Language & Framework**, bundled as
+  the **SKILL**: syntax, kinds, sections, compile model, std/co, CLI surface.
+- [02-ReactorHarness.md](./02-ReactorHarness.md) — **the Reactor Harness**,
+  bundled as the **CLI/Server**: the runtime control architecture (loop,
+  invariants, kernel, memoization, forecast, receipts, composition). It answers
+  _what the runtime must do_.
+- [03-ReactorPattern.md](./03-ReactorPattern.md) — **the Reactor-Native
+  Authoring Pattern**: how to write `*.prose.md` so the harness's mechanisms
+  engage.
+- [04-Evals.md](./04-Evals.md) — **this document, the evaluation methodology**,
+  **not shipped as runtime**: it travels with the technical report. It answers
+  _how we prove 02's claims are true, to a reader who is paid to say they are
+  false_. It is to 02 what a measurement protocol is to a physical theory.
+- [00-Tenets.md](./00-Tenets.md) — **the constitution**; when the system is in
+  tension with a tenet, the tenet wins.
+
+This document is structured in three parts, mirroring its siblings:
+
+- **Ideal** — the evaluation suite as it *should* be: the full required
+  evaluation methodology and its required suite of evals. This is the authored
+  vision. It is frozen.
+- **Current** — a code-grounded snapshot of what the deterministic evaluation
+  apparatus *actually is* today: the `@openprose/reactor-cradle` v0.1 package,
+  with real module paths, real scenario IDs, and real test counts.
+- **Roadmap (Delta)** — the honest gap: which named evals are not yet built,
+  and what bridges Current → Ideal.
+
+`Ideal − Current = Roadmap`. The three are kept distinct so this document can
+never again claim shipped what is not.
+
+---
+
+## I. Ideal — The Ideal Evaluation
+
+### What an eval suite for a category claim actually is
+
+It is not a test suite. Tests answer "did the code do what we built it to do."
+This instrument answers a harder question: **"is the category real, and is it
+ours?"** — asked by a reader who is paid to say no. Every design choice below
+is the answer to one question asked of the suite: _what would a hostile expert
+need to see before they could no longer dismiss the claim?_ The eval is an
+instrument of adversarial persuasion; its credibility is the strength of the
+strongest baseline it beats, not the number of tests it passes.
+
+### The only two claims that matter
+
+The technical report makes exactly two load-bearing claims. The suite exists
+to make each _difficult to dismiss_, and to **state precisely where each
+fails** — a claim with no stated failure boundary reads as marketing:
+
+- **Claim A — "Reactor is better."** Not better in general — better at the one
+  thing the architecture exists for: _maintaining truth under evented change at
+  a cost that scales with surprise rather than wall-clock time, while failing
+  safe._ This is not one claim; it is a small set of per-mechanism falsifiable
+  sub-claims (below), each of which could have come out the other way.
+- **Claim B — "Model X is better than Model Y _for Reactor_."** The
+  first-principles reframe that makes this useful rather than a leaderboard:
+  the result is **role-conditional fit**, not a ranking. The defensible,
+  report-grade findings are (i) which model is the best _judge_ (status
+  accuracy + calibration), which the best _fulfiller_ (restoration without
+  overreach), which the safest _cheap_ model once calibration is earned; and
+  (ii) **where the architecture compensates for a weaker model** — if the
+  harness narrows the gap between a cheap and a frontier model, that _is_ the
+  architectural value proposition restated in model terms, and it is the single
+  most valuable Claim-B result.
+
+### The eval invariants
+
+Each survives the negation test: drop it and a hostile reviewer wins.
+
+1. **Decidability over judgment.** Every headline number is the output of a
+   deterministic predicate over a content-addressed artifact — the
+   `openprose.receipt v0` log (02). **No headline claim may rest on an LLM
+   grading an LLM.** Output _quality_ ("was the briefing good?") is real but
+   lives in a separate, clearly-labelled, blind-human-adjudicated track that
+   never enters the abstract. This wall — decision-trace correctness vs. output
+   quality — is the single biggest credibility lever and the methodology's
+   keystone.
+2. **The adversary is the strongest cheap thing, not a strawman.** Beating a
+   naive single-agent loop proves nothing. The load-bearing baseline is the one
+   that is _cheap **and** correct_ in the regime under claim: a strong
+   content-diff-plus-embedding cache, and an **oracle-optimally-scheduled
+   cron**. The non-obvious, empirically-confirmed point: on the silent-drift
+   headline regime a content cache is **blind by construction**, so beating it
+   there demonstrates nothing — the honest comparator is the oracle cron, and
+   the real claim is _"Reactor's learned forecast approaches an oracle schedule
+   it was never given."_ A strong cheap baseline that ties Reactor on a regime
+   is reported as a tie **in the abstract**.
+3. **The cost claim is a preregistered falsifiable hypothesis with an explicit
+   null.** "For every token, name the surprise" is operationalized as a
+   regression of spend on preregistered surprise-count against the null that
+   spend tracks wall-clock / event-count, with the surprise labels frozen and
+   content-hashed _before any run_ and the decision rule fixed _before any
+   data_. A graph is not a result; a hypothesis that could have failed is.
+4. **Preregistration, and the abstract carries its own losses.** Persuasive
+   power is inversely proportional to what the report hides. The surprise
+   labels, statistical decision rule, baseline set, and model matrix are
+   committed (hashed) before runs; ties and losses appear in the abstract with
+   the same prominence as wins. A reviewer cannot allege fishing when the
+   analysis plan predates the data and the failures are stated up front.
+5. **Honest cost-confidence.** Token-truth is local and deterministic; any
+   normalized or dollar figure is **provider-reconciled or it is explicitly not
+   report-grade** — a hard-won empirical lesson: the provider generation
+   endpoint is latency-bound, and response-usage is not reconciled usage. Every
+   cost figure carries its confidence tier.
+6. **Boundaries are measured, not hidden.** The architecture has structurally
+   irreducible costs (the plan-audit floor; the no-cheap-hash domain; the
+   no-anchor calibration tax — 02 _Where it excels_). An eval that only shows
+   the favorable regime is not report-grade. The instrument must **quantify the
+   boundary**: where cost-scales-with-surprise degrades to forecast cadence,
+   and by how much. Stating the boundary precisely is what makes the central
+   claim believable.
+7. **The eval is itself replayable and exitable.** The suite that proves the
+   receipt invariants must obey them: fixtures content-addressed, model
+   snapshots pinned, a snapshot roll **voids** (never patches) the run, the
+   whole thing reproducible by a skeptic from a fresh clone. The replay engine
+   runs against the recorded receipt artifact and never re-derives it.
+8. **Two truth oracles, never merged** (mirrors 02's failure model):
+   correctness-truth ("was the verdict right") and cost-truth ("what did it
+   cost") are different sockets with different failure meanings; a cost result
+   may never launder into a correctness result or vice versa.
+9. **The suite mirrors the unification recursions, not a feature list.** Per
+   02's thesis, composition-amortization and policy-recompile-stability are the
+   N>1 and policy-over-time recursions of the _same_ memoization mechanism. The
+   suite is structured so the report says "one mechanism, three
+   demonstrations," not "twelve features."
+
+### Claim A, decomposed
+
+Each sub-claim ships with a one-sentence statement and explicit null, its
+strongest cheap adversary, a deterministic verdict predicate, and a
+preregistered decision rule.
+
+| Sub-claim | Strongest cheap adversary | Decided by |
+| --- | --- | --- |
+| Cost scales with surprise, not time | oracle-cron + strong diff/embedding cache | regression vs. null over a content-hashed receipt log |
+| Memoized reuse spends zero judge tokens | Reactor-without-memoization | `tokens.reused` is judge-free in the receipt; pure predicate |
+| Forecast catches silent drift a cache cannot | content cache (blind here, by construction) | injected silent drift; detection vs. oracle-cron at matched cost |
+| Variable-depth preserves accuracy at lower cost | fixed-ensemble Reactor | accuracy delta ≈ 0 with cost delta < 0, preregistered band |
+| Fail-safe interrupt precision | cron + prompt with durable state | typed-interrupt confusion matrix vs. oracle labels |
+| Receipts replay; composition amortizes; supply-chain pins | Reactor-without-receipts / islands | clean-machine replay equality; N-dependent cost amortization; rejection of unpinned upstream |
+
+### Claim B, decomposed
+
+Run **both adapter seams** (the bounded-activation agent SDK and the
+model-gateway socket — 02 _Architecture_) so the seam boundary stays honest and
+the policy-author migration path is exercised, not assumed. Report role-fit and
+**Reactor-compensation curves** (cheap-vs-frontier gap with and without each
+mechanism), never a single quality ranking.
+
+---
+
+## II. Current — What the Apparatus Actually Is
+
+Audited 2026-05-21 against `openprose/prose` `main` at HEAD `52724ed`. The
+deterministic evaluation apparatus is the **`@openprose/reactor-cradle`**
+package, version **`0.1.0`**, at
+`packages/reactor-cradle/`. It is published on npm and depends on
+`@openprose/reactor` `workspace:0.1.0`. Its test suite is
+**121 tests, 0 failures** (`pnpm --filter @openprose/reactor-cradle test`;
+`node --test` over the built `dist/`).
+
+What this section reports is true and narrow: **the Cradle is the deterministic
+test-and-evidence harness for the local Reactor package — not the full
+report-grade evaluation suite derived in Section III.** It carries deterministic scenarios, baselines,
+spikes, and release-evidence helpers. It does not run a live provider/model
+matrix, has no preregistered statistical track, and is not the report
+apparatus. The Cradle is the deterministic floor that ships at v0.1.
+
+### What the Cradle is
+
+> "`@openprose/reactor-cradle` is the deterministic test harness for the local
+> OpenProse Reactor package. It is where Reactor behavior is replayed,
+> compared, projected, and packaged into release evidence without requiring
+> live services for the normal test path."
+> — `packages/reactor-cradle/README.md`
+
+It is explicitly **a test and evidence package, not the production Reactor
+runtime**, and not the report-grade eval harness of Section I.
+
+### Deterministic scenarios — what ships and is replayable
+
+The Cradle drives real `@openprose/reactor` behavior under deterministic
+doubles (a virtual clock, in-memory and filesystem storage, a recorded
+model-gateway). Scenarios are integration tests under
+`packages/reactor-cradle/src/__tests__/`, each a single `node:test` case:
+
+| Scenario | File | What it deterministically exercises |
+| --- | --- | --- |
+| **W7** static cost | `w7-static-cost.integration.test.ts` | Static-world Cradle run; composes Reactor cost helpers; flat-spend under a static world. |
+| **C2** hands-free | `c2-hands-free.integration.test.ts` | Static `incident-briefing-static-zero` scenario over a local replay cassette (`fixtures/c2-static-zero.scenario` + `.model-cassette.json`); 4 test cases. |
+| **C5** event-changing | `c5-event-changing.integration.test.ts` | Periodic-surprise scenario producing event-changing receipts with no network (`fixtures/c5-periodic-surprise.scenario`). |
+| **B1** scheduler tick | `b1-scheduler-tick.integration.test.ts` | Scheduler sleeps before due time and writes a forecast receipt at due time. |
+| **B2** auto-recompile | `b2-auto-recompile.integration.test.ts` | Tick auto-recompiles on drift; delays the same evidence inside the min interval. |
+| **B3** auto-rollback | `b3-auto-rollback.integration.test.ts` | Tick rolls back a freshly authored self-tripping policy. |
+| **B4** cycle detection | `b4-cycle-detection.integration.test.ts` | Ingest blocks an A→B→A dependency receipt graph before any model-gateway call. |
+| **B7** transitive freshness | `b7-transitive-freshness.integration.test.ts` | An authored transitive-freshness function changes a downstream freshness verdict. |
+| **E1** composition | `e1-composition.integration.test.ts` | Composes A/B/C through receipt pins; stops downstream on memo hits. |
+| **E2** composition | `e2-composition.integration.test.ts` | Enforces supply-chain pins, transitive freshness, and fork/exit carry-over. |
+
+Scenario parsing, the runner, and time handling are real modules
+(`src/scenario/parser.ts`, `src/scenario/runner.ts`, `src/scenario/time.ts`,
+`src/scenario/types.ts`). The world model supports three profiles —
+`static`, `periodic-surprise`, `adversarial-silent`
+(`src/world/synthetic-world.ts`); `adversarial-silent` is defined and tested as
+"typed but fail-closed" — it does not yet drive a full silent-drift detection
+eval.
+
+### Baselines — the controls that ship
+
+Three baseline controls live under `packages/reactor-cradle/src/baselines/`,
+all deterministic, all exported from the package root:
+
+- **`no-memo`** (`baselines/no-memo/index.ts`) — ablation of the W7 static run:
+  re-derives the Reactor receipt schedule with memo credit disabled, charging
+  every token-bearing receipt's total as fresh judge work. Schema
+  `openprose.reactor-cradle.baseline.no-memo-summary`.
+- **`naive-loop`** (`baselines/naive-loop/index.ts`) — a non-Reactor control
+  with no receipts, memo keys, forecast policy, or reusable verdict
+  architecture; every review turn re-prompts at the recorded cassette's per-turn
+  token charge. Schema `openprose.reactor-cradle.baseline.naive-loop.summary`.
+- **`cost-thesis`** (`baselines/cost-thesis/index.ts`) — assembles the static
+  and event-changing comparison rows from the Reactor run plus the two controls.
+  Schema `openprose.reactor-cradle.baseline.cost-thesis.summary`.
+
+This is the apparatus behind the headline v0.1 number. The packaged
+`flat-tokens` example drives four real `createReactor().ingest()` turns and
+prints **`tokens.fresh=46`, `tokens.reused=46`, `ratio=46:46`**; the C5 summary
+compares that Reactor run with the **no-memo control (`92:0`)** and the
+**naive-loop control (`92:0`)**.
+
+**Honest boundary of the cost thesis as it ships:** of the three rows, **only
+the Reactor row is runtime-produced**. The cost-thesis module labels each row's
+provenance explicitly — `runtime-produced`, `simulated` (no-memo), `control`
+(naive-loop) — and its own notes state "Only the Reactor row is
+runtime-produced." The comparison is a deterministic three-way control
+contrast over one runtime receipt schedule. It is **not** the preregistered
+spend-vs-surprise regression with a frozen null of Section I, invariant 3 / A1.
+There is no statistical decision rule, no preregistered surprise-label freeze,
+and no oracle-cron adversary in the package.
+
+### Assertion families — the deterministic predicates
+
+`packages/reactor-cradle/src/assert/index.ts` defines five assertion families,
+each a deterministic predicate over a scenario run or receipt log:
+
+- `static-surprise-zero` — static-world surprise stays at zero across the trace.
+- `surprise-attribution-complete` — every token-bearing receipt/model payload
+  names a valid surprise cause (`real-input`, `forecast-recheck`,
+  `escalation`).
+- `flat-spend-under-static` — post-bootstrap static-world fresh spend stays
+  flat, except plan-audit-floor receipts.
+- `no-fixed-interval-work` — forecast-paced runs spend no tokens in
+  virtual-clock gaps before the next scheduled check.
+- `release-parity-fixture` — emitted by the release-parity module (below).
+
+### Replay model gateway and parity
+
+`src/replay/model-gateway.ts` provides recording/replay model-gateway cassettes
+(schema `openprose.reactor.model-gateway-cassette`): the replay gateway
+fails closed on an unexpected or out-of-order request and on cassette
+exhaustion, and returns byte-identical recorded payloads. `src/replay/parity.ts`
+provides a byte-identical comparator and a cross-adapter parity matrix. The
+parity matrix has **three rows**: `deterministic-in-memory` (ready),
+`filesystem` (ready), `postgres` (**`future` — not implemented**). The matrix
+`ok` only when ready rows pass and at least one ran.
+
+### K1 / K2 spikes
+
+Under `packages/reactor-cradle/src/spikes/`:
+
+- **K1 — ensemble spread** (`spikes/k1-ensemble-spread.ts`) — scores a recorded
+  model ensemble against a calibration anchor, with a conjunctive diversity
+  floor (model-family, provider, size-boundary) before spread can be
+  calibrated. Recorded fixtures include a `k1-live-recorded.json` cassette (one
+  live-recorded OpenRouter ensemble).
+- **K2 — policy author** (`spikes/k2-policy-author.ts`) — validates a recorded
+  policy-author artifact's shape and fails closed on off-live-observable facts
+  or a malformed policy.
+- **live-refresh** (`spikes/live-refresh.ts`) — an explicit, opt-in,
+  cap-and-accounting-guarded OpenRouter recording path. By default the normal
+  test path **does not read env or perform any live refresh**; the live path is
+  guarded, key-redacted, and rejects non-default models.
+
+The spikes are **recorded-only by default**. There is one recorded live K1
+cassette; there is **no live provider/model matrix**.
+
+### Release-parity and release-candidate evidence
+
+- **`src/release-parity/index.ts`** — the **R6** recorded release-parity suite,
+  a deterministic fixture floor of **10 represented cases**: `healthy-quiet`,
+  `drifting-schedules-fulfillment`, `blocked-human-review`,
+  `forecast-pulls-judge-earlier`, `hysteresis-prevents-flip-flop`,
+  `duplicate-event-idempotency`, `stale-status-fencing`,
+  `contract-revision-fencing`, `policy-recompile-byte-identical-registry`,
+  `memoized-verdict-zero-fresh-tokens`. Each case carries verified receipts,
+  decisions, and trace evidence; the suite runs the byte-identical replay
+  parity matrix. It explicitly **defers one case — `down-after-budget-exhaustion`**
+  — recording the gap rather than synthesizing a false proof, because the
+  runtime exposes no typed retry-budget or pressure-dispatch primitive.
+- **`src/release-candidate/index.ts`** — the **R7** release-candidate evidence
+  bundle helpers, assembling deterministic Cradle/Reactor smoke and command
+  evidence into a content-hashed bundle and Markdown report.
+
+### Eval result and projections
+
+`src/eval/index.ts` builds a content-hashed `openprose.reactor-cradle.eval-result`
+artifact over assertion and parity outputs, renders it as Markdown, and
+projects it to `owner` / `subscriber` / `public` tiers with secret/PII
+redaction. The model-matrix field is **structurally pinned to `not-run`** — the
+type `CradleEvalModelMatrixStatusV0` is the single literal `"not-run"`, and the
+builder throws if it is anything else. The live model matrix is, by
+construction, deferred.
+
+### Other deterministic modules
+
+`policy-author`, `policy-drift`, `recompile`, `rollback`, `policy-replay`, and
+`provider-parity` are recorded-proof modules (P-series and D-series) exercising
+policy authoring, drift detection, recompile/rollback planning, recorded-artifact
+replay, and a two-provider policy-artifact byte-parity proof — all without live
+agents or gateways.
+
+### Honest status of the Reactor column
+
+The Cradle drives **real `@openprose/reactor` `createReactor().ingest()`** in
+W7/C2 and exercises the receipt, memo, forecast, composition, and kernel
+modules directly. In that narrow sense, a deterministic Reactor result **exists
+today** — the static-world cost thesis is measured and locally runnable.
+
+But the report-grade Reactor column of Section I — the preregistered cost
+regression, the silent-drift detection eval against an oracle cron, the
+variable-depth ensemble result, the live model matrix, the boundary
+quantification, the blind output-quality track — **is not in this package.**
+The Cradle is the deterministic floor; it is what ships at v0.1.
+
+---
+
+## III. Roadmap (Delta) — The Gap to the Ideal
+
+`Ideal − Current`. The Cradle ships the deterministic scenario floor. The
+report-grade Required Evaluation Suite remains to be built. The gap, named:
+
+The named suite below is **derived from the Ideal claim tables and invariants
+above**. It is not additional authored Ideal text; it is the roadmap checklist
+that makes `Ideal − Current` concrete.
+
+- **Claim A — cost & memoization.**
+  - **A1 — Cost-scales-with-surprise.** Preregistered regression of spend on
+    frozen surprise labels against the wall-clock/event-count null, over a
+    content-hashed receipt log, vs. oracle-cron + strong diff/embedding cache.
+  - **A2 — Zero-fresh memoized reuse.** Predicate that memo-hit receipts carry
+    `tokens.fresh = 0`, vs. Reactor-without-memoization.
+  - **A3 — Composition amortization.** N-dependent cost amortization across a
+    composed responsibility graph: one mechanism, the N>1 recursion.
+  - **A4 — Policy-recompile stability.** Recompile produces a byte-identical
+    registry artifact when inputs are unchanged: one mechanism, the
+    policy-over-time recursion.
+- **Claim A — forecast & drift.**
+  - **A5 — Forecast catches silent drift.** Injected silent drift; detection
+    vs. the oracle-cron at matched cost (the content cache is blind here by
+    construction).
+  - **A6 — No fixed-interval work.** Forecast-paced runs spend no tokens in
+    virtual-clock gaps before the next scheduled check.
+  - **A7 — Variable-depth ensemble.** Variable-depth judging preserves accuracy
+    at lower cost than a fixed ensemble, within a preregistered band.
+- **Claim A — fail-safe & supply chain.**
+  - **A8 — Typed-interrupt precision.** Confusion matrix of typed interrupts
+    (`needs-input`, `needs-judgment`, `contract-declared`, …) vs. oracle
+    labels, vs. cron + prompt with durable state.
+  - **A9 — Auto-recompile on drift.** A drift verdict triggers a bounded
+    policy recompile, with a minimum-interval guard.
+  - **A10 — Auto-rollback of a self-tripping policy.** A freshly authored
+    policy that self-trips is rolled back to last-known-good.
+  - **A11 — Cycle / dependency-graph safety.** A cyclic dependency receipt
+    graph is blocked before model spend.
+  - **A12 — Transitive-freshness fencing.** A stale or contract-mismatched
+    upstream receipt is fenced before downstream use.
+  - **A13 — Receipt replay equality.** The receipt log replays byte-identically
+    from a clean clone; a snapshot roll voids the run.
+- **Claim B — role-conditional model fit.**
+  - **B1 — Best-judge.** Status accuracy + calibration per model.
+  - **B2 — Best-fulfiller.** Restoration without overreach per model.
+  - **B3 — Safest-cheap + compensation curves.** Where the architecture narrows
+    the cheap-vs-frontier gap, measured across both adapter seams.
+- **The boundary & meta track.**
+  - **C1 — Boundary quantification.** Where cost-scales-with-surprise degrades
+    to forecast cadence, and by how much (plan-audit floor, no-cheap-hash
+    domain, no-anchor calibration tax).
+  - **C2 — Output-quality track.** A separate, clearly-labelled,
+    blind-human-adjudicated track for output quality, walled off from every
+    headline number.
+
+1. **The preregistered cost regression (A1, invariant 3) is not built.** What
+   ships is a three-way deterministic control contrast (Reactor vs. no-memo vs.
+   naive-loop) over a single runtime receipt schedule, with explicit per-row
+   provenance. The Ideal requires a regression of spend on **frozen,
+   content-hashed surprise labels** against an explicit wall-clock/event-count
+   null, with the decision rule fixed before any data. No surprise-label
+   freeze, no statistical decision rule, and no oracle-cron adversary exist in
+   the package today.
+
+2. **The strongest-cheap adversaries are not all present (invariant 2).** The
+   `naive-loop` control is a deliberately weak strawman by the spec's own
+   standard. The load-bearing adversaries — a **strong content-diff +
+   embedding cache** and an **oracle-optimally-scheduled cron** — are not
+   implemented. The silent-drift headline (A5) specifically requires the
+   oracle-cron comparator and an injected-drift fixture set; the
+   `adversarial-silent` world profile exists but is currently only "typed but
+   fail-closed," not a drift-detection eval.
+
+3. **The live provider/model matrix (Claim B: B1/B2/B3) is not run.** The
+   eval-result model-matrix field is structurally pinned to `not-run`. One live
+   K1 cassette is recorded; the full live matrix, the role-fit findings
+   (best-judge / best-fulfiller / safest-cheap), and the **Reactor-compensation
+   curves** are entirely future work. Variable-depth live ensemble judging (A7)
+   is not in the runtime — the README states the runtime "does not perform
+   variable-depth live ensemble judging."
+
+4. **The boundary track (C1, invariant 6) is not quantified.** The
+   `flat-spend-under-static` assertion *permits* plan-audit-floor receipts but
+   no eval *measures the boundary* — where cost-scales-with-surprise degrades to
+   forecast cadence, and by how much. The no-cheap-hash domain and no-anchor
+   calibration tax are named in 02 but not measured here.
+
+5. **The blind output-quality track (C2, invariant 1) does not exist.** There
+   is no human-adjudicated quality track; the trace-vs-quality wall is honored
+   only by omission — no quality numbers are produced at all.
+
+6. **The preregistration apparatus (invariant 4) is not built.** No mechanism
+   freezes and content-hashes surprise labels, the statistical decision rule,
+   the baseline set, or the model matrix before runs. The recorded fixtures are
+   content-addressed (invariant 7 is partially honored), but the analysis-plan
+   freeze is absent.
+
+7. **Provider-reconciled cost confidence (invariant 5) is not wired.** Cost
+   figures in the Cradle are deterministic token counts from receipts. No
+   normalized or dollar figure is provider-reconciled; the confidence-tier
+   discipline is methodology, not yet code.
+
+8. **One release-parity case is explicitly deferred:**
+   `down-after-budget-exhaustion` — blocked on typed retry-budget and
+   pressure-dispatch primitives in the runtime. `postgres-parity` is the third
+   parity matrix row, marked `future`.
+
+### Sequencing (carried forward from the original plan)
+
+1. **Proof object stays reconciled.** The methodology derives from
+   `openprose.receipt v0` (02 open item I.1). The harness emits one receipt
+   definition; the eval scores the receipt the harness actually emits — as the
+   Cradle already does.
+2. **Land the Reactor-independent contribution first.** Real isolated
+   competitor runs plus the cost methodology and the harness comparison are a
+   _publishable contribution on their own_ — collected while the report-grade
+   Reactor column is built, so the apparatus is proven before the subject.
+3. **The Reactor column docks through the Cradle.** The Reactor row is not a
+   bespoke emitter bolted onto the eval harness; it is the Reactor presented as
+   one more adapter in the Cradle's parity-and-replay contract — a typed SDK
+   seam, an adapter-parity matrix with a byte-identity gate, a replay engine
+   that runs against the recorded receipt artifact and never re-derives it, and
+   assertion families evaluated over the receipt. The deterministic Cradle
+   scenarios already occupy that socket; the eval competitor adapters present
+   under the same contract, and the report-grade Reactor column slots in when
+   the live matrix and preregistered regression land. The first harness
+   milestone is itself scoped to _prove or kill the cost thesis_ — the same
+   preregistered hypothesis invariant 3 / A1 fixes — so the eval is that
+   milestone's acceptance instrument: align the preregistered surprise-label
+   and decision-rule freeze with that gate.
+4. **Write the report after the evals, never before.** Strong claim, then the
+   evidence, then the boundary. Ties and losses in the abstract.
+
+**Launch standard.** Do not publish "Reactor-class harness" until both claims
+survive their _strongest cheap adversaries_ under preregistration, the
+boundaries are quantified not hidden, the suite replays from a clean clone, and
+a skeptical reader can reproduce enough to be unable to dismiss it. The Cradle
+delivers the clean-clone replay floor today; the strongest-cheap-adversary and
+preregistration bars remain ahead.


### PR DESCRIPTION
## Summary

Fold the public OpenProse/Reactor spec into `openprose/prose` under `spec/` for the v0.1.0 release.

This PR:
- adds `00-Tenets.md` unchanged as the public tenet anchor
- adds restructured `01-Language`, `02-ReactorHarness`, `03-ReactorPattern`, and `04-Evals` with Ideal / Current / Roadmap separation
- refreshes the drafts from the rc audit to the shipped `reactor-v0.1.0` state
- updates the Reactor Harness Conformance Ledger to say v0.1 is released
- applies the N2b cost-control correction: same-unit static controls are `46:46` vs `92:0` / `92:0`, not the stale `256:0`
- moves the derived `04-Evals` Required Evaluation Suite out of the frozen Ideal section and into Roadmap
- removes private/internal relative links from the public spec files

## Validation

- `git diff --check`
- `rg '0\\.1\\.0-rc|5cfbac8|153 tests|281 tests|256:0|not yet published|technical report has not' spec` → no hits for stale release/status content
- `rg --pcre2 '\\[[^\\]]+\\]\\((?!https?://|#|\\./)[^)]+\\)' spec` → no private relative links

This is docs-only and follows the release handoff Step E spec reconciliation item.
