### PR TITLE
docs(examples): add top-level forwarding README so /tree/main/examples resolves

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,43 @@
+# OpenProse Examples
+
+The bundled examples live alongside the OpenProse skill at
+[`skills/open-prose/examples/`](../skills/open-prose/examples/).
+
+Each example is a small OpenProse Native Repository that models a real standing
+goal.
+
+- [stargazer-outreach](../skills/open-prose/examples/stargazer-outreach/) —
+  keeps high-intent GitHub stargazers enriched and ready for follow-up.
+- [incident-briefing-room](../skills/open-prose/examples/incident-briefing-room/) —
+  keeps an incident channel briefed with sourced status, impact, and next actions.
+- [customer-risk-radar](../skills/open-prose/examples/customer-risk-radar/) —
+  keeps customer risk visible before renewals or escalations surprise the team.
+- [release-readiness](../skills/open-prose/examples/release-readiness/) —
+  keeps a release candidate ready to ship with evidence, risks, and rollback notes.
+- [vendor-renewal-watch](../skills/open-prose/examples/vendor-renewal-watch/) —
+  keeps vendor renewals prepared before auto-renewal windows close.
+- [research-inbox-triage](../skills/open-prose/examples/research-inbox-triage/) —
+  keeps a research inbox deduplicated, prioritized, and converted into action.
+- [content-performance-loop](../skills/open-prose/examples/content-performance-loop/) —
+  keeps content performance learnings flowing into next actions.
+- [compliance-evidence-tracker](../skills/open-prose/examples/compliance-evidence-tracker/) —
+  keeps audit evidence fresh, reviewed, and gap-aware.
+- [auto-pocock](../skills/open-prose/examples/auto-pocock/) —
+  chains Matt Pocock's engineering skills into a single non-interactive OpenProse system.
+- [declared-skills](../skills/open-prose/examples/declared-skills/) —
+  shows a minimal `### Skills` requirement that fails closed at compile time.
+- [declared-tools](../skills/open-prose/examples/declared-tools/) —
+  shows a minimal `### Tools` requirement that fails closed at compile time.
+
+## External examples
+
+These live in separate repos because they depend on product-specific source code
+or follow their own release cadence.
+
+- [grant-radar](https://github.com/openprose/grant-finder/tree/main/examples/openprose) —
+  an OpenProse system that drives the public
+  [`grant-finder`](https://github.com/openprose/grant-finder) CLI to produce
+  source-cited non-dilutive funding reports.
+
+See [`skills/open-prose/examples/README.md`](../skills/open-prose/examples/README.md)
+for the quick-start guide.


### PR DESCRIPTION
Fixes #18.

The "browse examples" link on prose.md/learn points at `github.com/openprose/prose/tree/main/examples` and 404s — the actual examples live under `skills/open-prose/examples/`.

This adds a minimal forwarding README at the top-level `examples/` path so the GitHub URL now renders an index pointing at each canonical example directory. Nothing moved or duplicated; `skills/open-prose/examples/README.md` stays the source of truth.

If you'd rather fix the website link instead and not introduce a top-level forwarder, happy to drop this — let me know.