### PR TITLE
feat(reactor-cli): anonymous opt-out CLI-only telemetry

### DIFF
--- a/packages/reactor-cli/TELEMETRY.md
+++ b/packages/reactor-cli/TELEMETRY.md
@@ -1,0 +1,281 @@
+# Reactor CLI telemetry
+
+`@openprose/reactor-cli` collects **anonymous, opt-out, content-free** usage
+telemetry so we can see how many people use Reactor and for what. This document is
+the published, exact schema: every event, every property, every way to turn it
+off, and a transparency note on what we deliberately never collect.
+
+The short version:
+
+- **Anonymous.** The only identifier is a random per-machine UUID. No account, no
+  user, no email, no IP-derived geo.
+- **CLI-only.** Telemetry lives entirely in `@openprose/reactor-cli`. The SDK,
+  `@openprose/reactor`, emits **zero** network traffic — a library that phones home
+  from inside someone else's stack is a trust violation, so it never does.
+- **Content-free.** We collect the *shape* of usage, never the *content*. No prose,
+  markdown, prompt text, file paths, project or directory names, facet or node
+  names, API keys, model input/output, or precise geo — ever. See
+  [What we never collect](#what-we-never-collect).
+- **Opt-out, honored permanently.** `DO_NOT_TRACK=1`, `REACTOR_TELEMETRY=0`, or
+  `reactor telemetry disable` each turn it off for good. It is **off by default in
+  CI and any non-interactive (non-TTY) run.**
+- **Fire-and-forget.** A short, bounded `fetch` POST that never blocks, slows, or
+  errors a command — even if the endpoint is slow or down.
+- **Inspectable.** `reactor telemetry --dump` prints the exact JSON that would be
+  sent.
+
+## What is sent (the wire shape)
+
+Telemetry is a Segment-style `track` batch POSTed to the analytics endpoint:
+
+```
+POST <endpoint>
+content-type: application/json
+
+{
+  "batch": [
+    {
+      "type": "track",
+      "anonymousId": "<random per-machine UUID>",
+      "event": "reactor.<name>",
+      "properties": { /* all Reactor data lives here — see below */ },
+      "context": { "library": "@openprose/reactor-cli" },
+      "timestamp": "2026-06-02T18:00:00.000Z"
+    }
+  ]
+}
+```
+
+A batch carries 1–100 events. Each event's `timestamp` is an ISO-8601 string
+stamped when the event is enqueued.
+
+> **`context` is a closed whitelist.** The server validates `context` and rejects
+> any key other than `utm`, `page`, `device`, `ip`, `library`. Reactor sends
+> **only** `context.library = "@openprose/reactor-cli"`. **All** Reactor-specific
+> data rides in the free-form `properties` object — never in `context`.
+
+### `anonymousId`
+
+A random `crypto.randomUUID()` minted once per machine and stored in
+`~/.reactor/config.json` as `installId`. It correlates one machine's events
+without identifying a user, project, or path. It is not derived from anything —
+not the hostname, not the MAC, not the home directory.
+
+## Events
+
+Every event name is prefixed `reactor.`.
+
+| Event | Fired from | When |
+| --- | --- | --- |
+| `reactor.first_run` | `doctor` | Once per machine, alongside the first-run disclosure. |
+| `reactor.compile` | `compile` | After a compile (success / cache hit / failure). |
+| `reactor.run` | `run` | After a run completes. |
+| `reactor.serve` | `serve` | At boot, and once on the first poll cycle (sampled). |
+| `reactor.trigger` | `trigger` | After a trigger completes. |
+| `reactor.init` | `init` | After scaffolding a project. |
+| `reactor.doctor` | `doctor` | After the health check. |
+| `reactor.observe` | `status`, `topology`, `inspect`, `logs`, `trace`, `receipts` | After a read-only observability command (collapsed; carries a `sub`). |
+| `reactor.error` | any of the above | Alongside a failing command, carrying a coarse error category only. |
+
+### Shared properties (on every event)
+
+| Property | Type | Example | Notes |
+| --- | --- | --- | --- |
+| `schemaVersion` | number | `1` | Property-schema version; bumped only on a breaking shape change. |
+| `cliVersion` | string | `"0.2.0"` | `@openprose/reactor-cli` version. |
+| `reactorVersion` | string | `"0.2.0"` \| `"unknown"` | Resolved `@openprose/reactor` SDK version. |
+| `nodeVersion` | string | `"v20.11.0"` | `process.version`. |
+| `os` | string | `"darwin"` | `process.platform` — a coarse OS family, never a hostname. |
+| `arch` | string | `"arm64"` | `process.arch`. |
+| `ci` | boolean | `false` | Coarse CI/automation detection. |
+| `command` | string | `"run"` | The command name — never an argument value. |
+| `outcome` | enum | `"success"` | One of `success` \| `failure` \| `cache_hit`. |
+| `durationBucket` | enum | `"1-5s"` | Bucketed wall-clock duration (see [buckets](#buckets)). |
+
+### Per-event extra properties
+
+All extras are **bucketed or categorical**. Raw counts, durations, names, paths,
+messages, and provider keys never appear.
+
+#### `reactor.compile`, `reactor.run`, `reactor.trigger` (graph shape)
+
+| Property | Type | Example | Notes |
+| --- | --- | --- | --- |
+| `nodesBucket` | enum | `"6-20"` | Bucketed node count. |
+| `edgesBucket` | enum | `"1-5"` | Bucketed edge count. |
+| `cost.freshBucket` | enum | `"1-5"` | Bucketed fresh-cost token total. |
+| `cost.reusedBucket` | enum | `"21+"` | Bucketed reused-cost token total. |
+| `providerClass` | string | `"anthropic"` | Coarse provider **class**, never a key/URL/model id (see [provider class](#provider-class)). |
+| `dispositions` | object | `{ "rendered": "1-5", "skipped": "21+" }` | Bucketed counts keyed by disposition kind (`rendered` \| `skipped` \| `failed` \| `coalesced`) — never node identities. Present on `run`. |
+
+#### `reactor.observe`
+
+| Property | Type | Example | Notes |
+| --- | --- | --- | --- |
+| `sub` | enum | `"status"` | Which read-only command ran: `status` \| `topology` \| `inspect` \| `logs` \| `trace` \| `receipts`. |
+
+#### `reactor.serve`
+
+| Property | Type | Example | Notes |
+| --- | --- | --- | --- |
+| `pollIntervalBucket` | enum | `"30s+"` | Bucketed poll cadence. |
+| `concurrencyBucket` | enum | `"1-5"` | Bucketed worker-pool bound. |
+
+A long-running daemon fires `reactor.serve` once at boot and once on the **first**
+poll cycle (sampled), so it can never flood the backend.
+
+#### `reactor.error`
+
+| Property | Type | Example | Notes |
+| --- | --- | --- | --- |
+| `errorCategory` | enum | `"provider"` | Coarse category only: `provider` \| `config` \| `io` \| `chain_verify` \| `unknown`. **Never** the message, stack, or any operand. |
+
+### Buckets
+
+Raw counts and durations are weakly identifying side channels, so they are never
+emitted raw — they pass through a bucketer first.
+
+| Bucketer | Bands |
+| --- | --- |
+| Count (`nodesBucket`, `edgesBucket`, cost, dispositions, `concurrencyBucket`) | `0`, `1-5`, `6-20`, `21+` |
+| Duration (`durationBucket`, `pollIntervalBucket`) | `<1s`, `1-5s`, `5-30s`, `30s+` |
+
+### Provider class
+
+A free-form provider/adapter identifier is collapsed to a fixed **class** label —
+never a key, token, base URL, or model id. Recognized classes: `openrouter`,
+`openai`, `anthropic`, `google`, `azure`, `bedrock`, `local`. Anything
+unrecognized collapses to `other`; an absent provider is `none`.
+
+## Turning it off (the full opt-out matrix)
+
+Telemetry is **disabled** if **any** of the following hold. Each is permanent on
+its own; you do not need to combine them.
+
+| # | Condition | How |
+| --- | --- | --- |
+| 1 | `DO_NOT_TRACK` is truthy | `export DO_NOT_TRACK=1` (the [consoledonottrack.com](https://consoledonottrack.com) convention). Any value that is not unset / empty / `0` / `false`. |
+| 2 | Reactor env opt-out | `export REACTOR_TELEMETRY=0`, or set `REACTOR_TELEMETRY_DISABLED` to anything. |
+| 3 | Offline mode | `REACTOR_OFFLINE=1` (offline implies zero egress). |
+| 4 | CI | `CI` is truthy, or a known CI marker is set (`GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `BUILDKITE`, `TF_BUILD`, `JENKINS_URL`, `TEAMCITY_VERSION`). |
+| 5 | Non-interactive | stdout is **not a TTY** (piped/redirected/automated runs are not tracked). |
+| 6 | Project config | `reactor.yml` → `telemetry.enabled: false`. |
+| 7 | Machine config | `~/.reactor/config.json` → `telemetryEnabled: false` (written by `reactor telemetry disable`). |
+
+If none of the above hold, telemetry is **enabled** by default — but the
+disclosure (below) always runs first.
+
+### First-run disclosure
+
+The first time you run `reactor doctor` on a machine, a short notice prints to
+**stdout** — what is collected, that it is anonymous, the one-liner to turn it
+off, and a pointer to this file. It shows once per machine (tracked by
+`noticeShownVersion` in `~/.reactor/config.json`) and may re-show on a notable
+version upgrade. There is no banner at CLI entry and nothing on stderr.
+
+## The `reactor telemetry` command
+
+```sh
+reactor telemetry [status|enable|disable] [--dump] [--json]
+```
+
+| Invocation | Effect |
+| --- | --- |
+| `reactor telemetry` / `reactor telemetry status` | Reports whether telemetry is currently enabled, the gate reason when disabled, the resolved endpoint, and the anonymous install id (creating no state). |
+| `reactor telemetry enable` | Clears the machine-level opt-out (`telemetryEnabled: true`). Still honors `DO_NOT_TRACK` / `REACTOR_TELEMETRY=0` / CI / non-TTY / project config. |
+| `reactor telemetry disable` | Writes `telemetryEnabled: false` to `~/.reactor/config.json` — permanent, machine-level. |
+| `reactor telemetry --dump` | Prints the **exact** JSON (endpoint + Segment batch) that a representative event would send, then exits. It only prints — it never opens a socket. |
+
+`--json` makes `status`, `enable`, and `disable` emit machine-readable output.
+
+### `--dump` example
+
+```sh
+$ reactor telemetry --dump
+{
+  "endpoint": "https://api.openprose.ai/analytics",
+  "batch": [
+    {
+      "type": "track",
+      "anonymousId": "3f8c1e0a-...",
+      "event": "reactor.doctor",
+      "properties": {
+        "schemaVersion": 1,
+        "cliVersion": "0.2.0",
+        "reactorVersion": "0.2.0",
+        "nodeVersion": "v20.11.0",
+        "os": "darwin",
+        "arch": "arm64",
+        "ci": false,
+        "command": "doctor",
+        "outcome": "success",
+        "durationBucket": "<1s"
+      },
+      "context": { "library": "@openprose/reactor-cli" },
+      "timestamp": "2026-06-02T18:00:00.000Z"
+    }
+  ]
+}
+```
+
+## Endpoints
+
+| Build | Endpoint |
+| --- | --- |
+| npm-published (default) | `https://api.openprose.ai/analytics` (PROD) |
+| Local / dev | `https://api.dev.openprose.ai/analytics` (DEV) |
+
+The published default is **PROD**. Local and dev runs reach DEV because the
+monorepo's dev/test tooling exports `REACTOR_TELEMETRY_ENDPOINT`. Self-hosters can
+override the endpoint two ways (the project setting wins):
+
+```sh
+export REACTOR_TELEMETRY_ENDPOINT=https://analytics.example.com/analytics
+```
+
+```yaml
+# reactor.yml
+telemetry:
+  endpoint: https://analytics.example.com/analytics
+```
+
+## Transport guarantees
+
+- A bespoke `fetch` client — **zero new runtime dependencies** (Node ≥ 20 ships a
+  global `fetch`).
+- `event()` only enqueues; it never blocks and never throws.
+- `flush()` POSTs under a hard `AbortSignal.timeout(~2000ms)` and swallows every
+  transport error, so a slow or unreachable endpoint can never delay, reject, or
+  perturb the CLI. The exit path also bounds the flush with its own ceiling.
+- When telemetry is disabled, the sink is a true no-op: no install id is created,
+  no endpoint is resolved, and no network is touched.
+
+## What we never collect
+
+The trust invariant: we emit the *shape* of usage, never the *content*. The
+following are **forbidden in every field, with no exceptions**:
+
+- World-model content, the markdown, prompt text, or any model input/output
+- File paths, project or directory names
+- Exact facet or node names
+- API keys, tokens, base URLs, or model ids (only a coarse provider **class**)
+- Error messages or stacks (only a coarse error **category**)
+- Raw counts or durations (only buckets)
+- IP-derived or precise geo
+
+Bucketers, the provider-class map, and the fixed error-category vocabulary exist
+precisely so a caller can never accidentally smuggle a raw value through.
+
+## For analysts: isolating this event class
+
+Reactor CLI telemetry is uniquely identified two ways (belt and braces): the
+indexed event-name prefix, plus the whitelisted `library` discriminator.
+
+```sql
+SELECT *
+FROM analytics_events
+WHERE event_name LIKE 'reactor.%'                       -- indexed; primary filter
+  AND context->>'library' = '@openprose/reactor-cli';   -- belt + braces
+```
+
+The collection code is open source in this package under `src/telemetry/`.

--- a/packages/reactor-cli/src/__tests__/compile.test.ts
+++ b/packages/reactor-cli/src/__tests__/compile.test.ts
@@ -28,6 +28,8 @@ import { runCompileCommand } from '../commands/compile';
 import { manifestPath, loadIR, readTopologyShape, compileDir } from '../compile/ir-cache';
 import { firstErrorLine } from '../compile/run-compile';
 import { fakeStructuredProvider } from './fake-provider';
+import { fakeTelemetry } from './fake-telemetry';
+import { TelemetryEvent, NOOP_TELEMETRY, type Telemetry } from '../telemetry';
 
 describe('firstErrorLine (G21b: suppress the raw Require stack dump)', () => {
   it('keeps the legible first line and drops the multi-line Require stack', () => {
@@ -134,7 +136,7 @@ function capture(): { write: (l: string) => void; lines: string[] } {
   return { write: (l) => lines.push(l), lines };
 }
 
-async function compileOnce(stateDir: string, force = false) {
+async function compileOnce(stateDir: string, force = false, telemetry: Telemetry = NOOP_TELEMETRY) {
   const out = capture();
   const code = await runCompileCommand(
     {
@@ -146,6 +148,7 @@ async function compileOnce(stateDir: string, force = false) {
       testSkill: 'TEST SKILL',
     },
     out.write,
+    telemetry,
   );
   const report = JSON.parse(out.lines.join('\n')) as Record<string, unknown>;
   return { code, report };
@@ -334,6 +337,85 @@ describe('reactor compile (offline gate)', () => {
       assert.deepEqual(out.leaked, [], `live deps leaked on cache load: ${out.leaked.join(', ')}`);
     } finally {
       rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('reactor compile telemetry fire points', () => {
+  it('fires reactor.compile success with bucketed graph extras on a fresh compile', async () => {
+    const stateDir = freshStateDir();
+    const fake = fakeTelemetry();
+    try {
+      const { code } = await compileOnce(stateDir, false, fake.telemetry);
+      assert.equal(code, 0);
+      const compile = fake.events.filter((e) => e.name === TelemetryEvent.COMPILE);
+      assert.equal(compile.length, 1, 'exactly one reactor.compile event');
+      const props = compile[0]!.properties;
+      assert.equal(props.command, 'compile');
+      assert.equal(props.outcome, 'success');
+      // Content-free buckets only — the 2-node/1-edge fixture lands in the '1-5' band.
+      assert.equal(props.nodesBucket, '1-5');
+      assert.equal(props.edgesBucket, '1-5');
+      assert.ok(props.cost, 'cost buckets present');
+      // No raw counts leaked onto the properties object.
+      assert.equal((props as unknown as Record<string, unknown>).nodes, undefined);
+      assert.equal((props as unknown as Record<string, unknown>).edges, undefined);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fires reactor.compile cache_hit on a warm re-run', async () => {
+    const stateDir = freshStateDir();
+    try {
+      await compileOnce(stateDir);
+      const fake = fakeTelemetry();
+      const { code } = await compileOnce(stateDir, false, fake.telemetry);
+      assert.equal(code, 0);
+      const compile = fake.events.filter((e) => e.name === TelemetryEvent.COMPILE);
+      assert.equal(compile.length, 1);
+      assert.equal(compile[0]!.properties.outcome, 'cache_hit');
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fires reactor.error with a config category when no contracts are found', async () => {
+    const stateDir = freshStateDir();
+    const emptyDir = mkdtempSync(join(tmpdir(), 'reactor-cli-empty-'));
+    const fake = fakeTelemetry();
+    try {
+      const out = capture();
+      const code = await runCompileCommand(
+        { projectDir: emptyDir, stateDir, json: true },
+        out.write,
+        fake.telemetry,
+      );
+      assert.equal(code, 1);
+      const errors = fake.events.filter((e) => e.name === TelemetryEvent.ERROR);
+      assert.equal(errors.length, 1, 'exactly one reactor.error');
+      assert.equal(errors[0]!.properties.outcome, 'failure');
+      assert.equal(errors[0]!.properties.errorCategory, 'config');
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('the NOOP telemetry default leaves the report identical to an injected fake', async () => {
+    const a = freshStateDir();
+    const b = freshStateDir();
+    try {
+      const noop = await compileOnce(a, false, NOOP_TELEMETRY);
+      const fake = await compileOnce(b, false, fakeTelemetry().telemetry);
+      // Behavior/output is identical regardless of the telemetry sink injected.
+      assert.equal(noop.code, fake.code);
+      assert.equal(noop.report['status'], fake.report['status']);
+      assert.equal(noop.report['nodes'], fake.report['nodes']);
+      assert.equal(noop.report['edges'], fake.report['edges']);
+    } finally {
+      rmSync(a, { recursive: true, force: true });
+      rmSync(b, { recursive: true, force: true });
     }
   });
 });

--- a/packages/reactor-cli/src/__tests__/doctor.test.ts
+++ b/packages/reactor-cli/src/__tests__/doctor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -11,6 +11,8 @@ import {
   runLiveSmoke,
 } from '../commands/doctor';
 import { runInitCommand } from '../commands/init';
+import { fakeTelemetry } from './fake-telemetry';
+import { TelemetryEvent, readMachineConfig } from '../telemetry';
 
 describe('doctor', () => {
   it('collects a report with the running node version', async () => {
@@ -193,5 +195,99 @@ describe('doctor', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * The first-run disclosure + `reactor.first_run` are the single most trust-
+ * sensitive behavior (00-POLICY.md principle #2, 03-DECISIONS.md #3). These tests
+ * isolate the machine config through the REACTOR_CONFIG_DIR seam — the SAME seam
+ * the notice stamp and doctor's first-run detection (via readMachineConfig) both
+ * honor — so they also guard the notice/first-run coherence across the seam.
+ */
+describe('doctor first-run disclosure + reactor.first_run', () => {
+  let configDir: string;
+  const prevConfigDir = process.env.REACTOR_CONFIG_DIR;
+  const prevOffline = process.env.REACTOR_OFFLINE;
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), 'reactor-doctor-cfg-'));
+    process.env.REACTOR_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    if (prevConfigDir === undefined) delete process.env.REACTOR_CONFIG_DIR;
+    else process.env.REACTOR_CONFIG_DIR = prevConfigDir;
+    if (prevOffline === undefined) delete process.env.REACTOR_OFFLINE;
+    else process.env.REACTOR_OFFLINE = prevOffline;
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('first run prints the disclosure via write AND fires exactly one reactor.first_run', async () => {
+    const fake = fakeTelemetry();
+    const lines: string[] = [];
+    const code = await runDoctor({}, (l) => lines.push(l), fake.telemetry);
+    assert.equal(code, 0);
+    // The disclosure went to the write() stdout sink.
+    const text = lines.join('\n');
+    assert.match(text, /anonymous/i);
+    assert.match(text, /reactor telemetry disable/);
+    // Exactly one reactor.first_run fired.
+    const firstRuns = fake.events.filter((e) => e.name === TelemetryEvent.FIRST_RUN);
+    assert.equal(firstRuns.length, 1, 'exactly one reactor.first_run on a first machine run');
+    assert.equal(firstRuns[0]!.properties.command, 'doctor');
+  });
+
+  it('second run prints no disclosure and fires no reactor.first_run', async () => {
+    // First run stamps the notice.
+    await runDoctor({}, () => {}, fakeTelemetry().telemetry);
+    // Second run over the SAME seam config: silent.
+    const fake = fakeTelemetry();
+    const lines: string[] = [];
+    const code = await runDoctor({}, (l) => lines.push(l), fake.telemetry);
+    assert.equal(code, 0);
+    const text = lines.join('\n');
+    assert.doesNotMatch(text, /reactor telemetry disable/, 'no disclosure on the second run');
+    assert.equal(
+      fake.events.filter((e) => e.name === TelemetryEvent.FIRST_RUN).length,
+      0,
+      'no reactor.first_run on the second run',
+    );
+  });
+
+  it('--json suppresses the human disclosure lines on stdout (still fires first_run)', async () => {
+    const fake = fakeTelemetry();
+    const lines: string[] = [];
+    const code = await runDoctor({ json: true }, (l) => lines.push(l), fake.telemetry);
+    assert.equal(code, 0);
+    // stdout must remain machine-parseable: the disclosure copy is NOT present, and
+    // the single line parses as JSON.
+    const text = lines.join('\n');
+    assert.doesNotMatch(text, /reactor telemetry disable/, '--json must not print the disclosure');
+    assert.doesNotThrow(() => JSON.parse(text), 'stdout stays valid JSON under --json');
+    // first_run still computes from readMachineConfig and fires once.
+    assert.equal(
+      fake.events.filter((e) => e.name === TelemetryEvent.FIRST_RUN).length,
+      1,
+      'first_run still fires under --json',
+    );
+  });
+
+  it('the notice stamp and the first_run detection agree across runs (seam coherence)', async () => {
+    // Before any run, the seam config has no notice stamp → first run is "first".
+    assert.equal(readMachineConfig()?.noticeShownVersion, undefined);
+    await runDoctor({}, () => {}, fakeTelemetry().telemetry);
+    // After the first run, the stamp lands in the SAME seam file readMachineConfig
+    // reads — proving the notice (which writes via the identity leaf) and doctor's
+    // first-run detection (which reads readMachineConfig) share one file. If notice
+    // wrote to ~/.reactor instead, this read would still be undefined and first_run
+    // would re-fire on the next run.
+    const stamped = readMachineConfig();
+    assert.equal(typeof stamped?.noticeShownVersion, 'string');
+    // And a subsequent run sees the stamp → no re-fire (already asserted above, but
+    // re-checked here against the explicit seam read for coherence).
+    const fake = fakeTelemetry();
+    await runDoctor({}, () => {}, fake.telemetry);
+    assert.equal(fake.events.filter((e) => e.name === TelemetryEvent.FIRST_RUN).length, 0);
   });
 });

--- a/packages/reactor-cli/src/__tests__/fake-telemetry.ts
+++ b/packages/reactor-cli/src/__tests__/fake-telemetry.ts
@@ -1,0 +1,37 @@
+/**
+ * A capturing fake {@link Telemetry} for command tests. Records every `event`
+ * call (name + properties) so a test can assert the exact fire points, outcomes,
+ * and bucketed extras a command emits — without any network or disk. `flush` is a
+ * no-op resolved promise. This mirrors the `testProviders` / `testAdapters`
+ * injection style: a command accepts an optional `telemetry` arg defaulting to
+ * the real client, so injecting this fake proves the fire points and injecting
+ * the NO-OP changes nothing.
+ */
+
+import type { Telemetry, TelemetryEventName, EventProperties } from '../telemetry';
+
+/** One captured event: the `reactor.*` name and the content-free properties. */
+export interface CapturedEvent {
+  readonly name: TelemetryEventName;
+  readonly properties: EventProperties;
+}
+
+/** A capturing telemetry sink plus the list it appends to. */
+export interface FakeTelemetry {
+  readonly telemetry: Telemetry;
+  readonly events: CapturedEvent[];
+}
+
+/** Build a fresh capturing fake telemetry sink. */
+export function fakeTelemetry(): FakeTelemetry {
+  const events: CapturedEvent[] = [];
+  const telemetry: Telemetry = {
+    event(name: TelemetryEventName, properties: EventProperties): void {
+      events.push({ name, properties });
+    },
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+  return { telemetry, events };
+}

--- a/packages/reactor-cli/src/__tests__/init.test.ts
+++ b/packages/reactor-cli/src/__tests__/init.test.ts
@@ -27,6 +27,8 @@ import { runCompileCommand } from '../commands/compile';
 import { loadConfig } from '../config';
 import { loadIR, manifestPath } from '../compile/ir-cache';
 import { fakeStructuredProvider } from './fake-provider';
+import { fakeTelemetry } from './fake-telemetry';
+import { TelemetryEvent, NOOP_TELEMETRY } from '../telemetry';
 
 const INBOX = 'inbox';
 const DIGEST = 'digest';
@@ -214,6 +216,58 @@ describe('reactor init (offline gate)', () => {
       ]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('reactor init telemetry fire points', () => {
+  it('fires reactor.init success on a clean scaffold', async () => {
+    const dir = freshDir();
+    const fake = fakeTelemetry();
+    try {
+      const code = await runInitCommand({ dir, json: true }, () => {}, fake.telemetry);
+      assert.equal(code, 0);
+      const inits = fake.events.filter((e) => e.name === TelemetryEvent.INIT);
+      assert.equal(inits.length, 1, 'exactly one reactor.init');
+      assert.equal(inits[0]!.properties.command, 'init');
+      assert.equal(inits[0]!.properties.outcome, 'success');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fires reactor.init failure when refusing to clobber existing files', async () => {
+    const dir = freshDir();
+    const fake = fakeTelemetry();
+    try {
+      await runInitCommand({ dir }, () => {}, NOOP_TELEMETRY);
+      const code = await runInitCommand({ dir, json: true }, () => {}, fake.telemetry);
+      assert.equal(code, 1);
+      const inits = fake.events.filter((e) => e.name === TelemetryEvent.INIT);
+      assert.equal(inits.length, 1);
+      assert.equal(inits[0]!.properties.outcome, 'failure');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the NOOP telemetry default leaves the scaffold output identical', async () => {
+    const a = freshDir();
+    const b = freshDir();
+    try {
+      const outA = capture();
+      const codeA = await runInitCommand({ dir: a, json: true }, outA.write, NOOP_TELEMETRY);
+      const outB = capture();
+      const codeB = await runInitCommand({ dir: b, json: true }, outB.write, fakeTelemetry().telemetry);
+      assert.equal(codeA, codeB);
+      // The report payload (minus the dir path) is identical regardless of sink.
+      const ra = JSON.parse(outA.lines.join('\n')) as Record<string, unknown>;
+      const rb = JSON.parse(outB.lines.join('\n')) as Record<string, unknown>;
+      assert.equal(ra['status'], rb['status']);
+      assert.deepEqual(ra['written'], rb['written']);
+    } finally {
+      rmSync(a, { recursive: true, force: true });
+      rmSync(b, { recursive: true, force: true });
     }
   });
 });

--- a/packages/reactor-cli/src/__tests__/observe.test.ts
+++ b/packages/reactor-cli/src/__tests__/observe.test.ts
@@ -46,6 +46,8 @@ import {
   parseRate,
 } from '../commands/observe';
 import { fakeStructuredProvider } from './fake-provider';
+import { fakeTelemetry } from './fake-telemetry';
+import { TelemetryEvent } from '../telemetry';
 import { receiptsDir } from '../run/substrate';
 
 const SDK_ROOT = join(require.resolve('@openprose/reactor'), '..', '..');
@@ -544,5 +546,61 @@ describe('observability offline boundary', () => {
     assert.equal(res.status, 0, `probe failed: ${res.stderr}`);
     const leaked = JSON.parse(res.stdout || '[]') as string[];
     assert.deepEqual(leaked, [], `live deps leaked: ${leaked.join(', ')}`);
+  });
+});
+
+describe('reactor observe telemetry fire points (per-sub tag)', () => {
+  it('each observe sub-command fires reactor.observe with the correct `sub` tag', async () => {
+    const stateDir = freshState();
+    try {
+      await populateState(stateDir);
+
+      // status / topology / inspect / logs / trace / receipts each collapse to one
+      // reactor.observe event distinguished ONLY by the coarse `sub` tag.
+      const cases: { sub: string; run: (t: ReturnType<typeof fakeTelemetry>) => Promise<number> }[] = [
+        { sub: 'status', run: (t) => runStatusCommand({ directStateDir: stateDir, json: true }, () => {}, t.telemetry) },
+        { sub: 'topology', run: (t) => runTopologyCommand({ directStateDir: stateDir, json: true }, () => {}, t.telemetry) },
+        { sub: 'inspect', run: (t) => runInspectCommand({ directStateDir: stateDir, json: true, node: MONITOR }, () => {}, t.telemetry) },
+        { sub: 'logs', run: (t) => runLogsCommand({ directStateDir: stateDir, json: true }, () => {}, t.telemetry) },
+        { sub: 'trace', run: (t) => runTraceCommand({ directStateDir: stateDir, json: true }, () => {}, t.telemetry) },
+        { sub: 'receipts', run: (t) => runReceiptsCommand({ directStateDir: stateDir, json: true, sub: 'verify' }, () => {}, t.telemetry) },
+      ];
+
+      for (const c of cases) {
+        const fake = fakeTelemetry();
+        const code = await c.run(fake);
+        assert.equal(code, 0, `${c.sub} succeeded`);
+        const observes = fake.events.filter((e) => e.name === TelemetryEvent.OBSERVE);
+        assert.equal(observes.length, 1, `${c.sub}: exactly one reactor.observe`);
+        const props = observes[0]!.properties;
+        assert.equal(props.command, 'observe');
+        assert.equal(props.outcome, 'success');
+        assert.equal(props.sub, c.sub, `${c.sub}: correct sub tag`);
+      }
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a failing observe sub fires reactor.observe failure + a coarse reactor.error', async () => {
+    const stateDir = freshState(); // never populated → no compiled topology.
+    const fake = fakeTelemetry();
+    try {
+      const code = await runTopologyCommand(
+        { directStateDir: stateDir, json: true },
+        () => {},
+        fake.telemetry,
+      );
+      assert.notEqual(code, 0);
+      const observes = fake.events.filter((e) => e.name === TelemetryEvent.OBSERVE);
+      const errors = fake.events.filter((e) => e.name === TelemetryEvent.ERROR);
+      assert.equal(observes.length, 1);
+      assert.equal(observes[0]!.properties.sub, 'topology');
+      assert.equal(observes[0]!.properties.outcome, 'failure');
+      assert.equal(errors.length, 1, 'a categorized reactor.error accompanies the failure');
+      assert.equal(errors[0]!.properties.errorCategory, 'config');
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/reactor-cli/src/__tests__/offline-boundary.test.ts
+++ b/packages/reactor-cli/src/__tests__/offline-boundary.test.ts
@@ -75,3 +75,208 @@ describe('offline boundary (compiled entrypoint)', () => {
     assert.match(res.stdout, /doctor/);
   });
 });
+
+/**
+ * Telemetry-specific egress boundary (N2 + 02-IMPLEMENTATION-PLAN.md §7). Asserts
+ * that NO telemetry POST leaves the process when telemetry is disabled, and that
+ * merely loading the compiled entrypoint never triggers a send at module scope.
+ *
+ * The probe monkeypatches `globalThis.fetch` to record every call, then exercises
+ * the CLI in-process, so any stray telemetry POST is caught regardless of the
+ * (swallowed, fire-and-forget) transport.
+ */
+describe('telemetry offline egress boundary (compiled entrypoint)', () => {
+  /**
+   * Run `main(argv)` in a child node process with `globalThis.fetch` replaced by a
+   * recorder, under the given env, and return the count of fetch calls observed.
+   */
+  function fetchCallsDuringMain(argv: string[], env: NodeJS.ProcessEnv): number {
+    // The command writes to stdout, so we suppress that and emit the RESULT marker
+    // on stderr — keeping the probe's machine output cleanly separated from the
+    // command's human output.
+    const probe = `
+      let fetchCalls = 0;
+      globalThis.fetch = () => {
+        fetchCalls++;
+        return Promise.resolve(new Response(null, { status: 200 }));
+      };
+      const origWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = () => true; // swallow the command's stdout
+      const { main } = require(${JSON.stringify(cliEntry)});
+      main(${JSON.stringify(argv)})
+        .catch(() => {})
+        .finally(() => {
+          process.stdout.write = origWrite;
+          process.stderr.write('RESULT:' + JSON.stringify({ fetchCalls }) + '\\n');
+        });
+    `;
+    const res = spawnSync(process.execPath, ['-e', probe], { env, encoding: 'utf8' });
+    assert.equal(res.status, 0, `probe failed: ${res.stderr}`);
+    const m = /RESULT:(\{.*\})/.exec(res.stderr);
+    assert.ok(m, `probe produced no RESULT marker; stderr: ${res.stderr}`);
+    const out = JSON.parse(m![1]!) as { fetchCalls: number };
+    return out.fetchCalls;
+  }
+
+  it('requiring cli.js sends ZERO telemetry at module scope', () => {
+    const probe = `
+      let fetchCalls = 0;
+      globalThis.fetch = () => { fetchCalls++; return Promise.resolve(new Response(null, { status: 200 })); };
+      require(${JSON.stringify(cliEntry)});
+      // Give any stray microtask a tick to run before we report.
+      setImmediate(() => process.stdout.write(JSON.stringify({ fetchCalls })));
+    `;
+    const res = spawnSync(process.execPath, ['-e', probe], {
+      env: zeroEnv(),
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `probe failed: ${res.stderr}`);
+    const out = JSON.parse(res.stdout.trim() || '{"fetchCalls":-1}') as { fetchCalls: number };
+    assert.equal(out.fetchCalls, 0, 'importing the entrypoint must not POST telemetry');
+  });
+
+  it('REACTOR_OFFLINE=1 disables telemetry: ZERO fetch egress on a `doctor` run', () => {
+    const calls = fetchCallsDuringMain(['node', 'reactor', 'doctor'], {
+      PATH: process.env.PATH,
+      REACTOR_OFFLINE: '1',
+    });
+    assert.equal(calls, 0, 'REACTOR_OFFLINE=1 must produce zero telemetry egress');
+  });
+
+  it('a non-TTY run (default in the test harness) sends ZERO telemetry on `status`', () => {
+    // spawnSync gives the child a non-TTY stdout, which the gate treats as
+    // disabled — so even with no explicit opt-out, no telemetry leaves the process.
+    const calls = fetchCallsDuringMain(['node', 'reactor', 'status'], {
+      PATH: process.env.PATH,
+    });
+    assert.equal(calls, 0, 'a non-TTY run must produce zero telemetry egress');
+  });
+
+  it('DO_NOT_TRACK=1 disables telemetry: ZERO fetch egress on a `status` run', () => {
+    const calls = fetchCallsDuringMain(['node', 'reactor', 'status'], {
+      PATH: process.env.PATH,
+      DO_NOT_TRACK: '1',
+    });
+    assert.equal(calls, 0, 'DO_NOT_TRACK=1 must produce zero telemetry egress');
+  });
+
+  it('`reactor telemetry --dump` PRINTS the payload but sends ZERO egress', () => {
+    const probe = `
+      let fetchCalls = 0;
+      globalThis.fetch = () => { fetchCalls++; return Promise.resolve(new Response(null, { status: 200 })); };
+      const { main } = require(${JSON.stringify(cliEntry)});
+      let out = '';
+      const origWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = (chunk) => { out += chunk; return true; };
+      main(['node', 'reactor', 'telemetry', '--dump'])
+        .catch(() => {})
+        .finally(() => {
+          process.stdout.write = origWrite;
+          process.stdout.write(JSON.stringify({ fetchCalls, hasBatch: out.includes('"batch"') }));
+        });
+    `;
+    const res = spawnSync(process.execPath, ['-e', probe], {
+      env: { PATH: process.env.PATH },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `probe failed: ${res.stderr}`);
+    const out = JSON.parse(res.stdout.trim() || '{}') as {
+      fetchCalls: number;
+      hasBatch: boolean;
+    };
+    assert.equal(out.fetchCalls, 0, '--dump must NEVER send — it only prints');
+    assert.equal(out.hasBatch, true, '--dump prints the { batch: [...] } payload');
+  });
+});
+
+/**
+ * The POSITIVE counterpart to the egress boundary: when telemetry is ENABLED
+ * (interactive TTY, clean env), a single CLI run MUST reach `fetch` with a
+ * well-formed `/analytics` batch. Without this, every disable condition could be
+ * inverted (gate always disabled, or initTelemetry always NO-OP) and the suite
+ * would still pass while shipping a feature that never sends anything.
+ *
+ * The probe forces `process.stdout.isTTY = true` (the gate's TTY requirement),
+ * supplies a clean env with a SENTINEL endpoint, isolates the machine config via
+ * REACTOR_CONFIG_DIR, monkeypatches `fetch` to record the request, and drives
+ * `main()` end-to-end through the gate → initTelemetry → client wiring.
+ */
+describe('telemetry enabled-path egress (gate -> init -> client wiring)', () => {
+  it('an enabled, interactive `doctor` run POSTs exactly one /analytics batch', () => {
+    const sentinel = 'https://sentinel.telemetry.test/analytics';
+    const probe = `
+      const os = require('node:os');
+      const fs = require('node:fs');
+      const path = require('node:path');
+      const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reactor-egress-'));
+      process.env.REACTOR_CONFIG_DIR = cfgDir;
+      // The gate requires an interactive TTY; spawnSync gives a non-TTY, so force it.
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+      const posts = [];
+      globalThis.fetch = (url, init) => {
+        let body;
+        try { body = JSON.parse(init.body); } catch (_e) { body = null; }
+        posts.push({ url: String(url), body });
+        return Promise.resolve(new Response(null, { status: 200 }));
+      };
+
+      const origWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = () => true; // swallow the doctor report
+      const { main } = require(${JSON.stringify(cliEntry)});
+      main(['node', 'reactor', 'doctor'])
+        .catch(() => {})
+        .finally(() => {
+          process.stdout.write = origWrite;
+          process.stderr.write('RESULT:' + JSON.stringify({ posts }) + '\\n');
+        });
+    `;
+    // A deliberately CLEAN env: NO CI, NO DO_NOT_TRACK, NO REACTOR_OFFLINE — only
+    // PATH + the sentinel endpoint override. (CONFIG_DIR is set inside the probe.)
+    const res = spawnSync(process.execPath, ['-e', probe], {
+      env: {
+        PATH: process.env.PATH,
+        REACTOR_TELEMETRY_ENDPOINT: sentinel,
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `probe failed: ${res.stderr}`);
+    const m = /RESULT:(\{.*\})/.exec(res.stderr);
+    assert.ok(m, `probe produced no RESULT marker; stderr: ${res.stderr}`);
+    const out = JSON.parse(m![1]!) as {
+      posts: { url: string; body: { batch?: unknown[] } | null }[];
+    };
+
+    // Exactly one POST, to the resolved sentinel endpoint.
+    assert.equal(out.posts.length, 1, 'enabled run POSTs exactly one telemetry batch');
+    assert.equal(out.posts[0]!.url, sentinel, 'POST went to the resolved /analytics endpoint');
+
+    // The body is a well-formed Segment batch of 1..100 `track` events.
+    const body = out.posts[0]!.body;
+    assert.ok(body && Array.isArray(body.batch), 'body is { batch: [...] }');
+    const batch = body.batch as Array<{
+      type: string;
+      event: string;
+      anonymousId: string;
+      properties: Record<string, unknown>;
+      context: Record<string, unknown>;
+      timestamp: string;
+    }>;
+    assert.ok(batch.length >= 1 && batch.length <= 100, 'batch holds 1..100 events');
+    for (const ev of batch) {
+      assert.equal(ev.type, 'track');
+      assert.match(ev.event, /^reactor\./, 'event name is namespaced reactor.*');
+      assert.equal(typeof ev.anonymousId, 'string');
+      assert.ok(ev.anonymousId.length > 0, 'anonymousId (installId) is present');
+      assert.equal(typeof ev.timestamp, 'string');
+      // CRITICAL: context may ONLY contain whitelisted keys — here exactly library
+      // (server validates with forbidNonWhitelisted; any other key is HTTP 400).
+      assert.deepEqual(Object.keys(ev.context), ['library'], 'context has ONLY library');
+      assert.equal(ev.context.library, '@openprose/reactor-cli');
+    }
+    // doctor fires reactor.first_run (first machine run) + reactor.doctor.
+    const names = batch.map((e) => e.event);
+    assert.ok(names.includes('reactor.doctor'), 'the doctor event is in the batch');
+    assert.ok(names.includes('reactor.first_run'), 'the first_run event is in the batch');
+  });
+});

--- a/packages/reactor-cli/src/__tests__/run.test.ts
+++ b/packages/reactor-cli/src/__tests__/run.test.ts
@@ -40,6 +40,8 @@ import { bootServe } from '../commands/serve';
 import { runTriggerCommand } from '../commands/trigger';
 import { createSerialQueue } from '../run/serial-queue';
 import { fakeStructuredProvider } from './fake-provider';
+import { fakeTelemetry } from './fake-telemetry';
+import { TelemetryEvent } from '../telemetry';
 
 // The on-disk two-node fixture (resolve against the SDK SOURCE tree, as the
 // Phase-1 compile gate does).
@@ -493,6 +495,104 @@ describe('receipt chain integrity (offline gate)', () => {
         assert.equal(verification.ok, true, `node ${node} receipt chain must verify`);
       }
       await handle.shutdown();
+    } finally {
+      rmSync(d.state, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('command telemetry fire points (run / trigger)', () => {
+  it('reactor.run fires success with bucketed dispositions on a boot', async () => {
+    const d = freshDirs();
+    const fake = fakeTelemetry();
+    try {
+      const out = capture();
+      const code = await runRunCommand(
+        {
+          projectDir: FIXTURE_DIR,
+          stateDir: d.state,
+          json: true,
+          testAdapters: {
+            clock: createSystemClockAdapter(),
+            storage: createMemoryStorageAdapter(),
+            worldModel: new FileSystemWorldModelStore({
+              directory: join(d.state, 'world-models'),
+            }),
+          },
+          testRender: { buildRender: buildFakeRender as never },
+          testCompileOptions: testCompileOptions() as never,
+        },
+        out.write,
+        fake.telemetry,
+      );
+      assert.equal(code, 0);
+      const runs = fake.events.filter((e) => e.name === TelemetryEvent.RUN);
+      assert.equal(runs.length, 1, 'exactly one reactor.run event');
+      const props = runs[0]!.properties;
+      assert.equal(props.command, 'run');
+      assert.equal(props.outcome, 'success');
+      // Dispositions are tallied + bucketed by fixed kind (never node identities).
+      assert.ok(props.dispositions, 'dispositions tally present');
+      assert.equal(props.dispositions!['rendered'], '1-5');
+      // The values are bucket labels, not raw counts.
+      for (const v of Object.values(props.dispositions!)) {
+        assert.match(String(v), /^(0|1-5|6-20|21\+)$/);
+      }
+    } finally {
+      rmSync(d.state, { recursive: true, force: true });
+    }
+  });
+
+  it('reactor.run fires failure when no contracts are found', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'reactor-cli-run-empty-'));
+    const state = mkdtempSync(join(tmpdir(), 'reactor-cli-run-state-'));
+    const fake = fakeTelemetry();
+    try {
+      const out = capture();
+      const code = await runRunCommand(
+        { projectDir: empty, stateDir: state, json: true, offline: true },
+        out.write,
+        fake.telemetry,
+      );
+      assert.notEqual(code, 0);
+      const runs = fake.events.filter((e) => e.name === TelemetryEvent.RUN);
+      assert.equal(runs.length, 1);
+      assert.equal(runs[0]!.properties.outcome, 'failure');
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+      rmSync(state, { recursive: true, force: true });
+    }
+  });
+
+  it('reactor.trigger fires on an external-wake one-shot mount', async () => {
+    const d = freshDirs();
+    const fake = fakeTelemetry();
+    try {
+      const out = capture();
+      const code = await runTriggerCommand(
+        {
+          node: MONITOR,
+          projectDir: FIXTURE_DIR,
+          stateDir: d.state,
+          json: true,
+          testAdapters: {
+            clock: createSystemClockAdapter(),
+            storage: createMemoryStorageAdapter(),
+            worldModel: new FileSystemWorldModelStore({
+              directory: join(d.state, 'world-models'),
+            }),
+          },
+          testRender: { buildRender: buildFakeRender as never },
+          testCompileOptions: testCompileOptions() as never,
+        },
+        out.write,
+        fake.telemetry,
+      );
+      assert.equal(code, 0);
+      const triggers = fake.events.filter((e) => e.name === TelemetryEvent.TRIGGER);
+      assert.equal(triggers.length, 1, 'exactly one reactor.trigger event');
+      assert.equal(triggers[0]!.properties.command, 'trigger');
+      assert.equal(triggers[0]!.properties.outcome, 'success');
     } finally {
       rmSync(d.state, { recursive: true, force: true });
     }

--- a/packages/reactor-cli/src/__tests__/serve-host.test.ts
+++ b/packages/reactor-cli/src/__tests__/serve-host.test.ts
@@ -40,10 +40,13 @@ import {
 } from '@openprose/reactor/adapters';
 
 import { bootHost } from '../run/host';
+import { runServeCommand } from '../commands/serve';
 import { startHttpServer } from '../run/http-server';
 import { rollupCost } from '../run/cost';
 import { createWorkerPool } from '../run/worker-pool';
 import { fakeStructuredProvider } from './fake-provider';
+import { fakeTelemetry } from './fake-telemetry';
+import { TelemetryEvent } from '../telemetry';
 
 const SDK_ROOT = join(require.resolve('@openprose/reactor'), '..', '..');
 const FIXTURE_DIR = join(
@@ -465,5 +468,127 @@ describe('the cost projector (offline gate)', () => {
     assert.deepEqual(rolled.bySurpriseCause['self'], { fresh: 10, reused: 9 });
     assert.equal(rolled.dispositions.rendered, 2);
     assert.equal(rolled.dispositions.skipped, 1);
+  });
+});
+
+describe('reactor serve telemetry fire points', () => {
+  it('fires exactly one reactor.serve boot event with bucketed cadence/concurrency', async () => {
+    const stateRoot = freshState();
+    const fake = fakeTelemetry();
+    try {
+      const code = await runServeCommand(
+        {
+          projectDir: FIXTURE_DIR,
+          stateDir: stateRoot,
+          offline: true,
+          pollIntervalMs: 10,
+          concurrency: 1,
+          returnHost: true, // boot + bind, then return before the loop.
+          testSeams: { default: seamFor(stateRoot, 'default') },
+        },
+        () => {},
+        fake.telemetry,
+      );
+      assert.equal(code, 0);
+      const serve = fake.events.filter((e) => e.name === TelemetryEvent.SERVE);
+      assert.equal(serve.length, 1, 'exactly one serve boot event (no loop ran)');
+      const props = serve[0]!.properties;
+      assert.equal(props.command, 'serve');
+      assert.equal(props.outcome, 'success');
+      // ServeProperties: cadence + concurrency, both bucketed (never raw ms/N).
+      assert.equal(props.pollIntervalBucket, '<1s');
+      assert.equal(props.concurrencyBucket, '1-5');
+      assert.equal((props as unknown as Record<string, unknown>).pollIntervalMs, undefined);
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('SAMPLES the poll-cycle event first-cycle-only across many cycles', async () => {
+    const stateRoot = freshState();
+    const fake = fakeTelemetry();
+    try {
+      // Snapshot the SIGINT listeners present BEFORE serve boots (the test
+      // runner's own handler lives here); serve installs ITS handler during boot.
+      const preexistingBeforeBoot = process.listeners('SIGINT').slice();
+      // Drive the FULL blocking daemon loop with a tiny cadence so several cycles
+      // run, then stop via SIGINT. The poll-cycle SERVE event is first-only-sampled
+      // (serve.ts:609-628), so regardless of how many cycles fire we must see at
+      // most ONE sampled poll event in addition to the single boot event.
+      const serveDone = runServeCommand(
+        {
+          projectDir: FIXTURE_DIR,
+          stateDir: stateRoot,
+          offline: true,
+          json: true,
+          pollIntervalMs: 5,
+          concurrency: 1,
+          testSeams: { default: seamFor(stateRoot, 'default') },
+        },
+        () => {},
+        fake.telemetry,
+      );
+      // Let multiple poll cycles elapse, then signal a graceful shutdown. We must
+      // not let the SYNTHETIC SIGINT reach the test runner's own SIGINT handler
+      // (which would terminate the file with code 130). So temporarily detach any
+      // pre-existing SIGINT listeners, emit (reaching only serve's `process.once`
+      // handler installed during boot), then restore them.
+      await new Promise((r) => setTimeout(r, 120));
+      const preexisting = process.listeners('SIGINT').slice();
+      // Keep only the serve loop's handler: remove the listeners that were present
+      // BEFORE this serve booted (i.e. the test runner's), emit, then restore.
+      const serveHandlers = process
+        .listeners('SIGINT')
+        .filter((l) => !preexistingBeforeBoot.includes(l));
+      process.removeAllListeners('SIGINT');
+      for (const h of serveHandlers) process.on('SIGINT', h as never);
+      process.emit('SIGINT');
+      const code = await serveDone;
+      // Restore the original listeners (whatever the runner had installed).
+      process.removeAllListeners('SIGINT');
+      for (const h of preexisting) {
+        if (!serveHandlers.includes(h)) process.on('SIGINT', h as never);
+      }
+      assert.equal(code, 0);
+      const serve = fake.events.filter((e) => e.name === TelemetryEvent.SERVE);
+      // One boot event + exactly one sampled poll-cycle event = 2 total, never more,
+      // even though many cycles ran. Both carry success + the serve extras.
+      assert.equal(serve.length, 2, 'boot + exactly one sampled poll-cycle event');
+      for (const e of serve) {
+        assert.equal(e.properties.outcome, 'success');
+        assert.equal(e.properties.command, 'serve');
+        assert.equal(e.properties.pollIntervalBucket, '<1s');
+      }
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fires reactor.serve failure + reactor.error when boot fails (no contracts)', async () => {
+    const stateRoot = freshState();
+    const emptyProject = mkdtempSync(join(tmpdir(), 'reactor-cli-serve-empty-'));
+    const fake = fakeTelemetry();
+    try {
+      const code = await runServeCommand(
+        {
+          projectDir: emptyProject,
+          stateDir: stateRoot,
+          offline: true,
+          json: true,
+          returnHost: true,
+        },
+        () => {},
+        fake.telemetry,
+      );
+      assert.notEqual(code, 0);
+      const serve = fake.events.filter((e) => e.name === TelemetryEvent.SERVE);
+      const errors = fake.events.filter((e) => e.name === TelemetryEvent.ERROR);
+      assert.equal(serve.length, 1);
+      assert.equal(serve[0]!.properties.outcome, 'failure');
+      assert.equal(errors.length, 1, 'a categorized reactor.error accompanies the boot failure');
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+      rmSync(emptyProject, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/reactor-cli/src/__tests__/telemetry-command.test.ts
+++ b/packages/reactor-cli/src/__tests__/telemetry-command.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `reactor telemetry` subcommand tests — the opt-out / inspection surface
+ * (02-IMPLEMENTATION-PLAN.md §5).
+ *
+ * Hermetic + keyless: each test points `REACTOR_CONFIG_DIR` at a throwaway temp
+ * dir (the identity leaf's test seam) so the machine config writes never touch the
+ * real `~/.reactor`. No network — `--dump` only PRINTS. Asserts:
+ *   - `status` reports enabled/disabled + the gate reason + endpoint.
+ *   - `disable` writes telemetryEnabled:false (permanent); `enable` clears it.
+ *   - `--dump` prints the EXACT `{ batch: [track] }` wire shape with `context`
+ *     carrying ONLY `library`, and never POSTs.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { runTelemetryCommand } from '../commands/telemetry';
+
+let tmpDir: string;
+let prevConfigDir: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'reactor-telemetry-'));
+  prevConfigDir = process.env['REACTOR_CONFIG_DIR'];
+  process.env['REACTOR_CONFIG_DIR'] = tmpDir;
+});
+
+afterEach(() => {
+  if (prevConfigDir === undefined) delete process.env['REACTOR_CONFIG_DIR'];
+  else process.env['REACTOR_CONFIG_DIR'] = prevConfigDir;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Capture the lines a command writes. */
+function capture(): { lines: string[]; write: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, write: (line) => lines.push(line) };
+}
+
+/** Parse the JSON the config file holds (the identity leaf's schema). */
+function readConfig(): Record<string, unknown> | undefined {
+  const file = path.join(tmpDir, 'config.json');
+  if (!existsSync(file)) return undefined;
+  return JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+}
+
+describe('reactor telemetry', () => {
+  it('disable writes telemetryEnabled:false to the machine config', async () => {
+    const { write } = capture();
+    const code = await runTelemetryCommand({ sub: 'disable' }, write);
+    assert.equal(code, 0);
+    assert.equal(readConfig()?.telemetryEnabled, false);
+  });
+
+  it('enable clears the opt-out (telemetryEnabled:true)', async () => {
+    await runTelemetryCommand({ sub: 'disable' }, () => {});
+    assert.equal(readConfig()?.telemetryEnabled, false);
+    const code = await runTelemetryCommand({ sub: 'enable' }, () => {});
+    assert.equal(code, 0);
+    assert.equal(readConfig()?.telemetryEnabled, true);
+  });
+
+  it('disable then enable preserves the install id (no churn)', async () => {
+    await runTelemetryCommand({ sub: 'disable' }, () => {});
+    const idA = readConfig()?.installId;
+    await runTelemetryCommand({ sub: 'enable' }, () => {});
+    const idB = readConfig()?.installId;
+    assert.equal(typeof idA, 'string');
+    assert.equal(idA, idB, 'the anonymous install id is stable across enable/disable');
+  });
+
+  it('status (json) reports the gate decision + endpoint; disabled under DO_NOT_TRACK', async () => {
+    // Drive the gate via env (seam-independent) so the assertion does not depend on
+    // the real ~/.reactor: DO_NOT_TRACK is the canonical opt-out the gate honors.
+    const prev = process.env['DO_NOT_TRACK'];
+    process.env['DO_NOT_TRACK'] = '1';
+    try {
+      const { lines, write } = capture();
+      const code = await runTelemetryCommand({ sub: 'status', json: true }, write);
+      assert.equal(code, 0);
+      const out = JSON.parse(lines.join('')) as {
+        enabled: boolean;
+        reason?: string;
+        endpoint: string;
+      };
+      assert.equal(out.enabled, false);
+      assert.equal(out.reason, 'do_not_track');
+      assert.match(out.endpoint, /\/analytics$/);
+    } finally {
+      if (prev === undefined) delete process.env['DO_NOT_TRACK'];
+      else process.env['DO_NOT_TRACK'] = prev;
+    }
+  });
+
+  it('disable makes a subsequent status report disabled (config-coherent gate)', async () => {
+    // The gate reads the SAME machine config (via the REACTOR_CONFIG_DIR seam) that
+    // `disable` wrote, so the opt-out is coherent end-to-end. We pin a TTY + clean
+    // env so the config flag is the only disable condition in play.
+    await runTelemetryCommand({ sub: 'disable' }, () => {});
+    // Clear every HIGHER-precedence opt-out so the machine-config flag is the only
+    // disable condition the gate can surface (the offline test harness itself sets
+    // REACTOR_OFFLINE=1 + CI, which would otherwise win the precedence).
+    const higherPrecedence = [
+      'DO_NOT_TRACK',
+      'REACTOR_TELEMETRY',
+      'REACTOR_TELEMETRY_DISABLED',
+      'REACTOR_OFFLINE',
+      'CI',
+    ] as const;
+    const saved = new Map<string, string | undefined>();
+    for (const k of higherPrecedence) {
+      saved.set(k, process.env[k]);
+      delete process.env[k];
+    }
+    const prevIsTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    try {
+      const { lines, write } = capture();
+      await runTelemetryCommand({ sub: 'status', json: true }, write);
+      const out = JSON.parse(lines.join('')) as { enabled: boolean; reason?: string };
+      assert.equal(out.enabled, false);
+      assert.equal(out.reason, 'config_disabled');
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', { value: prevIsTty, configurable: true });
+      for (const [k, v] of saved) {
+        if (v !== undefined) process.env[k] = v;
+      }
+    }
+  });
+
+  it('--dump prints the exact { batch: [track] } wire shape, context only { library }', async () => {
+    const { lines, write } = capture();
+    const code = await runTelemetryCommand({ dump: true }, write);
+    assert.equal(code, 0);
+    const dump = JSON.parse(lines.join('\n')) as {
+      endpoint: string;
+      batch: Array<Record<string, unknown>>;
+    };
+    assert.match(dump.endpoint, /\/analytics$/);
+    assert.ok(Array.isArray(dump.batch) && dump.batch.length === 1);
+    const ev = dump.batch[0]!;
+    assert.equal(ev.type, 'track');
+    assert.equal(typeof ev.anonymousId, 'string');
+    assert.equal(ev.event, 'reactor.doctor');
+    assert.equal(typeof ev.timestamp, 'string');
+    const context = ev.context as Record<string, unknown>;
+    assert.deepEqual(Object.keys(context), ['library']);
+    assert.equal(context.library, '@openprose/reactor-cli');
+    // properties carry only the content-free shared block.
+    const props = ev.properties as Record<string, unknown>;
+    assert.equal(props.schemaVersion, 1);
+    assert.equal(props.command, 'doctor');
+    assert.equal(props.outcome, 'success');
+  });
+
+  it('--dump honors the REACTOR_TELEMETRY_ENDPOINT override', async () => {
+    const prev = process.env['REACTOR_TELEMETRY_ENDPOINT'];
+    process.env['REACTOR_TELEMETRY_ENDPOINT'] = 'https://api.dev.openprose.ai/analytics';
+    try {
+      const { lines, write } = capture();
+      await runTelemetryCommand({ dump: true }, write);
+      const dump = JSON.parse(lines.join('\n')) as { endpoint: string };
+      assert.equal(dump.endpoint, 'https://api.dev.openprose.ai/analytics');
+    } finally {
+      if (prev === undefined) delete process.env['REACTOR_TELEMETRY_ENDPOINT'];
+      else process.env['REACTOR_TELEMETRY_ENDPOINT'] = prev;
+    }
+  });
+});

--- a/packages/reactor-cli/src/cli.ts
+++ b/packages/reactor-cli/src/cli.ts
@@ -26,6 +26,9 @@ import {
   type ReceiptsSubcommand,
 } from './commands/observe';
 import { cliVersion } from './meta';
+import { loadConfig } from './config';
+import { initTelemetry, NOOP_TELEMETRY, type Telemetry } from './telemetry';
+import { runTelemetryCommand, type TelemetryCliOptions } from './commands/telemetry';
 
 /**
  * Project the four shared global flags off commander's merged options into the
@@ -59,7 +62,10 @@ function globalsOf(cmd: Command): {
  * the exit code does not depend on the parser's internal post-action behavior
  * (which differs across commander majors).
  */
-export function buildProgram(onExitCode: (code: number) => void = () => {}): Command {
+export function buildProgram(
+  onExitCode: (code: number) => void = () => {},
+  telemetry: Telemetry = NOOP_TELEMETRY,
+): Command {
   const program = new Command();
 
   program
@@ -80,12 +86,16 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .action(async (dir: string | undefined, cmdOptions: { force?: boolean }, cmd: Command) => {
       const { json, offline } = globalsOf(cmd);
       onExitCode(
-        await runInitCommand({
-          ...(dir !== undefined ? { dir } : {}),
-          ...(cmdOptions.force !== undefined ? { force: cmdOptions.force } : {}),
-          ...(json !== undefined ? { json } : {}),
-          ...(offline !== undefined ? { offline } : {}),
-        }),
+        await runInitCommand(
+          {
+            ...(dir !== undefined ? { dir } : {}),
+            ...(cmdOptions.force !== undefined ? { force: cmdOptions.force } : {}),
+            ...(json !== undefined ? { json } : {}),
+            ...(offline !== undefined ? { offline } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
     });
 
@@ -97,10 +107,14 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .option('--live', 'additionally probe one live smoke render (requires a key + deps)')
     .action(async (cmdOptions: { live?: boolean }, cmd: Command) => {
       onExitCode(
-        await runDoctor({
-          ...globalsOf(cmd),
-          ...(cmdOptions.live !== undefined ? { live: cmdOptions.live } : {}),
-        }),
+        await runDoctor(
+          {
+            ...globalsOf(cmd),
+            ...(cmdOptions.live !== undefined ? { live: cmdOptions.live } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
     });
 
@@ -113,11 +127,15 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .option('--check', 'exit non-zero if the cache is stale; do not compile (CI)')
     .action(async (cmdOptions: { force?: boolean; check?: boolean }, cmd: Command) => {
       onExitCode(
-        await runCompileCommand({
-          ...globalsOf(cmd),
-          ...(cmdOptions.force !== undefined ? { force: cmdOptions.force } : {}),
-          ...(cmdOptions.check !== undefined ? { check: cmdOptions.check } : {}),
-        }),
+        await runCompileCommand(
+          {
+            ...globalsOf(cmd),
+            ...(cmdOptions.force !== undefined ? { force: cmdOptions.force } : {}),
+            ...(cmdOptions.check !== undefined ? { check: cmdOptions.check } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
     });
 
@@ -127,7 +145,7 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
       'Ensure the IR is fresh, boot the reactor, drain to quiescence, and report',
     )
     .action(async (_cmdOptions: Record<string, unknown>, cmd: Command) => {
-      onExitCode(await runRunCommand(globalsOf(cmd)));
+      onExitCode(await runRunCommand(globalsOf(cmd), undefined, telemetry));
     });
 
   program
@@ -161,19 +179,23 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
         const httpPort =
           cmdOptions.http !== undefined ? Number(cmdOptions.http) : undefined;
         onExitCode(
-          await runServeCommand({
-            ...globalsOf(cmd),
-            ...(pollIntervalMs !== undefined && Number.isFinite(pollIntervalMs)
-              ? { pollIntervalMs }
-              : {}),
-            ...(concurrency !== undefined && Number.isFinite(concurrency)
-              ? { concurrency }
-              : {}),
-            ...(httpPort !== undefined && Number.isFinite(httpPort)
-              ? { httpPort }
-              : {}),
-            ...(cmdOptions.host !== undefined ? { httpHost: cmdOptions.host } : {}),
-          }),
+          await runServeCommand(
+            {
+              ...globalsOf(cmd),
+              ...(pollIntervalMs !== undefined && Number.isFinite(pollIntervalMs)
+                ? { pollIntervalMs }
+                : {}),
+              ...(concurrency !== undefined && Number.isFinite(concurrency)
+                ? { concurrency }
+                : {}),
+              ...(httpPort !== undefined && Number.isFinite(httpPort)
+                ? { httpPort }
+                : {}),
+              ...(cmdOptions.host !== undefined ? { httpHost: cmdOptions.host } : {}),
+            },
+            undefined,
+            telemetry,
+          ),
         );
       },
     );
@@ -190,11 +212,15 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
         cmd: Command,
       ) => {
         onExitCode(
-          await runTriggerCommand({
-            node,
-            ...(cmdOptions.data !== undefined ? { data: cmdOptions.data } : {}),
-            ...globalsOf(cmd),
-          }),
+          await runTriggerCommand(
+            {
+              node,
+              ...(cmdOptions.data !== undefined ? { data: cmdOptions.data } : {}),
+              ...globalsOf(cmd),
+            },
+            undefined,
+            telemetry,
+          ),
         );
       },
     );
@@ -208,14 +234,14 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .command('status')
     .description('Report the standing compile cost beside the live run cost + dispositions')
     .action(async (_opts: Record<string, unknown>, cmd: Command) => {
-      onExitCode(await runStatusCommand(globalsOf(cmd)));
+      onExitCode(await runStatusCommand(globalsOf(cmd), undefined, telemetry));
     });
 
   program
     .command('topology')
     .description('Print the compiled DAG: nodes (+ wake source) and resolved edges')
     .action(async (_opts: Record<string, unknown>, cmd: Command) => {
-      onExitCode(await runTopologyCommand(globalsOf(cmd)));
+      onExitCode(await runTopologyCommand(globalsOf(cmd), undefined, telemetry));
     });
 
   program
@@ -225,11 +251,15 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .option('--strict', 'exit non-zero if the node receipt chain does not verify (CI)')
     .action(async (node: string, opts: { strict?: boolean }, cmd: Command) => {
       onExitCode(
-        await runInspectCommand({
-          ...globalsOf(cmd),
-          node,
-          ...(opts.strict !== undefined ? { strict: opts.strict } : {}),
-        }),
+        await runInspectCommand(
+          {
+            ...globalsOf(cmd),
+            node,
+            ...(opts.strict !== undefined ? { strict: opts.strict } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
     });
 
@@ -239,10 +269,14 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .option('--node <node>', 'filter the stream to a single node')
     .action(async (opts: { node?: string }, cmd: Command) => {
       onExitCode(
-        await runLogsCommand({
-          ...globalsOf(cmd),
-          ...(opts.node !== undefined ? { node: opts.node } : {}),
-        }),
+        await runLogsCommand(
+          {
+            ...globalsOf(cmd),
+            ...(opts.node !== undefined ? { node: opts.node } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
     });
 
@@ -252,10 +286,14 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
     .argument('[node]', 'a single node to trace (default: every node with receipts)')
     .action(async (node: string | undefined, _opts: Record<string, unknown>, cmd: Command) => {
       onExitCode(
-        await runTraceCommand({
-          ...globalsOf(cmd),
-          ...(node !== undefined ? { node } : {}),
-        }),
+        await runTraceCommand(
+          {
+            ...globalsOf(cmd),
+            ...(node !== undefined ? { node } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
     });
 
@@ -285,13 +323,38 @@ export function buildProgram(onExitCode: (code: number) => void = () => {}): Com
         return;
       }
       onExitCode(
-        await runReceiptsCommand({
-          ...globalsOf(cmd),
-          ...(normalized !== undefined ? { sub: normalized } : {}),
-          ...(opts.node !== undefined ? { node: opts.node } : {}),
-          ...(opts.rate !== undefined ? { rate: opts.rate } : {}),
-        }),
+        await runReceiptsCommand(
+          {
+            ...globalsOf(cmd),
+            ...(normalized !== undefined ? { sub: normalized } : {}),
+            ...(opts.node !== undefined ? { node: opts.node } : {}),
+            ...(opts.rate !== undefined ? { rate: opts.rate } : {}),
+          },
+          undefined,
+          telemetry,
+        ),
       );
+    });
+
+  // -------------------------------------------------------------------------
+  // `reactor telemetry` — the opt-out / inspection subcommand (status | enable |
+  // disable | --dump). Keyless + read/writes only ~/.reactor/config.json + env.
+  // -------------------------------------------------------------------------
+  program
+    .command('telemetry')
+    .description(
+      'Inspect or change anonymous CLI telemetry: status | enable | disable (--dump prints what would be sent)',
+    )
+    .argument('[sub]', 'status | enable | disable (default: status)')
+    .option('--dump', 'print the exact JSON a representative event WOULD send, then exit')
+    .action(async (sub: string | undefined, opts: { dump?: boolean }, cmd: Command) => {
+      const { json } = globalsOf(cmd);
+      const telemetryOptions: TelemetryCliOptions = {
+        ...(sub !== undefined ? { sub } : {}),
+        ...(opts.dump !== undefined ? { dump: opts.dump } : {}),
+        ...(json !== undefined ? { json } : {}),
+      };
+      onExitCode(await runTelemetryCommand(telemetryOptions));
     });
 
   return program;
@@ -318,9 +381,24 @@ const COMMANDER_SUCCESS_CODES = new Set([
  */
 export async function main(argv: string[]): Promise<number> {
   let code = 0;
+
+  // Initialize telemetry ONCE at entry. The gate (CI/non-TTY/DO_NOT_TRACK/env/
+  // config) returns a NO-OP when disabled — a disabled run does zero work + zero
+  // egress, so this never perturbs the hot path. The project-level preference
+  // (`reactor.yml` → `telemetry:`) is read from the resolved `--project` dir.
+  // initTelemetry never throws (it fails closed to the no-op), so the CLI never
+  // depends on it. NO first-run notice is printed here — that lives in `doctor`.
+  const projectTelemetry = projectTelemetryFromArgv(argv);
+  const telemetry = await initTelemetry(
+    projectTelemetry !== undefined ? { projectTelemetry } : {},
+  ).then(
+    (r) => r.telemetry,
+    () => NOOP_TELEMETRY,
+  );
+
   const program = buildProgram((c) => {
     code = c;
-  });
+  }, telemetry);
   // Take ownership of commander's process-exit so usage errors exit 2 (the
   // documented code), and help/version exit 0 — instead of commander's blanket 1.
   // exitOverride must be set on EACH command: an unknown option on a subcommand
@@ -351,8 +429,69 @@ export async function main(argv: string[]): Promise<number> {
       return 2;
     }
     throw err; // a real error — let the caller's catch report it (exit 1).
+  } finally {
+    // Drain queued telemetry on EVERY exit path (success, usage error, or a
+    // rethrown failure) behind a hard, bounded wall so a slow/down endpoint can
+    // never delay or hang the CLI's exit. `flush()` is already self-bounding +
+    // non-throwing; this is a belt-and-braces ceiling, and a no-op telemetry
+    // resolves instantly.
+    await flushBounded(telemetry);
   }
   return code;
+}
+
+/** A hard wall-clock ceiling (ms) on the exit-path telemetry flush. */
+const FLUSH_EXIT_BUDGET_MS = 2500;
+
+/**
+ * Await `telemetry.flush()` but never longer than {@link FLUSH_EXIT_BUDGET_MS}.
+ * The flush client is already bounded + swallows transport errors; this races it
+ * against a timer so a pathological hang still cannot delay CLI exit, and any
+ * rejection is swallowed (telemetry must never affect the exit code).
+ */
+async function flushBounded(telemetry: Telemetry): Promise<void> {
+  try {
+    await Promise.race([
+      telemetry.flush(),
+      new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, FLUSH_EXIT_BUDGET_MS);
+        // Don't let the timer itself keep the event loop alive past a clean exit.
+        if (typeof t.unref === 'function') t.unref();
+      }),
+    ]);
+  } catch {
+    // Telemetry is best-effort; a flush fault never perturbs the CLI.
+  }
+}
+
+/**
+ * Resolve the project-level telemetry preference (`reactor.yml` → `telemetry:`)
+ * from argv, BEFORE commander parses — so the gate can honor a project opt-out and
+ * the endpoint override on the very first run. Reads `--project <dir>` (default
+ * `.`) and loads the config keyless; any fault yields `undefined` (no preference),
+ * never a throw. This is the only argv pre-read the entrypoint performs.
+ */
+function projectTelemetryFromArgv(
+  argv: string[],
+): { enabled?: boolean; endpoint?: string } | undefined {
+  try {
+    let projectDir: string | undefined;
+    for (let i = 0; i < argv.length; i++) {
+      if (argv[i] === '--project') {
+        projectDir = argv[i + 1];
+        break;
+      }
+      const eq = argv[i]?.startsWith('--project=') ? argv[i]!.slice('--project='.length) : undefined;
+      if (eq !== undefined) {
+        projectDir = eq;
+        break;
+      }
+    }
+    const config = loadConfig(projectDir !== undefined ? { projectDir } : {});
+    return config.telemetry;
+  } catch {
+    return undefined;
+  }
 }
 
 // Only run when invoked as a binary, not when imported by tests.

--- a/packages/reactor-cli/src/commands/compile.ts
+++ b/packages/reactor-cli/src/commands/compile.ts
@@ -32,6 +32,14 @@ import {
 import type { ConfigOverrides } from '../config';
 import { loadConfig } from '../config';
 import { resolveSdk } from '../meta';
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  buildEventProperties,
+  buildGraphProperties,
+  errorCategory,
+  type Telemetry,
+} from '../telemetry';
 
 export interface CompileCommandOptions extends ConfigOverrides {
   /** Re-compile regardless of cache freshness. */
@@ -80,10 +88,41 @@ export interface CompileReport {
 export async function runCompileCommand(
   options: CompileCommandOptions = {},
   write: (line: string) => void = (line) => process.stdout.write(line + '\n'),
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
   if (options.offline === true) {
     process.env['REACTOR_OFFLINE'] = '1';
   }
+
+  // Wall-clock start for the bucketed duration on the outcome event. Telemetry is
+  // a no-op when disabled, so this perturbs nothing on the hot path.
+  const startedAt = Date.now();
+  /** Fire `reactor.compile` with the bucketed shared block + graph extras. */
+  const fireCompile = (
+    outcome: 'success' | 'failure' | 'cache_hit',
+    graph?: { nodes?: number; edges?: number; costFresh?: number; costReused?: number },
+  ): void => {
+    telemetry.event(
+      TelemetryEvent.COMPILE,
+      buildEventProperties(
+        { command: 'compile', outcome, durationMs: Date.now() - startedAt },
+        buildGraphProperties({
+          ...(graph ?? {}),
+          provider: config?.model.provider,
+        }),
+      ),
+    );
+  };
+  /** Fire `reactor.error` with a coarse category (never a message/stack). */
+  const fireError = (err: unknown): void => {
+    telemetry.event(
+      TelemetryEvent.ERROR,
+      buildEventProperties(
+        { command: 'compile', outcome: 'failure', durationMs: Date.now() - startedAt },
+        { errorCategory: errorCategory(err) },
+      ),
+    );
+  };
 
   const config = loadConfig({
     stateDir: options.stateDir,
@@ -106,6 +145,7 @@ export async function runCompileCommand(
     } else {
       write(msg);
     }
+    fireError(new Error(msg));
     return 1;
   }
   const setFingerprint = contractSetFingerprint(images);
@@ -115,10 +155,13 @@ export async function runCompileCommand(
   // --check: never compile; non-zero exit if stale.
   if (options.check === true) {
     if (fresh) {
-      emitReport(cacheReport(stateDir, setFingerprint, sdkVersion, model, 'cache-hit'), options, write);
+      const report = cacheReport(stateDir, setFingerprint, sdkVersion, model, 'cache-hit');
+      emitReport(report, options, write);
+      fireCompile('cache_hit', { nodes: report.nodes, edges: report.edges });
       return 0;
     }
     emitReport(staleReport(stateDir, setFingerprint, sdkVersion, model), options, write);
+    fireCompile('failure');
     return 1;
   }
 
@@ -126,11 +169,9 @@ export async function runCompileCommand(
   // prove the cache is mountable from a fresh process (compileNode, no model).
   if (fresh && options.force !== true) {
     loadIR(stateDir); // throws if the cache is incomplete — a hit must be whole.
-    emitReport(
-      cacheReport(stateDir, setFingerprint, sdkVersion, model, 'cache-hit'),
-      options,
-      write,
-    );
+    const report = cacheReport(stateDir, setFingerprint, sdkVersion, model, 'cache-hit');
+    emitReport(report, options, write);
+    fireCompile('cache_hit', { nodes: report.nodes, edges: report.edges });
     return 0;
   }
 
@@ -154,6 +195,7 @@ export async function runCompileCommand(
     // handler (which prints it and exits 1).
     const hint = providerErrorHint(err);
     if (hint === undefined) {
+      fireError(err);
       throw err;
     }
     if (options.json === true) {
@@ -161,6 +203,7 @@ export async function runCompileCommand(
     } else {
       write(`reactor compile failed: ${hint}`);
     }
+    fireError(err);
     return 1;
   }
 
@@ -184,6 +227,12 @@ export async function runCompileCommand(
     state_dir: stateDir,
   };
   emitReport(report, options, write);
+  fireCompile('success', {
+    nodes: report.nodes,
+    edges: report.edges,
+    costFresh: report.cost.fresh,
+    costReused: report.cost.reused,
+  });
   return 0;
 }
 

--- a/packages/reactor-cli/src/commands/doctor.ts
+++ b/packages/reactor-cli/src/commands/doctor.ts
@@ -29,6 +29,14 @@ import {
 } from '../compile/ir-cache';
 import { loadContractSet } from '../compile/contract-images';
 import { defaultSandboxHost } from '../run/sandbox';
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  buildEventProperties,
+  maybeShowDoctorNotice,
+  readMachineConfig,
+  type Telemetry,
+} from '../telemetry';
 
 /** Minimum node major version the CLI is validated against (matches the SDK's
  * engines.node ">=20.0.0"). */
@@ -442,16 +450,56 @@ function formatIr(ir: DoctorReport['ir']): string {
 export async function runDoctor(
   options: DoctorCommandOptions = {},
   write: (line: string) => void = (line) => process.stdout.write(line + '\n'),
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
   if (options.offline === true) {
     process.env['REACTOR_OFFLINE'] = '1';
   }
+
+  const startedAt = Date.now();
+
+  // FIRST-RUN DISCLOSURE — doctor is the ONLY surface (03-DECISIONS.md #3). The
+  // notice prints to STDOUT via `write`, once per machine. Detect a first machine
+  // run BEFORE the notice stamps `noticeShownVersion`, so `reactor.first_run`
+  // fires exactly once alongside the disclosure. Fail-closed: a config read fault
+  // never blocks doctor (the notice leaf is itself defensive). The notice prints
+  // human text, so under `--json` we suppress it to keep stdout machine-parseable.
+  const firstRun = (() => {
+    try {
+      const cfg = readMachineConfig();
+      return cfg?.noticeShownVersion === undefined;
+    } catch {
+      return false;
+    }
+  })();
+  if (options.json !== true) {
+    maybeShowDoctorNotice(write);
+  }
+  if (firstRun) {
+    telemetry.event(
+      TelemetryEvent.FIRST_RUN,
+      buildEventProperties({ command: 'doctor', outcome: 'success', durationMs: 0 }),
+    );
+  }
+
   const report = await collectDoctorReport(options);
   if (options.json === true) {
     write(JSON.stringify(report));
   } else {
     write(formatDoctorReport(report));
   }
+
+  // `reactor.doctor` — outcome tracks the offline-health verdict (+ a requested
+  // `--live` smoke), the same boolean the exit code below reflects.
+  const healthy = report.healthyForOffline && (options.live !== true || report.live?.ok === true);
+  telemetry.event(
+    TelemetryEvent.DOCTOR,
+    buildEventProperties({
+      command: 'doctor',
+      outcome: healthy ? 'success' : 'failure',
+      durationMs: Date.now() - startedAt,
+    }),
+  );
   // Exit 0 only when healthy-for-offline AND (no --live requested, or the live
   // smoke passed). A requested `--live` that FAILS must exit non-zero so it
   // composes in CI as the documented exit-code table promises — while a

--- a/packages/reactor-cli/src/commands/init.ts
+++ b/packages/reactor-cli/src/commands/init.ts
@@ -26,6 +26,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  buildEventProperties,
+  type Telemetry,
+} from '../telemetry';
+
 /** Options for {@link runInitCommand}. */
 export interface InitCommandOptions {
   /** Target directory (the positional `[dir]`; default `.`). */
@@ -214,10 +221,20 @@ export function scaffoldFiles(): readonly ScaffoldFile[] {
 export async function runInitCommand(
   options: InitCommandOptions = {},
   write: (line: string) => void = (line) => process.stdout.write(line + '\n'),
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
   if (options.offline === true) {
     process.env['REACTOR_OFFLINE'] = '1';
   }
+
+  const startedAt = Date.now();
+  /** Fire `reactor.init` with the bucketed shared block (init carries no graph). */
+  const fireInit = (outcome: 'success' | 'failure'): void => {
+    telemetry.event(
+      TelemetryEvent.INIT,
+      buildEventProperties({ command: 'init', outcome, durationMs: Date.now() - startedAt }),
+    );
+  };
 
   const dir = path.resolve(options.dir ?? '.');
   const files = scaffoldFiles();
@@ -232,6 +249,7 @@ export async function runInitCommand(
       skipped: existing.map((f) => f.relativePath),
     };
     emit(report, options, write);
+    fireInit('failure');
     return 1;
   }
 
@@ -254,6 +272,7 @@ export async function runInitCommand(
         existingEntries: entries.sort(),
       };
       emit(report, options, write);
+      fireInit('failure');
       return 1;
     }
   }
@@ -273,6 +292,7 @@ export async function runInitCommand(
     skipped: [],
   };
   emit(report, options, write);
+  fireInit('success');
   return 0;
 }
 

--- a/packages/reactor-cli/src/commands/observe.ts
+++ b/packages/reactor-cli/src/commands/observe.ts
@@ -37,6 +37,14 @@ import {
   formatCost,
 } from './observe-format';
 import { emitError } from './emit';
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  buildEventProperties,
+  type ObserveSub,
+  type Outcome,
+  type Telemetry,
+} from '../telemetry';
 
 /** Shared options for the read-only observability commands. */
 export interface ObserveOptions extends ConfigOverrides {
@@ -75,6 +83,36 @@ function openView(options: ObserveOptions): StateView {
   return StateView.open(stateDir);
 }
 
+/**
+ * Fire one `reactor.observe` event for a read-only observability sub-command. The
+ * six observe commands collapse to a single event distinguished only by the
+ * coarse `sub` tag (a fixed vocabulary — never a node/path/argument). A failure
+ * outcome also fires `reactor.error` with a coarse category.
+ */
+function fireObserve(
+  telemetry: Telemetry,
+  sub: ObserveSub,
+  outcome: Outcome,
+  startedAt: number,
+): void {
+  telemetry.event(
+    TelemetryEvent.OBSERVE,
+    buildEventProperties(
+      { command: 'observe', outcome, durationMs: Date.now() - startedAt },
+      { sub },
+    ),
+  );
+  if (outcome === 'failure') {
+    telemetry.event(
+      TelemetryEvent.ERROR,
+      buildEventProperties(
+        { command: 'observe', outcome: 'failure', durationMs: Date.now() - startedAt },
+        { errorCategory: 'config' },
+      ),
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // status
 // ---------------------------------------------------------------------------
@@ -82,7 +120,9 @@ function openView(options: ObserveOptions): StateView {
 export async function runStatusCommand(
   options: ObserveOptions = {},
   write: Writer = stdout,
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
   const view = openView(options);
   const projection = projectStatus(view);
   if (options.json === true) {
@@ -90,6 +130,7 @@ export async function runStatusCommand(
   } else {
     write(formatStatus(projection));
   }
+  fireObserve(telemetry, 'status', 'success', startedAt);
   return 0;
 }
 
@@ -116,9 +157,12 @@ function topologyAbsentMessage(cmd: string, stateDir: string): string {
 export async function runTopologyCommand(
   options: ObserveOptions = {},
   write: Writer = stdout,
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
   const view = openView(options);
   if (!view.hasTopology()) {
+    fireObserve(telemetry, 'topology', 'failure', startedAt);
     return emitError(write, options.json, topologyAbsentMessage('topology', view.stateDir));
   }
   const projection = projectTopology(view);
@@ -127,6 +171,7 @@ export async function runTopologyCommand(
   } else {
     write(formatTopology(projection));
   }
+  fireObserve(telemetry, 'topology', 'success', startedAt);
   return 0;
 }
 
@@ -143,9 +188,12 @@ export interface InspectOptions extends ObserveOptions {
 export async function runInspectCommand(
   options: InspectOptions,
   write: Writer = stdout,
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
   const view = openView(options);
   if (!view.hasTopology()) {
+    fireObserve(telemetry, 'inspect', 'failure', startedAt);
     return emitError(
       write,
       options.json,
@@ -154,6 +202,7 @@ export async function runInspectCommand(
   }
   const projection = projectInspect(view, options.node);
   if (!projection.known) {
+    fireObserve(telemetry, 'inspect', 'failure', startedAt);
     return emitError(
       write,
       options.json,
@@ -168,8 +217,10 @@ export async function runInspectCommand(
   // The chain check exits nonzero only under --strict (so a plain inspect is a
   // pure read; a CI gate opts into the failure).
   if (options.strict === true && !projection.chain.ok) {
+    fireObserve(telemetry, 'inspect', 'failure', startedAt);
     return 1;
   }
+  fireObserve(telemetry, 'inspect', 'success', startedAt);
   return 0;
 }
 
@@ -185,7 +236,9 @@ export interface LogsOptions extends ObserveOptions {
 export async function runLogsCommand(
   options: LogsOptions = {},
   write: Writer = stdout,
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
   const view = openView(options);
   const entries = projectLogs(view, options.node);
   if (options.json === true) {
@@ -193,6 +246,7 @@ export async function runLogsCommand(
   } else {
     write(formatLogs(entries));
   }
+  fireObserve(telemetry, 'logs', 'success', startedAt);
   return 0;
 }
 
@@ -207,7 +261,9 @@ export interface TraceOptions extends ObserveOptions {
 export async function runTraceCommand(
   options: TraceOptions = {},
   write: Writer = stdout,
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
   const view = openView(options);
   const traces = projectTrace(view, options.node);
   if (options.json === true) {
@@ -215,6 +271,7 @@ export async function runTraceCommand(
   } else {
     write(formatTrace(traces));
   }
+  fireObserve(telemetry, 'trace', 'success', startedAt);
   return 0;
 }
 
@@ -301,7 +358,9 @@ export function parseRate(raw: string): ParsedRate | undefined {
 export async function runReceiptsCommand(
   options: ReceiptsOptions = {},
   write: Writer = stdout,
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
   const view = openView(options);
   const sub = options.sub ?? 'list';
 
@@ -320,6 +379,7 @@ export async function runReceiptsCommand(
             'point --state-dir at a populated ledger.',
         );
       }
+      fireObserve(telemetry, 'receipts', 'failure', startedAt);
       return 1;
     }
     if (options.json === true) {
@@ -328,6 +388,7 @@ export async function runReceiptsCommand(
       write(formatReceiptsAudit(audit));
     }
     // A tampered/broken chain ⇒ NONZERO exit (the audit's whole point).
+    fireObserve(telemetry, 'receipts', audit.ok ? 'success' : 'failure', startedAt);
     return audit.ok ? 0 : 1;
   }
 
@@ -343,6 +404,7 @@ export async function runReceiptsCommand(
     if (options.rate !== undefined) {
       const rate = parseRate(options.rate);
       if (rate === undefined) {
+        fireObserve(telemetry, 'receipts', 'failure', startedAt);
         return emitError(
           write,
           options.json,
@@ -375,6 +437,7 @@ export async function runReceiptsCommand(
     } else {
       write(formatCost(cost) + (priced === undefined ? '' : formatDollarLine(priced)));
     }
+    fireObserve(telemetry, 'receipts', 'success', startedAt);
     return 0;
   }
 
@@ -385,5 +448,6 @@ export async function runReceiptsCommand(
   } else {
     write(formatLogs(entries, 'reactor receipts'));
   }
+  fireObserve(telemetry, 'receipts', 'success', startedAt);
   return 0;
 }

--- a/packages/reactor-cli/src/commands/run.ts
+++ b/packages/reactor-cli/src/commands/run.ts
@@ -31,6 +31,14 @@ import type { ConfigOverrides } from '../config';
 import { loadConfig, validateStateDirTarget } from '../config';
 import type { CompileCommandOptions } from './compile';
 import { emitError } from './emit';
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  buildEventProperties,
+  buildGraphProperties,
+  errorCategory,
+  type Telemetry,
+} from '../telemetry';
 
 import * as path from 'path';
 
@@ -59,10 +67,42 @@ export interface RunCommandOptions extends ConfigOverrides {
 export async function runRunCommand(
   options: RunCommandOptions = {},
   write: (line: string) => void = (line) => process.stdout.write(line + '\n'),
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
   if (options.offline === true) {
     process.env['REACTOR_OFFLINE'] = '1';
   }
+
+  const startedAt = Date.now();
+  /** Fire `reactor.run` with the bucketed shared block + graph/disposition extras. */
+  const fireRun = (
+    outcome: 'success' | 'failure',
+    graph?: {
+      nodes?: number;
+      edges?: number;
+      costFresh?: number;
+      costReused?: number;
+      dispositions?: readonly { readonly disposition: string }[];
+    },
+  ): void => {
+    telemetry.event(
+      TelemetryEvent.RUN,
+      buildEventProperties(
+        { command: 'run', outcome, durationMs: Date.now() - startedAt },
+        buildGraphProperties({ ...(graph ?? {}), provider: config?.model.provider }),
+      ),
+    );
+  };
+  /** Fire `reactor.error` with a coarse category (never a message/stack). */
+  const fireError = (err: unknown): void => {
+    telemetry.event(
+      TelemetryEvent.ERROR,
+      buildEventProperties(
+        { command: 'run', outcome: 'failure', durationMs: Date.now() - startedAt },
+        { errorCategory: errorCategory(err) },
+      ),
+    );
+  };
 
   const config = loadConfig({
     stateDir: options.stateDir,
@@ -82,9 +122,11 @@ export async function runRunCommand(
     } else {
       write(stateDirError);
     }
+    fireError(Object.assign(new Error(stateDirError), { code: 'ENOTDIR' }));
     return 2;
   }
 
+  try {
   // 1. Ensure the IR is fresh (compile if stale).
   const ensured = await ensureCompiledIR({
     contractsDir,
@@ -97,6 +139,7 @@ export async function runRunCommand(
       : {}),
   });
   if (ensured.kind === 'no-contracts') {
+    fireRun('failure');
     return emitError(
       write,
       options.json,
@@ -104,6 +147,7 @@ export async function runRunCommand(
     );
   }
   if (ensured.kind === 'compile-failed') {
+    fireRun('failure');
     return emitError(
       write,
       options.json,
@@ -161,7 +205,21 @@ export async function runRunCommand(
   // signal the whole pitch rests on, and CI/agents read the exit code. (The
   // documented exit table: 0 = ran clean, 1 = a node failed.)
   const anyFailed = report.dispositions.some((d) => d.disposition === 'failed');
+  fireRun(anyFailed ? 'failure' : 'success', {
+    nodes: loaded.ir.topology.topology.nodes.length,
+    edges: loaded.ir.topology.topology.edges.length,
+    costFresh: report.cost.fresh,
+    costReused: report.cost.reused,
+    dispositions: report.dispositions,
+  });
   return anyFailed ? 1 : 0;
+  } catch (err) {
+    // A thrown run (e.g. a live render/provider failure inside callRunProject)
+    // fires the coarse error signal, then rethrows so the top-level handler still
+    // prints + exits 1 exactly as before — telemetry never changes control flow.
+    fireError(err);
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/reactor-cli/src/commands/serve.ts
+++ b/packages/reactor-cli/src/commands/serve.ts
@@ -67,6 +67,15 @@ import type { ConfigOverrides, GatewayConfig, SandboxConfig } from '../config';
 import { loadConfig, validateStateDirTarget } from '../config';
 import { resolveSdk } from '../meta';
 import { runCompileCommand, type CompileCommandOptions } from './compile';
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  bucketCount,
+  bucketMs,
+  buildEventProperties,
+  errorCategory,
+  type Telemetry,
+} from '../telemetry';
 
 import * as path from 'path';
 
@@ -487,7 +496,21 @@ export async function bootServe(
 export async function runServeCommand(
   options: ServeCommandOptions = {},
   write: (line: string) => void = (line) => process.stdout.write(line + '\n'),
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
+  const startedAt = Date.now();
+  const intervalMs = options.pollIntervalMs ?? 60_000;
+  const concurrency = options.concurrency ?? 1;
+  /**
+   * Build the `reactor.serve` extras (`ServeProperties`): the poll cadence +
+   * concurrency, both bucketed. Carried on the boot event and the sampled
+   * poll-cycle event.
+   */
+  const serveExtras = {
+    pollIntervalBucket: bucketMs(intervalMs),
+    concurrencyBucket: bucketCount(concurrency),
+  };
+
   let host: Awaited<ReturnType<typeof bootHost>>;
   try {
     host = await bootHost({
@@ -512,8 +535,34 @@ export async function runServeCommand(
     } else {
       write(`${msg}${hint}`);
     }
+    // A boot failure fires the coarse serve failure + a categorized error, then
+    // returns — telemetry never alters the exit code.
+    telemetry.event(
+      TelemetryEvent.SERVE,
+      buildEventProperties(
+        { command: 'serve', outcome: 'failure', durationMs: Date.now() - startedAt },
+        serveExtras,
+      ),
+    );
+    telemetry.event(
+      TelemetryEvent.ERROR,
+      buildEventProperties(
+        { command: 'serve', outcome: 'failure', durationMs: Date.now() - startedAt },
+        { errorCategory: errorCategory(err) },
+      ),
+    );
     return usage ? 2 : 1;
   }
+
+  // The host booted: fire ONE `reactor.serve` success at boot (the daemon may run
+  // for hours, so the boot event is the reliable "a serve started" signal).
+  telemetry.event(
+    TelemetryEvent.SERVE,
+    buildEventProperties(
+      { command: 'serve', outcome: 'success', durationMs: Date.now() - startedAt },
+      serveExtras,
+    ),
+  );
 
   let httpServer: HttpServerHandle | undefined;
   if (options.httpPort !== undefined) {
@@ -547,13 +596,17 @@ export async function runServeCommand(
     );
   }
 
-  const intervalMs = options.pollIntervalMs ?? 60_000;
   let stopped = false;
   const stop = (): void => {
     stopped = true;
   };
   process.once('SIGTERM', stop);
   process.once('SIGINT', stop);
+
+  // Poll-cycle telemetry is SAMPLED (first cycle only) so a long-running daemon
+  // cannot flood the backend — the boot event already proved a serve started; the
+  // first cycle proves the loop is live. A flag suffices for the first-only sample.
+  let pollCycleSampled = false;
 
   // The driver loop: poll gateways (ingress) + continuity across all reactors,
   // surface live cost, sleep, until SIGTERM. Gateways poll BEFORE continuity each
@@ -563,6 +616,16 @@ export async function runServeCommand(
     const now = host.reactors[0]?.reactor.clock.now() ?? new Date().toISOString();
     await host.pollGatewaysAll(now);
     await host.pollAll(now);
+    if (!pollCycleSampled) {
+      pollCycleSampled = true;
+      telemetry.event(
+        TelemetryEvent.SERVE,
+        buildEventProperties(
+          { command: 'serve', outcome: 'success', durationMs: Date.now() - startedAt },
+          serveExtras,
+        ),
+      );
+    }
     if (options.json !== true) {
       write(formatCostLine(host.cost().host));
     }

--- a/packages/reactor-cli/src/commands/telemetry.ts
+++ b/packages/reactor-cli/src/commands/telemetry.ts
@@ -1,0 +1,196 @@
+/**
+ * `reactor telemetry` — inspect or change anonymous CLI telemetry.
+ *
+ * Subcommands (cli surface): `status` | `enable` | `disable`, plus a `--dump`
+ * flag (on any/no subcommand) that prints the EXACT JSON a representative event
+ * WOULD send and exits. This is the published, inspectable opt-out + transparency
+ * surface (00-POLICY.md principle #6, 02-IMPLEMENTATION-PLAN.md §5).
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): reachable from the offline entrypoint, so it MUST
+ * NOT static-import any model-bearing dependency (`@openai/agents`, `zod`) or any
+ * model-bearing SDK barrel. It touches only the keyless telemetry leaves + env +
+ * `~/.reactor/config.json`. It NEVER opens a socket — even `--dump` only PRINTS
+ * the payload; it does not POST it.
+ *
+ * - `disable` writes `telemetryEnabled: false` to `~/.reactor/config.json`
+ *   (permanent, machine-level).
+ * - `enable` clears the opt-out (writes `telemetryEnabled: true`).
+ * - `status` reports whether telemetry is currently enabled + the gate reason +
+ *   the resolved endpoint + the anonymous install id (already non-identifying).
+ * - `--dump` prints the canonical Segment batch (`{ batch: [event] }`) exactly as
+ *   the transport would serialize it, so a user can audit every field before
+ *   trusting it.
+ */
+
+import {
+  buildSharedProperties,
+  getOrCreateInstallId,
+  readMachineConfig,
+  TelemetryEvent,
+  writeMachineConfig,
+  type MachineConfig,
+} from '../telemetry';
+import { isTelemetryEnabled } from '../telemetry/gate';
+import { resolveEndpoint } from '../telemetry/endpoint';
+
+/** The recognized `reactor telemetry` subcommands. */
+export type TelemetrySubcommand = 'status' | 'enable' | 'disable';
+
+/** Options for {@link runTelemetryCommand}. */
+export interface TelemetryCliOptions {
+  /** `status` (default) | `enable` | `disable`. */
+  readonly sub?: string;
+  /** `--dump`: print the exact JSON a representative event would send, then exit. */
+  readonly dump?: boolean;
+  /** Machine-readable JSON output. */
+  readonly json?: boolean;
+}
+
+type Writer = (line: string) => void;
+
+const stdout: Writer = (line) => process.stdout.write(line + '\n');
+
+/** The single allowed `context` value — `library` is whitelisted server-side. */
+const LIBRARY = '@openprose/reactor-cli' as const;
+
+/**
+ * Build the EXACT wire object the transport would POST for one representative
+ * event (`reactor.doctor`, success, a typical run). This mirrors the client's
+ * Segment `track` shape verbatim: ALL reactor data in `properties`, `context`
+ * carrying ONLY the whitelisted `library` key, an ISO timestamp, the anonymous
+ * `anonymousId`. The `timestamp` is stamped at dump time (a real send stamps at
+ * enqueue) — every other field is precisely what would be sent.
+ */
+function buildDumpBatch(installId: string): { batch: unknown[] } {
+  const properties = buildSharedProperties({
+    command: 'doctor',
+    outcome: 'success',
+    durationMs: 0,
+  });
+  return {
+    batch: [
+      {
+        type: 'track',
+        anonymousId: installId,
+        event: TelemetryEvent.DOCTOR,
+        properties,
+        context: { library: LIBRARY },
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
+/**
+ * Run `reactor telemetry`. Returns the process exit code (always 0 — this is a
+ * configuration/inspection command, never a failure path). `write` defaults to
+ * stdout.
+ */
+export async function runTelemetryCommand(
+  options: TelemetryCliOptions = {},
+  write: Writer = stdout,
+): Promise<number> {
+  // `--dump` short-circuits every subcommand: print the canonical payload + the
+  // resolved endpoint, then exit. It NEVER sends — pure inspection.
+  if (options.dump === true) {
+    // Read-only: inspection must NOT mint/persist an install id (honors the
+    // opt-out spirit — a user auditing the payload, or one opted out via
+    // DO_NOT_TRACK, should write no machine state). Mirror `status`.
+    const installId = currentInstallId() ?? '(anonymous-id created on first send)';
+    const dump = {
+      endpoint: resolveEndpoint(),
+      ...buildDumpBatch(installId),
+    };
+    write(JSON.stringify(dump, null, options.json === true ? 0 : 2));
+    return 0;
+  }
+
+  const sub = normalizeSub(options.sub);
+
+  if (sub === 'disable') {
+    writeFlag(false);
+    if (options.json === true) {
+      write(JSON.stringify({ telemetryEnabled: false }));
+    } else {
+      write('reactor telemetry: disabled — telemetryEnabled:false written to ~/.reactor/config.json.');
+      write('  (re-enable any time with `reactor telemetry enable`)');
+    }
+    return 0;
+  }
+
+  if (sub === 'enable') {
+    writeFlag(true);
+    if (options.json === true) {
+      write(JSON.stringify({ telemetryEnabled: true }));
+    } else {
+      write('reactor telemetry: enabled — machine-level opt-out cleared.');
+      write('  (still honors DO_NOT_TRACK / REACTOR_TELEMETRY=0 / CI / non-TTY / project config)');
+    }
+    return 0;
+  }
+
+  // status (default): report the live gate decision + endpoint + anonymous id.
+  const decision = isTelemetryEnabled({
+    env: process.env,
+    isTty: process.stdout.isTTY === true,
+  });
+  const endpoint = resolveEndpoint();
+  const installId = currentInstallId();
+  if (options.json === true) {
+    write(
+      JSON.stringify({
+        enabled: decision.enabled,
+        ...(decision.reason !== undefined ? { reason: decision.reason } : {}),
+        endpoint,
+        ...(installId !== undefined ? { installId } : {}),
+      }),
+    );
+    return 0;
+  }
+  write('reactor telemetry');
+  write('');
+  write(`  status         ${decision.enabled ? 'enabled' : 'disabled'}`);
+  if (!decision.enabled && decision.reason !== undefined) {
+    write(`  reason         ${decision.reason}`);
+  }
+  write(`  endpoint       ${endpoint}`);
+  write(`  install id     ${installId ?? '(none yet — created on first send)'}`);
+  write('');
+  write('  Inspect exactly what is sent:  reactor telemetry --dump');
+  write('  Turn it off permanently:       reactor telemetry disable');
+  write('  Or set DO_NOT_TRACK=1 / REACTOR_TELEMETRY=0 in your environment.');
+  return 0;
+}
+
+
+/** Normalize a raw subcommand token to the known set (default `status`). */
+function normalizeSub(raw: string | undefined): TelemetrySubcommand {
+  if (raw === 'enable' || raw === 'disable' || raw === 'status') return raw;
+  return 'status';
+}
+
+/**
+ * Read the persisted install id WITHOUT minting one (status must not create state
+ * as a side effect of merely reading). Returns `undefined` when none exists yet.
+ */
+function currentInstallId(): string | undefined {
+  const cfg = readMachineConfig();
+  return cfg !== undefined && cfg.installId.length > 0 ? cfg.installId : undefined;
+}
+
+/**
+ * Persist the machine-level telemetry flag, preserving every sibling-owned field
+ * (`installId`, `noticeShownVersion`). Best-effort: a write fault is swallowed by
+ * the leaf — the boolean is advisory.
+ */
+function writeFlag(enabled: boolean): void {
+  const existing = readMachineConfig();
+  const next: MachineConfig = {
+    installId: existing?.installId && existing.installId.length > 0 ? existing.installId : getOrCreateInstallId(),
+    telemetryEnabled: enabled,
+    ...(existing?.noticeShownVersion !== undefined
+      ? { noticeShownVersion: existing.noticeShownVersion }
+      : {}),
+  };
+  writeMachineConfig(next);
+}

--- a/packages/reactor-cli/src/commands/trigger.ts
+++ b/packages/reactor-cli/src/commands/trigger.ts
@@ -52,6 +52,14 @@ import { loadConfig, validateStateDirTarget } from '../config';
 import { resolveSdk } from '../meta';
 import { runCompileCommand, type CompileCommandOptions } from './compile';
 import { emitError } from './emit';
+import {
+  NOOP_TELEMETRY,
+  TelemetryEvent,
+  buildEventProperties,
+  buildGraphProperties,
+  errorCategory,
+  type Telemetry,
+} from '../telemetry';
 
 export interface TriggerCommandOptions extends ConfigOverrides {
   /** The node to trigger (required). */
@@ -70,12 +78,48 @@ export interface TriggerCommandOptions extends ConfigOverrides {
 export async function runTriggerCommand(
   options: TriggerCommandOptions,
   write: (line: string) => void = (line) => process.stdout.write(line + '\n'),
+  telemetry: Telemetry = NOOP_TELEMETRY,
 ): Promise<number> {
   if (options.offline === true) {
     process.env['REACTOR_OFFLINE'] = '1';
   }
 
+  const startedAt = Date.now();
+  // Captured via a mutable holder (not the later `const config`) so an EARLY fire
+  // — before config is resolved — never trips the const's temporal-dead-zone.
+  let providerClassInput: string | undefined;
+  /** Fire `reactor.trigger` with the bucketed shared block + graph/disposition extras. */
+  const fireTrigger = (
+    outcome: 'success' | 'failure',
+    graph?: {
+      nodes?: number;
+      edges?: number;
+      costFresh?: number;
+      costReused?: number;
+      dispositions?: readonly { readonly disposition: string }[];
+    },
+  ): void => {
+    telemetry.event(
+      TelemetryEvent.TRIGGER,
+      buildEventProperties(
+        { command: 'trigger', outcome, durationMs: Date.now() - startedAt },
+        buildGraphProperties({ ...(graph ?? {}), provider: providerClassInput }),
+      ),
+    );
+  };
+  /** Fire `reactor.error` with a coarse category (never a message/stack). */
+  const fireError = (err: unknown): void => {
+    telemetry.event(
+      TelemetryEvent.ERROR,
+      buildEventProperties(
+        { command: 'trigger', outcome: 'failure', durationMs: Date.now() - startedAt },
+        { errorCategory: errorCategory(err) },
+      ),
+    );
+  };
+
   if (typeof options.node !== 'string' || options.node.length === 0) {
+    fireTrigger('failure');
     return emitError(write, options.json, 'reactor trigger: a node id is required');
   }
 
@@ -85,6 +129,7 @@ export async function runTriggerCommand(
     try {
       parsedData = parseData(options.data);
     } catch (err) {
+      fireError(err);
       return emitError(
         write,
         options.json,
@@ -98,6 +143,7 @@ export async function runTriggerCommand(
     projectDir: options.projectDir,
     model: options.model,
   });
+  providerClassInput = config.model.provider;
   const stateDir = config.state.dir;
   const contractsDir = path.resolve(options.projectDir ?? '.');
   const model = config.model.compile_model;
@@ -112,12 +158,15 @@ export async function runTriggerCommand(
     } else {
       write(stateDirError);
     }
+    fireError(Object.assign(new Error(stateDirError), { code: 'ENOTDIR' }));
     return 2;
   }
 
+  try {
   // Ensure IR fresh (compile if stale).
   const images = keylessLoadContractSet(contractsDir);
   if (images.length === 0) {
+    fireTrigger('failure');
     return emitError(
       write,
       options.json,
@@ -143,6 +192,7 @@ export async function runTriggerCommand(
       () => {},
     );
     if (code !== 0) {
+      fireTrigger('failure');
       return emitError(write, options.json, 'reactor trigger: compile failed (IR stale)');
     }
   }
@@ -150,6 +200,7 @@ export async function runTriggerCommand(
   // Load + re-lower (KEYLESS).
   const loaded = loadCompiledProject(stateDir);
   if (loaded.ir.topology.topology.nodes.every((n) => n.node !== options.node)) {
+    fireTrigger('failure');
     return emitError(
       write,
       options.json,
@@ -224,7 +275,22 @@ export async function runTriggerCommand(
     reactor.ledger.all().map((r) => ({ node: r.node, cost: r.cost })),
   );
   emitReport(report, parsedData, options, write);
+  const anyFailed = report.dispositions.some((d) => d.disposition === 'failed');
+  fireTrigger(anyFailed ? 'failure' : 'success', {
+    nodes: loaded.ir.topology.topology.nodes.length,
+    edges: loaded.ir.topology.topology.edges.length,
+    costFresh: report.cost.fresh,
+    costReused: report.cost.reused,
+    dispositions: report.dispositions,
+  });
   return 0;
+  } catch (err) {
+    // A thrown trigger (e.g. a live render/provider failure) fires the coarse
+    // error signal, then rethrows so the top-level handler prints + exits 1 —
+    // telemetry never alters control flow.
+    fireError(err);
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/reactor-cli/src/config.ts
+++ b/packages/reactor-cli/src/config.ts
@@ -37,6 +37,17 @@ export interface StateConfig {
   readonly dir: string;
 }
 
+/**
+ * Project-level telemetry preference (`reactor.yml` → `telemetry:`). Both fields
+ * are optional: `enabled: false` is the project opt-out the gate honors, and
+ * `endpoint` redirects the analytics POST (self-host / dev). Content-free; this is
+ * the ONLY telemetry surface the config exposes.
+ */
+export interface TelemetryConfig {
+  readonly enabled?: boolean;
+  readonly endpoint?: string;
+}
+
 /** One external-driven gateway entry point (`cli.md` §6 / §6.1). */
 export interface GatewayConfig {
   readonly node: string;
@@ -75,6 +86,12 @@ export interface ReactorConfig {
    * top-level `state`/`project`/`gateways`. A multi-reactor host declares N.
    */
   readonly reactors: readonly RawReactorEntry[];
+  /**
+   * Project-level telemetry preference (`reactor.yml` → `telemetry:`). Absent when
+   * the project expresses no preference; the CLI telemetry gate reads
+   * `enabled`/`endpoint` from here.
+   */
+  readonly telemetry?: TelemetryConfig;
 }
 
 /** A loosely-typed `reactors:` list entry as parsed from `reactor.yml`. */
@@ -147,6 +164,7 @@ export function loadConfig(overrides: ConfigOverrides = {}): ReactorConfig {
     sandbox: merged.sandbox,
     gateways: merged.gateways,
     reactors: merged.reactors,
+    ...(merged.telemetry !== undefined ? { telemetry: merged.telemetry } : {}),
   };
 }
 
@@ -292,6 +310,7 @@ interface RawConfig {
   sandbox?: MutableSandbox;
   gateways?: GatewayConfig[];
   reactors?: RawReactorEntry[];
+  telemetry?: TelemetryConfig;
 }
 
 /** Shape a parsed YAML value into the partial raw config (best-effort, typed). */
@@ -343,6 +362,14 @@ function shapeRawConfig(tree: unknown): Partial<RawConfig> {
     out.reactors = reactors.filter(isRecord).map(shapeReactorEntry);
   }
 
+  const telemetry = tree['telemetry'];
+  if (isRecord(telemetry)) {
+    const t: { -readonly [K in keyof TelemetryConfig]?: TelemetryConfig[K] } = {};
+    if (typeof telemetry['enabled'] === 'boolean') t.enabled = telemetry['enabled'];
+    if (typeof telemetry['endpoint'] === 'string') t.endpoint = telemetry['endpoint'];
+    out.telemetry = t;
+  }
+
   return out;
 }
 
@@ -388,6 +415,9 @@ function mergeConfig(base: ReactorConfig, over: Partial<RawConfig>): ReactorConf
     sandbox,
     gateways: over.gateways ?? [...base.gateways],
     reactors: over.reactors ?? [...base.reactors],
+    // Telemetry is preference-only: carry the project's block through when present
+    // (the bare defaults express no preference, so there is nothing to merge under).
+    ...(over.telemetry !== undefined ? { telemetry: over.telemetry } : {}),
   };
 }
 

--- a/packages/reactor-cli/src/telemetry/client.test.ts
+++ b/packages/reactor-cli/src/telemetry/client.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Transport leaf tests — `createHttpTelemetry` (the bespoke Segment sender).
+ *
+ * Hermetic + keyless: no real network. Each test swaps `globalThis.fetch` for a
+ * fake to capture the POST (or to reject/hang) and restores it after. Proves the
+ * trust + safety contract:
+ *
+ *   1. `flush()` POSTs a VALID `/analytics` body: `{ batch: [track,...] }` with
+ *      1..100 events, each `type:"track"`, `anonymousId:installId`,
+ *      `event:name`, an ISO-8601 `timestamp`, the caller `properties`, and a
+ *      `context` whose ONLY key is `library:"@openprose/reactor-cli"`.
+ *   2. `event()`/`flush()` NEVER throw or reject — even when `fetch` rejects,
+ *      times out (aborts), or throws synchronously.
+ *   3. The serialized payload carries NONE of a forbidden denylist of keys
+ *      (path/content/prompt/apiKey/...) — the CONTENT-FREE guarantee.
+ *   4. Batches are bounded to ≤100 events per POST.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createHttpTelemetry } from './client';
+import {
+  TelemetryEvent,
+  SCHEMA_VERSION,
+  type EventProperties,
+} from './events';
+
+const ENDPOINT = 'https://api.dev.openprose.ai/analytics';
+const INSTALL_ID = 'test-install-id-0000';
+
+/** A representative content-free shared property block (no extras needed here). */
+function sampleProperties(): EventProperties {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    cliVersion: '9.9.9',
+    reactorVersion: '9.9.9',
+    nodeVersion: 'v20.0.0',
+    os: 'linux',
+    arch: 'x64',
+    ci: false,
+    command: 'run',
+    outcome: 'success',
+    durationBucket: '<1s',
+  };
+}
+
+/** Captured fetch calls; `restore()` puts the real `fetch` back. */
+interface FetchSpy {
+  readonly calls: Array<{ url: string; init: RequestInit }>;
+  restore(): void;
+}
+
+/** Install a fake `globalThis.fetch` returning a 200 and capturing each call. */
+function installFetch(impl: typeof fetch): FetchSpy {
+  const original = globalThis.fetch;
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  globalThis.fetch = ((input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    return impl(input as never, init);
+  }) as typeof fetch;
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+let spy: FetchSpy | undefined;
+
+afterEach(() => {
+  spy?.restore();
+  spy = undefined;
+});
+
+describe('createHttpTelemetry', () => {
+  it('POSTs a valid /analytics batch with context only { library }', async () => {
+    spy = installFetch(async () => new Response(null, { status: 200 }));
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    tel.event(TelemetryEvent.RUN, sampleProperties());
+    await tel.flush();
+
+    assert.equal(spy.calls.length, 1, 'exactly one POST');
+    const call = spy.calls[0]!;
+    assert.equal(call.url, ENDPOINT);
+    assert.equal(call.init.method, 'POST');
+
+    const body = JSON.parse(String(call.init.body)) as {
+      batch: Array<Record<string, unknown>>;
+    };
+    assert.ok(Array.isArray(body.batch), 'top-level batch array');
+    assert.ok(
+      body.batch.length >= 1 && body.batch.length <= 100,
+      'batch holds 1..100 events',
+    );
+
+    const ev = body.batch[0] as Record<string, unknown>;
+    assert.equal(ev.type, 'track');
+    assert.equal(ev.anonymousId, INSTALL_ID);
+    assert.equal(ev.event, TelemetryEvent.RUN);
+    assert.ok(ev.event === 'reactor.run');
+
+    // timestamp is a round-trippable ISO-8601 string
+    assert.equal(typeof ev.timestamp, 'string');
+    assert.equal(new Date(ev.timestamp as string).toISOString(), ev.timestamp);
+
+    // properties carry the caller payload
+    assert.deepEqual(ev.properties, sampleProperties());
+
+    // CRITICAL: context has EXACTLY one key, `library`.
+    const context = ev.context as Record<string, unknown>;
+    assert.deepEqual(Object.keys(context), ['library']);
+    assert.equal(context.library, '@openprose/reactor-cli');
+  });
+
+  it('never sends forbidden (content-bearing) keys in the serialized payload', async () => {
+    spy = installFetch(async () => new Response(null, { status: 200 }));
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    tel.event(TelemetryEvent.COMPILE, sampleProperties());
+    await tel.flush();
+
+    const raw = String(spy.calls[0]!.init.body);
+    const denylist = [
+      'path',
+      'filePath',
+      'filepath',
+      'dir',
+      'directory',
+      'projectName',
+      'content',
+      'markdown',
+      'prompt',
+      'promptText',
+      'apiKey',
+      'api_key',
+      'token',
+      'secret',
+      'model',
+      'input',
+      'output',
+      'facet',
+      'nodeName',
+      'ip',
+      'geo',
+      'utm',
+      'page',
+      'device',
+    ];
+    for (const key of denylist) {
+      assert.ok(
+        !raw.includes(`"${key}"`),
+        `forbidden key "${key}" must be absent from the serialized payload`,
+      );
+    }
+  });
+
+  it('flush() resolves (never throws) when fetch REJECTS', async () => {
+    spy = installFetch(async () => {
+      throw new Error('network down');
+    });
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    tel.event(TelemetryEvent.RUN, sampleProperties());
+    await assert.doesNotReject(() => tel.flush());
+  });
+
+  it('flush() resolves (never throws) when fetch TIMES OUT / aborts', async () => {
+    // Simulate the transport aborting: reject promptly with an AbortError (the
+    // same rejection `AbortSignal.timeout` produces) so the non-throwing path is
+    // exercised deterministically without waiting on the real 2s timer. The
+    // client passes a real AbortSignal.timeout(2000); we also assert it is wired.
+    let sawSignal = false;
+    spy = installFetch((_input, init) => {
+      const signal = (init as RequestInit | undefined)?.signal;
+      sawSignal = signal instanceof AbortSignal;
+      return Promise.reject(new DOMException('aborted', 'AbortError'));
+    });
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    tel.event(TelemetryEvent.RUN, sampleProperties());
+    await assert.doesNotReject(() => tel.flush());
+    assert.ok(sawSignal, 'client passes an AbortSignal (timeout) to fetch');
+  });
+
+  it('flush() resolves when fetch throws SYNCHRONOUSLY', async () => {
+    spy = installFetch(() => {
+      throw new Error('synchronous fetch fault');
+    });
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    tel.event(TelemetryEvent.RUN, sampleProperties());
+    await assert.doesNotReject(() => tel.flush());
+  });
+
+  it('flush() with an empty queue does not POST and resolves', async () => {
+    spy = installFetch(async () => new Response(null, { status: 200 }));
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    await assert.doesNotReject(() => tel.flush());
+    assert.equal(spy.calls.length, 0, 'no POST for an empty queue');
+  });
+
+  it('bounds each POST to <=100 events (chunks a large queue)', async () => {
+    spy = installFetch(async () => new Response(null, { status: 200 }));
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+
+    for (let i = 0; i < 250; i++) {
+      tel.event(TelemetryEvent.RUN, sampleProperties());
+    }
+    await tel.flush();
+
+    assert.equal(spy.calls.length, 3, '250 events -> 100 + 100 + 50 = 3 POSTs');
+    for (const call of spy.calls) {
+      const body = JSON.parse(String(call.init.body)) as { batch: unknown[] };
+      assert.ok(
+        body.batch.length >= 1 && body.batch.length <= 100,
+        'every batch is 1..100 events',
+      );
+    }
+  });
+
+  it('event() never throws', () => {
+    const tel = createHttpTelemetry({ endpoint: ENDPOINT, installId: INSTALL_ID });
+    assert.doesNotThrow(() => tel.event(TelemetryEvent.RUN, sampleProperties()));
+  });
+});

--- a/packages/reactor-cli/src/telemetry/client.ts
+++ b/packages/reactor-cli/src/telemetry/client.ts
@@ -1,0 +1,126 @@
+/**
+ * Telemetry transport leaf — the bespoke `fetch` Segment-batch sender.
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): reachable from the telemetry factory the offline
+ * entrypoint loads, so it MUST NOT static-import any model-bearing dependency
+ * (`@openai/agents`, `zod`) or any SDK barrel. It uses only the global `fetch`
+ * (Node >=20) and the `Telemetry` contract from `./index`. Zero runtime deps.
+ *
+ * TRUST POSTURE (00-POLICY.md): fire-and-forget. `event()` only enqueues — it
+ * never blocks and never throws. `flush()` POSTs the queued Segment `track`
+ * events to `<endpoint>` as `{ batch }` under a hard `AbortSignal.timeout`, and
+ * swallows EVERY transport error (`.catch(() => {})`). A slow or unreachable
+ * endpoint can never delay, reject, or perturb the CLI — `flush()` always
+ * resolves. The CONTENT-FREE guarantee is upheld upstream: this leaf serializes
+ * exactly the `properties` it is handed and stamps only the allowed
+ * `context: { library }` key (the server validates `context` with
+ * `forbidNonWhitelisted` — any other key is HTTP 400).
+ */
+
+import type { Telemetry } from './index';
+import type { TelemetryEventName, EventProperties } from './events';
+
+/** The single allowed `context` value — `library` is whitelisted server-side. */
+const LIBRARY = '@openprose/reactor-cli' as const;
+
+/** Hard wall-clock cap on a flush POST (ms). Bounds CLI exit; never tunable up. */
+const FLUSH_TIMEOUT_MS = 2000;
+
+/** The Segment batch ceiling. The server accepts 1..100 events per request. */
+const MAX_BATCH = 100;
+
+/** Inputs to {@link createHttpTelemetry}: an absolute endpoint + anonymous id. */
+export interface HttpTelemetryArgs {
+  /** Absolute `/analytics` URL (resolved by `./endpoint` or the project config). */
+  readonly endpoint: string;
+  /** The anonymous machine install id — rides as Segment `anonymousId`. */
+  readonly installId: string;
+}
+
+/**
+ * One Segment `track` event in the wire shape the `/analytics` controller
+ * ingests. ALL Reactor-specific data lives in {@link properties}; `context`
+ * carries ONLY the whitelisted `library` key (never path/content/prompt/etc.).
+ */
+interface SegmentTrackEvent {
+  readonly type: 'track';
+  readonly anonymousId: string;
+  readonly event: TelemetryEventName;
+  readonly properties: EventProperties;
+  readonly context: { readonly library: typeof LIBRARY };
+  readonly timestamp: string;
+}
+
+/**
+ * Construct the bounded, fire-and-forget telemetry sink.
+ *
+ * - `event(name, properties)` enqueues one Segment `track` event with an ISO-8601
+ *   timestamp captured at enqueue time. It is total: it never blocks the caller
+ *   and never throws (even a queue cap is handled silently).
+ * - `flush()` drains the queue in batches of ≤100 and POSTs each as `{ batch }`
+ *   via the global `fetch` under `AbortSignal.timeout(2000)`. It awaits the POSTs
+ *   but swallows every rejection/timeout, so it ALWAYS resolves — a caller may
+ *   `await` it on the CLI exit path without risk of a hang or a throw.
+ */
+export function createHttpTelemetry(args: HttpTelemetryArgs): Telemetry {
+  const { endpoint, installId } = args;
+  let queue: SegmentTrackEvent[] = [];
+
+  function event(name: TelemetryEventName, properties: EventProperties): void {
+    // Never let enqueuing perturb the command — swallow anything (e.g. a Date
+    // fault) and simply drop the event.
+    try {
+      queue.push({
+        type: 'track',
+        anonymousId: installId,
+        event: name,
+        properties,
+        context: { library: LIBRARY },
+        timestamp: new Date().toISOString(),
+      });
+    } catch {
+      // intentionally nothing — telemetry must never affect the CLI
+    }
+  }
+
+  async function flush(): Promise<void> {
+    if (queue.length === 0) return;
+
+    // Take ownership of the pending events; new events that arrive during the
+    // flush enqueue afresh and are picked up by the next flush.
+    const pending = queue;
+    queue = [];
+
+    // POST in chunks of ≤100 so we always satisfy the server's batch bound.
+    for (let i = 0; i < pending.length; i += MAX_BATCH) {
+      const batch = pending.slice(i, i + MAX_BATCH);
+      await postBatch(endpoint, batch);
+    }
+  }
+
+  return { event, flush };
+}
+
+/**
+ * POST a single ≤100-event batch as `{ batch }`. Bounded by a 2s abort timeout
+ * and TOTALLY non-throwing: any network error, timeout, abort, or non-2xx status
+ * is swallowed. Returns a resolved promise unconditionally.
+ */
+async function postBatch(
+  endpoint: string,
+  batch: readonly SegmentTrackEvent[],
+): Promise<void> {
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ batch }),
+      signal: AbortSignal.timeout(FLUSH_TIMEOUT_MS),
+    }).catch(() => {
+      // network error / abort / timeout — fire-and-forget, swallow it
+    });
+  } catch {
+    // Even a synchronous fault constructing the request (or an environment
+    // without `AbortSignal.timeout`) must not escape — telemetry is best-effort.
+  }
+}

--- a/packages/reactor-cli/src/telemetry/command.ts
+++ b/packages/reactor-cli/src/telemetry/command.ts
@@ -1,0 +1,187 @@
+/**
+ * Command-side telemetry helpers — the thin, CONTENT-FREE bridge between a
+ * command handler's raw result and the `EventProperties` the sink accepts.
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): reachable from the command handlers (which the
+ * offline entrypoint loads), so it MUST NOT static-import any model-bearing
+ * dependency (`@openai/agents`, `zod`) or any model-bearing SDK barrel. It
+ * composes only the keyless `./events` model.
+ *
+ * Every helper here is a PURE projection from a coarse, already-bucketable input
+ * to the categorical/bucketed property shape. No raw count, duration, name, path,
+ * message, or stack is ever read into a property — the bucketers + `providerClass`
+ * + the fixed {@link errorCategory} vocabulary are the only routes a value takes,
+ * exactly so a caller can never accidentally smuggle content through.
+ */
+
+import {
+  bucketCount,
+  buildSharedProperties,
+  providerClass as toProviderClass,
+  type CountBucket,
+  type ErrorCategory,
+  type EventProperties,
+  type GraphProperties,
+  type Outcome,
+  type SharedPropertyInput,
+} from './events';
+
+/**
+ * The coarse disposition kinds telemetry tallies. Exactly the CLI's known
+ * reconcile dispositions — a FIXED vocabulary, never a node identity. The counts
+ * per kind are bucketed via {@link tallyDispositions}.
+ */
+export type DispositionKind = 'rendered' | 'skipped' | 'failed' | 'coalesced';
+
+/**
+ * Bucket a count-by-disposition tally into the content-free
+ * `Record<dispositionKind, CountBucket>` carried on `reactor.run`. The input is a
+ * list of per-node dispositions (the run report's shape); only the COUNT of each
+ * fixed kind survives — never which node, nor how many beyond the bucket band.
+ */
+export function tallyDispositions(
+  dispositions: readonly { readonly disposition: string }[],
+): Readonly<Record<string, CountBucket>> {
+  const counts: Record<string, number> = {};
+  for (const d of dispositions) {
+    counts[d.disposition] = (counts[d.disposition] ?? 0) + 1;
+  }
+  const out: Record<string, CountBucket> = {};
+  for (const kind of Object.keys(counts)) {
+    out[kind] = bucketCount(counts[kind] ?? 0);
+  }
+  return out;
+}
+
+/** The inputs to {@link buildGraphProperties}: raw graph + cost SHAPE numbers. */
+export interface GraphPropertyInput {
+  /** Raw node count — bucketed, never emitted raw. */
+  readonly nodes?: number;
+  /** Raw edge count — bucketed, never emitted raw. */
+  readonly edges?: number;
+  /** Raw fresh-cost token total — bucketed. */
+  readonly costFresh?: number;
+  /** Raw reused-cost token total — bucketed. */
+  readonly costReused?: number;
+  /** A free-form provider/adapter id — collapsed to a CLASS, never emitted. */
+  readonly provider?: string;
+  /** Per-node dispositions — tallied + bucketed by kind. */
+  readonly dispositions?: readonly { readonly disposition: string }[];
+}
+
+/**
+ * Build the `reactor.compile`/`reactor.run` graph extras from raw SHAPE numbers.
+ * Every count is bucketed; the provider is collapsed to a coarse class; the
+ * dispositions are tallied by fixed kind. The result is fully content-free.
+ */
+export function buildGraphProperties(input: GraphPropertyInput): GraphProperties {
+  const graph: GraphProperties = {
+    nodesBucket: bucketCount(input.nodes ?? 0),
+    edgesBucket: bucketCount(input.edges ?? 0),
+    cost: {
+      freshBucket: bucketCount(input.costFresh ?? 0),
+      reusedBucket: bucketCount(input.costReused ?? 0),
+    },
+    providerClass: toProviderClass(input.provider),
+  };
+  if (input.dispositions !== undefined) {
+    return { ...graph, dispositions: tallyDispositions(input.dispositions) };
+  }
+  return graph;
+}
+
+/**
+ * Assemble a full {@link EventProperties} object from the shared block input plus
+ * optional per-event extras. A convenience so a command builds the whole payload
+ * in one keyless call (the shared block is always present; extras merge on top).
+ */
+export function buildEventProperties(
+  shared: SharedPropertyInput,
+  extras?: Partial<EventProperties>,
+): EventProperties {
+  const base = buildSharedProperties(shared);
+  return extras === undefined ? base : { ...base, ...extras };
+}
+
+/**
+ * Map an arbitrary thrown value to a COARSE {@link ErrorCategory} — never the
+ * message, stack, or any operand. The categorization reads only a numeric
+ * `status` (when a provider error carries one) and matches a small set of stable
+ * shape markers; anything unrecognized is `"unknown"`. This is the ONLY route an
+ * error takes into telemetry.
+ *
+ * - `provider`     — a live adapter/model call failed (HTTP 401/402/429/5xx, or a
+ *                    recognizable provider/auth/rate-limit marker).
+ * - `config`       — bad/absent config, contracts, or topology.
+ * - `io`           — filesystem / state-dir (ENOENT/EACCES/ENOTDIR/EEXIST …).
+ * - `chain_verify` — a receipt-chain verification failure.
+ * - `unknown`      — anything uncategorized.
+ */
+export function errorCategory(err: unknown): ErrorCategory {
+  const e = err as { status?: unknown; code?: unknown; message?: unknown } | undefined;
+  const status = typeof e?.status === 'number' ? e.status : undefined;
+  const code = typeof e?.code === 'string' ? e.code : undefined;
+  // The message is read ONLY to classify into the fixed enum below; it never
+  // becomes a property. Lower-cased so the marker match is case-insensitive.
+  const text = typeof e?.message === 'string' ? e.message.toLowerCase() : '';
+
+  // Filesystem / IO — a Node errno code is the strongest, content-free signal.
+  if (code !== undefined && IO_CODES.has(code)) return 'io';
+
+  // Provider / live-call failures — an HTTP status or a stable auth/billing marker.
+  if (
+    status === 401 ||
+    status === 402 ||
+    status === 429 ||
+    (typeof status === 'number' && status >= 500 && status < 600)
+  ) {
+    return 'provider';
+  }
+  if (
+    text.includes('unauthorized') ||
+    text.includes('insufficient credits') ||
+    text.includes('insufficient_quota') ||
+    text.includes('rate limit') ||
+    text.includes('api key') ||
+    text.includes('openrouter') ||
+    text.includes('provider')
+  ) {
+    return 'provider';
+  }
+
+  // Receipt-chain verification.
+  if (text.includes('chain') && (text.includes('verif') || text.includes('tamper'))) {
+    return 'chain_verify';
+  }
+
+  // Config / contracts / topology.
+  if (
+    text.includes('no .prose.md') ||
+    text.includes('contracts') ||
+    text.includes('topology') ||
+    text.includes('config') ||
+    text.includes('reactor.yml') ||
+    text.includes('compile') ||
+    text.includes('stale')
+  ) {
+    return 'config';
+  }
+
+  return 'unknown';
+}
+
+/** The Node filesystem/IO errno codes that classify a thrown error as `io`. */
+const IO_CODES = new Set<string>([
+  'ENOENT',
+  'EACCES',
+  'EEXIST',
+  'ENOTDIR',
+  'EISDIR',
+  'EPERM',
+  'EROFS',
+  'ENOSPC',
+  'EMFILE',
+]);
+
+// Re-export the leaf vocabulary commands need so a handler imports from one place.
+export type { EventProperties, Outcome, ErrorCategory };

--- a/packages/reactor-cli/src/telemetry/endpoint.test.ts
+++ b/packages/reactor-cli/src/telemetry/endpoint.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Telemetry endpoint resolution leaf (`./endpoint`).
+ *
+ * Hermetic: no key, no network — only `process.env` mutation (saved/restored).
+ * Proves the documented precedence (02-IMPLEMENTATION-PLAN.md §endpoint):
+ *   1. `REACTOR_TELEMETRY_ENDPOINT` env override beats the default.
+ *   2. The default is PROD `https://api.openprose.ai/analytics`.
+ *   3. Normalization sanity: surrounding whitespace is trimmed, and an empty /
+ *      whitespace-only override falls back to the default rather than emitting a
+ *      blank URL.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveEndpoint, PROD_ENDPOINT, TELEMETRY_ENDPOINT_ENV } from './endpoint';
+
+describe('resolveEndpoint', () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[TELEMETRY_ENDPOINT_ENV];
+    delete process.env[TELEMETRY_ENDPOINT_ENV];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env[TELEMETRY_ENDPOINT_ENV];
+    } else {
+      process.env[TELEMETRY_ENDPOINT_ENV] = saved;
+    }
+  });
+
+  it('defaults to the PROD published endpoint when no override is set', () => {
+    assert.equal(resolveEndpoint(), PROD_ENDPOINT);
+    assert.equal(resolveEndpoint(), 'https://api.openprose.ai/analytics');
+  });
+
+  it('lets the REACTOR_TELEMETRY_ENDPOINT env override beat the default', () => {
+    const dev = 'https://api.dev.openprose.ai/analytics';
+    process.env[TELEMETRY_ENDPOINT_ENV] = dev;
+    assert.equal(resolveEndpoint(), dev);
+    assert.notEqual(resolveEndpoint(), PROD_ENDPOINT);
+  });
+
+  it('honors an arbitrary self-hosted override verbatim', () => {
+    process.env[TELEMETRY_ENDPOINT_ENV] = 'http://localhost:4000/analytics';
+    assert.equal(resolveEndpoint(), 'http://localhost:4000/analytics');
+  });
+
+  it('trims surrounding whitespace from the override', () => {
+    process.env[TELEMETRY_ENDPOINT_ENV] = '  https://api.dev.openprose.ai/analytics  ';
+    assert.equal(resolveEndpoint(), 'https://api.dev.openprose.ai/analytics');
+  });
+
+  it('falls back to the default for an empty or whitespace-only override', () => {
+    process.env[TELEMETRY_ENDPOINT_ENV] = '';
+    assert.equal(resolveEndpoint(), PROD_ENDPOINT);
+
+    process.env[TELEMETRY_ENDPOINT_ENV] = '   ';
+    assert.equal(resolveEndpoint(), PROD_ENDPOINT);
+  });
+
+  it('always returns a non-empty absolute https URL by default', () => {
+    const url = resolveEndpoint();
+    assert.ok(url.length > 0);
+    assert.ok(/^https:\/\//.test(url));
+    assert.ok(url.endsWith('/analytics'));
+  });
+});

--- a/packages/reactor-cli/src/telemetry/endpoint.ts
+++ b/packages/reactor-cli/src/telemetry/endpoint.ts
@@ -1,0 +1,45 @@
+/**
+ * Telemetry endpoint resolution — leaf module (keyless, zero-dep).
+ *
+ * Resolves the absolute `POST <base>/analytics` URL the bespoke `fetch` client
+ * targets. Precedence (02-IMPLEMENTATION-PLAN.md §endpoint resolution):
+ *
+ *   1. `REACTOR_TELEMETRY_ENDPOINT` env (absolute override) — self-hosters +
+ *      local/dev tooling. Local/dev builds reach the verified-live DEV endpoint
+ *      `https://api.dev.openprose.ai/analytics` (note `api.dev`, not `dev.api`)
+ *      purely by the monorepo dev/test tooling exporting this env var; the leaf
+ *      itself hardcodes only the PROD published default.
+ *   2. Else the published default = PROD `https://api.openprose.ai/analytics`.
+ *
+ * A project-level `telemetry.endpoint` (from `reactor.yml`) takes precedence over
+ * everything here, but that override is applied by `index.ts` BEFORE it falls
+ * back to {@link resolveEndpoint}, so this leaf intentionally does not handle it.
+ *
+ * Content-free: no host of the world model, no paths, no identity — only a fixed
+ * URL string. Reads `node:process` env only.
+ */
+
+/** The npm-published default telemetry endpoint (PROD). */
+export const PROD_ENDPOINT = 'https://api.openprose.ai/analytics';
+
+/** The env var a self-hoster / dev build sets to redirect telemetry. */
+export const TELEMETRY_ENDPOINT_ENV = 'REACTOR_TELEMETRY_ENDPOINT';
+
+/**
+ * Resolve the absolute analytics endpoint. Reads `REACTOR_TELEMETRY_ENDPOINT`
+ * from `process.env`; when set to a non-empty value (after trimming surrounding
+ * whitespace) that override wins, otherwise the PROD published default is used.
+ *
+ * Called with NO args (env is read from `process.env` directly), matching the
+ * foundation contract consumed by `./index`.
+ */
+export function resolveEndpoint(): string {
+  const override = process.env[TELEMETRY_ENDPOINT_ENV];
+  if (typeof override === 'string') {
+    const trimmed = override.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  return PROD_ENDPOINT;
+}

--- a/packages/reactor-cli/src/telemetry/events.ts
+++ b/packages/reactor-cli/src/telemetry/events.ts
@@ -1,0 +1,284 @@
+/**
+ * Telemetry event model — the CONTENT-FREE property contract.
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): this module is reachable from the telemetry
+ * factory which the offline entrypoint loads. It MUST NOT static-import any
+ * model-bearing dependency (`@openai/agents`, `zod`) or any model-bearing SDK
+ * barrel. It reads only `process.*` and the keyless `../meta` helpers.
+ *
+ * THE TRUST INVARIANT (00-POLICY.md §4, 02-IMPLEMENTATION-PLAN.md §2):
+ * everything emitted here is the SHAPE of usage, never the CONTENT of it.
+ * FORBIDDEN in every field, with no exceptions: world-model content, the
+ * markdown, prompt text, file paths, project/directory names, exact facet/node
+ * names, API keys, model inputs/outputs, precise IP-derived geo. Only anonymous
+ * versions, os/arch, a `ci` boolean, the command name, a coarse outcome,
+ * bucketed counts/durations, a coarse provider CLASS, and a coarse error
+ * CATEGORY may appear. Bucketers + the `providerClass` helper exist precisely so
+ * a caller can never accidentally smuggle a raw count or a provider key through.
+ *
+ * The server validates `context` with `forbidNonWhitelisted` (only utm/page/
+ * device/ip/library allowed), so ALL of this rides in the event `properties`
+ * object — never in `context`. See 01-RESEARCH-FINDINGS.md §A.
+ */
+
+import { cliVersion, resolveSdk } from '../meta';
+
+/** The property-schema version. Bump only on a breaking property-shape change. */
+export const SCHEMA_VERSION = 1 as const;
+
+// ---------------------------------------------------------------------------
+// Event names (the `reactor.*` taxonomy — 02-IMPLEMENTATION-PLAN.md §2).
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical Reactor telemetry event names. Each is prefixed `reactor.` so
+ * `event_name LIKE 'reactor.%'` is the analyst's primary (indexed) WHERE clause
+ * and is collision-free against existing `library` values in the table.
+ */
+export const TelemetryEvent = Object.freeze({
+  /** First machine run — fired once, from `doctor`, alongside the disclosure. */
+  FIRST_RUN: 'reactor.first_run',
+  COMPILE: 'reactor.compile',
+  RUN: 'reactor.run',
+  SERVE: 'reactor.serve',
+  TRIGGER: 'reactor.trigger',
+  INIT: 'reactor.init',
+  DOCTOR: 'reactor.doctor',
+  /** The collapsed read-only observability commands (status/topology/…). */
+  OBSERVE: 'reactor.observe',
+  /** A coarse, content-free failure signal (carries `errorCategory` only). */
+  ERROR: 'reactor.error',
+} as const);
+
+/** The union of valid `reactor.*` event names. */
+export type TelemetryEventName = (typeof TelemetryEvent)[keyof typeof TelemetryEvent];
+
+// ---------------------------------------------------------------------------
+// Coarse categorical vocabularies (NEVER free strings from the world model).
+// ---------------------------------------------------------------------------
+
+/** The coarse command-outcome. NEVER a message or a raw status. */
+export type Outcome = 'success' | 'failure' | 'cache_hit';
+
+/**
+ * The coarse error CATEGORY (02-IMPLEMENTATION-PLAN.md §2). A fixed enum — never
+ * the error message, stack, or any operand. `provider` = a live-adapter/model
+ * call failed; `config` = bad/absent config or contracts; `io` = filesystem/
+ * state-dir; `chain_verify` = a receipt-chain verification failure; `unknown` =
+ * anything uncategorized.
+ */
+export type ErrorCategory = 'provider' | 'config' | 'io' | 'chain_verify' | 'unknown';
+
+/** The read-only observability sub-command tag for `reactor.observe`. */
+export type ObserveSub =
+  | 'status'
+  | 'topology'
+  | 'inspect'
+  | 'logs'
+  | 'trace'
+  | 'receipts';
+
+/** A bucketed small-integer count. */
+export type CountBucket = '0' | '1-5' | '6-20' | '21+';
+
+/** A bucketed wall-clock duration. */
+export type DurationBucket = '<1s' | '1-5s' | '5-30s' | '30s+';
+
+// ---------------------------------------------------------------------------
+// Bucketers (the only sanctioned way a count or a duration becomes a property).
+// ---------------------------------------------------------------------------
+
+/**
+ * Bucket a non-negative integer count into a coarse band. A raw count (e.g. an
+ * exact node total) is FORBIDDEN as a property — it is weakly identifying — so
+ * every count passes through here first. Negative / non-finite inputs clamp to
+ * `"0"`.
+ */
+export function bucketCount(n: number): CountBucket {
+  if (!Number.isFinite(n) || n <= 0) return '0';
+  if (n <= 5) return '1-5';
+  if (n <= 20) return '6-20';
+  return '21+';
+}
+
+/**
+ * Bucket a wall-clock duration in milliseconds into a coarse band. A raw ms
+ * value is FORBIDDEN as a property (it is a side channel); every duration passes
+ * through here. Negative / non-finite inputs clamp to `"<1s"`.
+ */
+export function bucketMs(ms: number): DurationBucket {
+  if (!Number.isFinite(ms) || ms < 1000) return '<1s';
+  if (ms < 5000) return '1-5s';
+  if (ms < 30000) return '5-30s';
+  return '30s+';
+}
+
+/**
+ * Map a free-form provider/adapter identifier to a coarse CLASS string — NEVER a
+ * key, token, base URL, or model id. Only the recognized provider family name
+ * leaves this function; anything unrecognized collapses to `"other"`, and an
+ * absent provider is `"none"`. This is the only sanctioned way a provider
+ * appears in telemetry.
+ */
+export function providerClass(provider: string | undefined): string {
+  if (provider === undefined) return 'none';
+  const p = provider.trim().toLowerCase();
+  if (p.length === 0) return 'none';
+  // Match a known family by substring; the returned token is a fixed class label,
+  // never the caller's string.
+  if (p.includes('openrouter')) return 'openrouter';
+  if (p.includes('openai')) return 'openai';
+  if (p.includes('anthropic')) return 'anthropic';
+  if (p.includes('google') || p.includes('gemini') || p.includes('vertex')) {
+    return 'google';
+  }
+  if (p.includes('azure')) return 'azure';
+  if (p.includes('bedrock') || p.includes('aws')) return 'bedrock';
+  if (p.includes('ollama') || p.includes('local')) return 'local';
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// CI detection (keyless, env-only).
+// ---------------------------------------------------------------------------
+
+/**
+ * Coarse CI detection from env. Honors the generic `CI` flag plus the common
+ * provider-specific markers, so an automated run is reported as `ci:true`
+ * regardless of which platform set it. (The opt-out gate ALSO disables telemetry
+ * under CI; this boolean is for the events that DO fire on interactive runs.)
+ */
+export function isCi(env: NodeJS.ProcessEnv = process.env): boolean {
+  const ci = env.CI;
+  if (typeof ci === 'string' && ci.length > 0 && ci !== '0' && ci !== 'false') {
+    return true;
+  }
+  return (
+    Boolean(env.GITHUB_ACTIONS) ||
+    Boolean(env.GITLAB_CI) ||
+    Boolean(env.CIRCLECI) ||
+    Boolean(env.BUILDKITE) ||
+    Boolean(env.TF_BUILD) ||
+    Boolean(env.JENKINS_URL) ||
+    Boolean(env.TEAMCITY_VERSION)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The shared property model (present on EVERY event).
+// ---------------------------------------------------------------------------
+
+/**
+ * The content-free properties carried by every `reactor.*` event. The ONLY place
+ * Reactor-specific data may ride (the server's `context` is a closed whitelist).
+ */
+export interface SharedProperties {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  /** This CLI package version (`@openprose/reactor-cli`). */
+  readonly cliVersion: string;
+  /** The resolved `@openprose/reactor` SDK version, or `"unknown"`. */
+  readonly reactorVersion: string;
+  /** `process.version` (e.g. `"v20.11.0"`). */
+  readonly nodeVersion: string;
+  /** `process.platform` (e.g. `"darwin"`). A coarse OS family, not a hostname. */
+  readonly os: NodeJS.Platform;
+  /** `process.arch` (e.g. `"arm64"`). */
+  readonly arch: string;
+  /** Coarse CI/automation detection. */
+  readonly ci: boolean;
+  /** The command name (`"run" | "compile" | ...`) — never an argument value. */
+  readonly command: string;
+  /** The coarse outcome. */
+  readonly outcome: Outcome;
+  /** The bucketed wall-clock duration of the command. */
+  readonly durationBucket: DurationBucket;
+}
+
+/** The inputs the caller supplies; the version/os/arch/ci fields are derived. */
+export interface SharedPropertyInput {
+  readonly command: string;
+  readonly outcome: Outcome;
+  /** Raw elapsed ms — bucketed here, never emitted raw. */
+  readonly durationMs: number;
+  /** Override CI detection (tests); defaults to {@link isCi}. */
+  readonly ci?: boolean;
+  /** Override the resolved SDK version (tests); defaults to {@link resolveSdk}. */
+  readonly reactorVersion?: string;
+  /** Override the env read for CI detection (tests). */
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Build the shared, content-free property block present on every event. Resolves
+ * the CLI + SDK versions via the keyless `../meta` helpers and reads only
+ * `process.platform`/`process.arch`. Pure aside from those reads; every caller-
+ * supplied number is bucketed before it lands in the returned object.
+ */
+export function buildSharedProperties(input: SharedPropertyInput): SharedProperties {
+  const reactorVersion =
+    input.reactorVersion ?? resolveSdk().version ?? 'unknown';
+  const ci = input.ci ?? isCi(input.env);
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    cliVersion: cliVersion(),
+    reactorVersion,
+    nodeVersion: process.version,
+    os: process.platform,
+    arch: process.arch,
+    ci,
+    command: input.command,
+    outcome: input.outcome,
+    durationBucket: bucketMs(input.durationMs),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-event extras (bucketed / categorical ONLY).
+// ---------------------------------------------------------------------------
+
+/**
+ * Extras for `reactor.compile` / `reactor.run` — graph SHAPE + cost SHAPE, all
+ * bucketed/categorical. `dispositions` is a count-by-disposition map (the
+ * disposition kind is a fixed vocabulary; the COUNTS are bucketed) — never node
+ * identities.
+ */
+export interface GraphProperties {
+  readonly nodesBucket: CountBucket;
+  readonly edgesBucket: CountBucket;
+  readonly cost: {
+    readonly freshBucket: CountBucket;
+    readonly reusedBucket: CountBucket;
+  };
+  /** The adapter/provider CLASS (via {@link providerClass}), never a key. */
+  readonly providerClass: string;
+  /** Bucketed counts keyed by disposition kind (a fixed vocabulary). */
+  readonly dispositions?: Readonly<Record<string, CountBucket>>;
+}
+
+/** Extras for `reactor.observe` — only which read-only sub-command ran. */
+export interface ObserveProperties {
+  readonly sub: ObserveSub;
+}
+
+/**
+ * Extras for `reactor.serve`. `pollIntervalBucket` is the cadence bucketed;
+ * `concurrencyBucket` the worker bound bucketed. Poll-cycle events are SAMPLED
+ * by the caller (first-only / 1-of-N) so a long-running daemon cannot flood.
+ */
+export interface ServeProperties {
+  readonly pollIntervalBucket: DurationBucket;
+  readonly concurrencyBucket: CountBucket;
+}
+
+/** Extras for `reactor.error` — the coarse category ONLY (never the message). */
+export interface ErrorProperties {
+  readonly errorCategory: ErrorCategory;
+}
+
+/**
+ * The fully-assembled property object for a single event: the shared block plus
+ * any per-event extras. This is exactly what rides in the Segment `properties`
+ * field. It is a plain JSON record so the transport can serialize it directly.
+ */
+export type EventProperties = SharedProperties &
+  Partial<GraphProperties & ObserveProperties & ServeProperties & ErrorProperties>;

--- a/packages/reactor-cli/src/telemetry/gate.test.ts
+++ b/packages/reactor-cli/src/telemetry/gate.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Opt-out gate truth table (02-IMPLEMENTATION-PLAN.md §3, §7).
+ *
+ * Hermetic: no key, no network, no filesystem. The gate is a PURE function of
+ * (env, isTty, projectTelemetry, machine-config); the machine-config read is
+ * injected via `GateDeps` so every branch — each of the six disable conditions
+ * individually, the precedence between them, and the all-clear enabled default —
+ * is exercised deterministically. Each disable case also asserts its short
+ * `reason` tag (the value `--dump` surfaces).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isTelemetryEnabled, type GateInput, type GateDeps } from './gate';
+
+/** A `GateDeps` whose machine flag is whatever the test pins (default: no pref). */
+function deps(machine: boolean | undefined = undefined): GateDeps {
+  return { readMachineTelemetryEnabled: () => machine };
+}
+
+/**
+ * The canonical ALL-CLEAR input: every opt-out source explicitly off, stdout is
+ * an interactive TTY, no project/machine preference. The enabled-by-default case.
+ */
+function allClear(): GateInput {
+  return { env: {}, isTty: true };
+}
+
+describe('isTelemetryEnabled — the opt-out truth table', () => {
+  it('is ENABLED by default when no opt-out condition holds (TTY, clean env)', () => {
+    const d = isTelemetryEnabled(allClear(), deps());
+    assert.equal(d.enabled, true);
+    assert.equal(d.reason, undefined);
+  });
+
+  // 1. DO_NOT_TRACK ---------------------------------------------------------
+  it('disables on DO_NOT_TRACK truthy → reason "do_not_track"', () => {
+    for (const v of ['1', 'true', 'yes', 'anything']) {
+      const d = isTelemetryEnabled({ env: { DO_NOT_TRACK: v }, isTty: true }, deps());
+      assert.equal(d.enabled, false, `DO_NOT_TRACK=${v}`);
+      assert.equal(d.reason, 'do_not_track', `DO_NOT_TRACK=${v}`);
+    }
+  });
+
+  it('does NOT disable on DO_NOT_TRACK unset / "" / "0" / "false"', () => {
+    for (const v of [undefined, '', '0', 'false', 'FALSE']) {
+      const env = v === undefined ? {} : { DO_NOT_TRACK: v };
+      const d = isTelemetryEnabled({ env, isTty: true }, deps());
+      assert.equal(d.enabled, true, `DO_NOT_TRACK=${String(v)}`);
+    }
+  });
+
+  // 2. REACTOR_TELEMETRY=0 / REACTOR_TELEMETRY_DISABLED ---------------------
+  it('disables on REACTOR_TELEMETRY=0 → reason "env_disabled"', () => {
+    const d = isTelemetryEnabled({ env: { REACTOR_TELEMETRY: '0' }, isTty: true }, deps());
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'env_disabled');
+  });
+
+  it('does NOT disable on REACTOR_TELEMETRY=1 (only "0" disables)', () => {
+    const d = isTelemetryEnabled({ env: { REACTOR_TELEMETRY: '1' }, isTty: true }, deps());
+    assert.equal(d.enabled, true);
+  });
+
+  it('disables on REACTOR_TELEMETRY_DISABLED set (even empty) → "env_disabled"', () => {
+    for (const v of ['', '1', 'whatever']) {
+      const d = isTelemetryEnabled(
+        { env: { REACTOR_TELEMETRY_DISABLED: v }, isTty: true },
+        deps(),
+      );
+      assert.equal(d.enabled, false, `value=${JSON.stringify(v)}`);
+      assert.equal(d.reason, 'env_disabled');
+    }
+  });
+
+  // 3. REACTOR_OFFLINE=1 ----------------------------------------------------
+  it('disables on REACTOR_OFFLINE=1 → reason "offline"', () => {
+    const d = isTelemetryEnabled({ env: { REACTOR_OFFLINE: '1' }, isTty: true }, deps());
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'offline');
+  });
+
+  it('does NOT disable on REACTOR_OFFLINE unset or ≠ "1"', () => {
+    for (const v of [undefined, '0', 'true']) {
+      const env = v === undefined ? {} : { REACTOR_OFFLINE: v };
+      const d = isTelemetryEnabled({ env, isTty: true }, deps());
+      assert.equal(d.enabled, true, `REACTOR_OFFLINE=${String(v)}`);
+    }
+  });
+
+  // 4. CI truthy OR non-TTY -------------------------------------------------
+  it('disables on CI truthy → reason "ci"', () => {
+    for (const v of ['1', 'true', 'TRUE']) {
+      const d = isTelemetryEnabled({ env: { CI: v }, isTty: true }, deps());
+      assert.equal(d.enabled, false, `CI=${v}`);
+      assert.equal(d.reason, 'ci', `CI=${v}`);
+    }
+  });
+
+  it('does NOT disable on CI unset / "" / "0" / "false" (TTY)', () => {
+    for (const v of [undefined, '', '0', 'false']) {
+      const env = v === undefined ? {} : { CI: v };
+      const d = isTelemetryEnabled({ env, isTty: true }, deps());
+      assert.equal(d.enabled, true, `CI=${String(v)}`);
+    }
+  });
+
+  it('disables on non-TTY stdout → reason "non_tty"', () => {
+    const d = isTelemetryEnabled({ env: {}, isTty: false }, deps());
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'non_tty');
+  });
+
+  // 5. project reactor.yml telemetry.enabled:false -------------------------
+  it('disables on project telemetry.enabled === false → "config_disabled"', () => {
+    const d = isTelemetryEnabled(
+      { env: {}, isTty: true, projectTelemetry: { enabled: false } },
+      deps(),
+    );
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'config_disabled');
+  });
+
+  it('does NOT disable on project telemetry.enabled === true or unset', () => {
+    const enabled = isTelemetryEnabled(
+      { env: {}, isTty: true, projectTelemetry: { enabled: true } },
+      deps(),
+    );
+    assert.equal(enabled.enabled, true);
+    const unset = isTelemetryEnabled(
+      { env: {}, isTty: true, projectTelemetry: { endpoint: 'https://x/analytics' } },
+      deps(),
+    );
+    assert.equal(unset.enabled, true);
+  });
+
+  // 6. machine ~/.reactor/config.json telemetryEnabled:false ---------------
+  it('disables on machine config telemetryEnabled === false → "config_disabled"', () => {
+    const d = isTelemetryEnabled(allClear(), deps(false));
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'config_disabled');
+  });
+
+  it('does NOT disable on machine config telemetryEnabled === true or no preference', () => {
+    assert.equal(isTelemetryEnabled(allClear(), deps(true)).enabled, true);
+    assert.equal(isTelemetryEnabled(allClear(), deps(undefined)).enabled, true);
+  });
+
+  // Precedence / combination -----------------------------------------------
+  it('surfaces the highest-precedence reason when multiple conditions hold', () => {
+    // DO_NOT_TRACK wins over CI and a non-TTY and a disabled config.
+    const d = isTelemetryEnabled(
+      {
+        env: { DO_NOT_TRACK: '1', CI: '1', REACTOR_OFFLINE: '1' },
+        isTty: false,
+        projectTelemetry: { enabled: false },
+      },
+      deps(false),
+    );
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'do_not_track');
+  });
+
+  it('CI takes precedence over a non-TTY (reason "ci", not "non_tty")', () => {
+    const d = isTelemetryEnabled({ env: { CI: '1' }, isTty: false }, deps());
+    assert.equal(d.enabled, false);
+    assert.equal(d.reason, 'ci');
+  });
+
+  // The default-deps single-arg contract (as index.ts calls it) ------------
+  it('accepts a single GateInput arg (deps defaults to the disk read)', () => {
+    // In the harness ~/.reactor/config.json is absent → no machine preference,
+    // so a clean TTY env is enabled with no thrown error.
+    const d = isTelemetryEnabled(allClear());
+    assert.equal(typeof d.enabled, 'boolean');
+  });
+});

--- a/packages/reactor-cli/src/telemetry/gate.ts
+++ b/packages/reactor-cli/src/telemetry/gate.ts
@@ -1,0 +1,164 @@
+/**
+ * Telemetry opt-out gate — the single decision point for whether ANY telemetry
+ * is collected or sent on this run.
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): this leaf is reachable from the telemetry factory
+ * which the offline entrypoint (`cli.ts`) loads, so it MUST NOT static-import any
+ * model-bearing dependency (`@openai/agents`, `zod`) or any model-bearing SDK
+ * barrel. It reads only the injected env, the injected TTY bit, the optional
+ * project-level config, and — for the machine-level flag — `~/.reactor/config.json`
+ * via `node:os`/`node:fs` (no network, no key).
+ *
+ * TRUST POSTURE (00-POLICY.md §3, 02-IMPLEMENTATION-PLAN.md §3): telemetry is
+ * opt-out and honors the community standards. Telemetry is DISABLED if ANY of:
+ *   1. `DO_NOT_TRACK` is truthy (≠ unset / "" / "0")      → `"do_not_track"`
+ *   2. `REACTOR_TELEMETRY=0` OR `REACTOR_TELEMETRY_DISABLED` set → `"env_disabled"`
+ *   3. `REACTOR_OFFLINE=1`                                  → `"offline"`
+ *   4. `CI` truthy OR stdout is not a TTY                   → `"ci"` / `"non_tty"`
+ *   5. project `reactor.yml` `telemetry.enabled: false`     → `"config_disabled"`
+ *   6. machine `~/.reactor/config.json` `telemetryEnabled: false` → `"config_disabled"`
+ * Otherwise (none of the above): ENABLED.
+ *
+ * `isTelemetryEnabled` is the consumed contract (single {@link GateInput} arg, as
+ * `index.ts` calls it). The machine-config read is injected through an optional
+ * second `deps` parameter that defaults to a real disk read, so the decision is a
+ * PURE function of (env, isTty, projectTelemetry, machine-config) and the entire
+ * truth table is unit-testable with no filesystem.
+ */
+
+import { machineConfigPath as identityConfigPath, readMachineConfig } from './identity';
+
+/**
+ * The gate's decision sources (the verbatim shape `index.ts` constructs and
+ * passes). `projectTelemetry` is the parsed `reactor.yml` `telemetry` block; when
+ * absent the project expresses no preference.
+ */
+export interface GateInput {
+  readonly env: NodeJS.ProcessEnv;
+  readonly isTty: boolean;
+  readonly projectTelemetry?: { readonly enabled?: boolean; readonly endpoint?: string };
+}
+
+/** The gate result: whether telemetry is enabled and (when off) a short reason. */
+export interface GateDecision {
+  readonly enabled: boolean;
+  /** A short, stable tag when disabled (consumed by `--dump`); absent when enabled. */
+  readonly reason?: string;
+}
+
+/**
+ * The injectable machine-config view the gate needs. Only the opt-out flag is
+ * relevant here; `undefined` means "no machine preference" (file absent, empty,
+ * corrupt, or flag unset) and the gate treats that as not-disabled.
+ */
+export interface GateDeps {
+  /**
+   * Read the persisted machine-level opt-out flag from `~/.reactor/config.json`.
+   * Returns `false` only when the user explicitly disabled telemetry; returns
+   * `undefined` for every other case (absent / unreadable / unset). Never throws.
+   */
+  readonly readMachineTelemetryEnabled: () => boolean | undefined;
+}
+
+/**
+ * The absolute path of the machine config file (`~/.reactor/config.json`, or the
+ * `REACTOR_CONFIG_DIR` seam). Delegates to the identity leaf so EVERY telemetry
+ * component agrees on one config location (so `reactor telemetry disable` is the
+ * exact same file the gate reads, in tests and in production alike).
+ */
+export function machineConfigPath(): string {
+  return identityConfigPath();
+}
+
+/**
+ * Default {@link GateDeps}: read the machine config (via the identity leaf, so the
+ * `REACTOR_CONFIG_DIR` seam is honored) and return its `telemetryEnabled` ONLY
+ * when it is the boolean `false` (an explicit opt-out). Any other state — missing
+ * file, unreadable, malformed JSON, missing/non-boolean field — yields `undefined`
+ * (no machine preference). Fail-closed to "not a preference" never crashes the gate.
+ */
+function readMachineTelemetryEnabledFromDisk(): boolean | undefined {
+  try {
+    const config = readMachineConfig();
+    if (config?.telemetryEnabled === false) return false;
+    if (config?.telemetryEnabled === true) return true;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const DEFAULT_DEPS: GateDeps = {
+  readMachineTelemetryEnabled: readMachineTelemetryEnabledFromDisk,
+};
+
+/**
+ * Is a raw env value "truthy" by the opt-out convention? Unset, empty, "0",
+ * "false" (case-insensitive) all count as NOT-truthy; anything else is truthy.
+ * This is the `DO_NOT_TRACK` / `CI` interpretation (consoledonottrack.com).
+ */
+function envTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const v = value.trim().toLowerCase();
+  if (v === '' || v === '0' || v === 'false') return false;
+  return true;
+}
+
+/** Is an env var SET (present at all, even empty)? Used for the "set" flags. */
+function envSet(value: string | undefined): boolean {
+  return value !== undefined;
+}
+
+/**
+ * The opt-out gate. Returns `{ enabled }` and, when disabled, a short `reason`.
+ * Disabled if ANY of the six conditions hold (evaluated in a fixed precedence so
+ * the surfaced `reason` is deterministic). PURE given the four inputs: the env,
+ * the TTY bit, the project preference, and the injected machine-config read.
+ *
+ * `index.ts` calls this with a single {@link GateInput}; the `deps` arg defaults
+ * to the real disk read and exists only so tests drive the machine-config branch
+ * without touching the filesystem.
+ */
+export function isTelemetryEnabled(
+  input: GateInput,
+  deps: GateDeps = DEFAULT_DEPS,
+): GateDecision {
+  const { env, isTty, projectTelemetry } = input;
+
+  // 1. DO_NOT_TRACK (consoledonottrack.com): truthy ≠ unset/""/"0"/"false".
+  if (envTruthy(env.DO_NOT_TRACK)) {
+    return { enabled: false, reason: 'do_not_track' };
+  }
+
+  // 2. Reactor-specific env opt-out: REACTOR_TELEMETRY=0 OR the disabled flag set.
+  if (env.REACTOR_TELEMETRY === '0' || envSet(env.REACTOR_TELEMETRY_DISABLED)) {
+    return { enabled: false, reason: 'env_disabled' };
+  }
+
+  // 3. REACTOR_OFFLINE=1 — offline implies zero egress (consistent with the
+  //    existing offline flag the rest of the CLI honors).
+  if (env.REACTOR_OFFLINE === '1') {
+    return { enabled: false, reason: 'offline' };
+  }
+
+  // 4. Automated / non-interactive runs: CI truthy, or stdout is not a TTY.
+  if (envTruthy(env.CI)) {
+    return { enabled: false, reason: 'ci' };
+  }
+  if (!isTty) {
+    return { enabled: false, reason: 'non_tty' };
+  }
+
+  // 5. Project-level opt-out (reactor.yml → telemetry.enabled: false).
+  if (projectTelemetry?.enabled === false) {
+    return { enabled: false, reason: 'config_disabled' };
+  }
+
+  // 6. Machine-level opt-out (~/.reactor/config.json → telemetryEnabled: false).
+  if (deps.readMachineTelemetryEnabled() === false) {
+    return { enabled: false, reason: 'config_disabled' };
+  }
+
+  // None of the opt-out conditions held → telemetry is enabled by default.
+  return { enabled: true };
+}

--- a/packages/reactor-cli/src/telemetry/identity.test.ts
+++ b/packages/reactor-cli/src/telemetry/identity.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the `./identity` telemetry leaf — anonymous install-id + machine
+ * config persistence in `~/.reactor/config.json`.
+ *
+ * Hermetic: NEVER touches the real home. Every case routes the config dir to a
+ * throwaway temp dir via the `REACTOR_CONFIG_DIR` env seam (passed as the
+ * explicit `env` arg so the suite never mutates `process.env`).
+ *
+ * Proven properties:
+ *   1. create-once: a fresh machine mints a UUID and persists the documented
+ *      `{ installId }` schema.
+ *   2. reuse: a second call returns the SAME id and does not rewrite a new one.
+ *   3. corrupt-file fallback: a non-JSON / non-object / id-less config does NOT
+ *      throw — a fresh id is regenerated and the file repaired, preserving any
+ *      sibling-owned fields (`telemetryEnabled`, `noticeShownVersion`).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  getOrCreateInstallId,
+  readMachineConfig,
+  writeMachineConfig,
+  machineConfigPath,
+  machineConfigDir,
+} from './identity';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A fresh temp config dir + an env that routes the leaf at it (test seam). */
+function freshEnv(): { env: NodeJS.ProcessEnv; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'reactor-cli-identity-'));
+  return { env: { REACTOR_CONFIG_DIR: dir }, dir };
+}
+
+describe('telemetry/identity', () => {
+  it('resolves the config path under the env-seam dir (never the real home)', () => {
+    const { env, dir } = freshEnv();
+    try {
+      assert.equal(machineConfigDir(env), dir);
+      assert.equal(machineConfigPath(env), join(dir, 'config.json'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('create-once: mints a UUID and persists the {installId} schema', () => {
+    const { env, dir } = freshEnv();
+    try {
+      assert.equal(existsSync(machineConfigPath(env)), false, 'no config before first call');
+      const id = getOrCreateInstallId(env);
+      assert.match(id, UUID_RE, 'returns a random UUID');
+
+      // Persisted to disk with the documented shape.
+      const onDisk = JSON.parse(readFileSync(machineConfigPath(env), 'utf8')) as {
+        installId?: string;
+      };
+      assert.equal(onDisk.installId, id);
+
+      // And readable back through the leaf's own reader.
+      assert.equal(readMachineConfig(env)?.installId, id);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reuse: a second call returns the SAME persisted id', () => {
+    const { env, dir } = freshEnv();
+    try {
+      const first = getOrCreateInstallId(env);
+      const second = getOrCreateInstallId(env);
+      assert.equal(second, first, 'id is stable across calls');
+      // The persisted id matches the very first mint (not re-minted).
+      assert.equal(readMachineConfig(env)?.installId, first);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('corrupt-file fallback: invalid JSON regenerates without throwing', () => {
+    const { env, dir } = freshEnv();
+    try {
+      // Seed a corrupt (non-JSON) config file.
+      writeMachineConfig({ installId: 'seed' }, env); // ensures dir exists
+      writeFileSync(machineConfigPath(env), '{ this is not valid json', 'utf8');
+
+      // readMachineConfig is a soft miss, not a throw.
+      assert.equal(readMachineConfig(env), undefined);
+
+      let id!: string;
+      assert.doesNotThrow(() => {
+        id = getOrCreateInstallId(env);
+      });
+      assert.match(id, UUID_RE);
+      // The file was repaired to valid JSON carrying the new id.
+      assert.equal(readMachineConfig(env)?.installId, id);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('id-less / partial config: regenerates an id and preserves sibling fields', () => {
+    const { env, dir } = freshEnv();
+    try {
+      // A config with no installId but sibling-owned flags set.
+      writeMachineConfig({ installId: '', telemetryEnabled: false, noticeShownVersion: '0.2.0' } as never, env);
+      const id = getOrCreateInstallId(env);
+      assert.match(id, UUID_RE);
+      const cfg = readMachineConfig(env);
+      assert.equal(cfg?.installId, id);
+      // Sibling-owned fields survive the repair.
+      assert.equal(cfg?.telemetryEnabled, false);
+      assert.equal(cfg?.noticeShownVersion, '0.2.0');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('non-object JSON (array) is a soft miss and regenerates', () => {
+    const { env, dir } = freshEnv();
+    try {
+      writeMachineConfig({ installId: 'seed' }, env);
+      writeFileSync(machineConfigPath(env), '[1,2,3]', 'utf8');
+      assert.equal(readMachineConfig(env), undefined);
+      const id = getOrCreateInstallId(env);
+      assert.match(id, UUID_RE);
+      assert.equal(readMachineConfig(env)?.installId, id);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/reactor-cli/src/telemetry/identity.ts
+++ b/packages/reactor-cli/src/telemetry/identity.ts
@@ -1,0 +1,171 @@
+/**
+ * Anonymous machine identity + machine-config persistence (the `./identity`
+ * leaf of the telemetry module).
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): reachable from the telemetry factory which the
+ * offline entrypoint loads, so this module MUST NOT static-import any
+ * model-bearing dependency (`@openai/agents`, `zod`) or any model-bearing SDK
+ * barrel. It touches only `node:os`, `node:fs`, and `node:crypto`.
+ *
+ * RESPONSIBILITY (02-IMPLEMENTATION-PLAN.md §1): own `~/.reactor/config.json`,
+ * the per-machine config that backs the anonymous install id, the machine-level
+ * opt-out flag, and the once-per-machine notice stamp. The schema is exactly
+ * `{ installId, telemetryEnabled?, noticeShownVersion }`.
+ *
+ * TRUST POSTURE (00-POLICY.md): `installId` is a random UUID — anonymous and
+ * content-free. It is created ONCE per machine (`crypto.randomUUID`) and then
+ * reused, so it correlates a machine's events without ever identifying a user,
+ * project, or path.
+ *
+ * NEVER-THROW (contract): every public function fails closed. A corrupt,
+ * unreadable, or unwritable config never propagates an error to the CLI — the id
+ * is regenerated in memory and a best-effort write is attempted. `initTelemetry`
+ * already wraps the call, but this leaf is defensive in its own right.
+ */
+
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+/** The machine-config file name inside the Reactor config dir. */
+const CONFIG_FILE = 'config.json';
+
+/** The Reactor config directory name under the user's home. */
+const CONFIG_DIR_NAME = '.reactor';
+
+/**
+ * Env override for the config DIRECTORY. This is the test seam: tests point it at
+ * a throwaway temp dir so they never read or write the real `~/.reactor`. When
+ * unset (the normal case), the directory is `<homedir>/.reactor`.
+ */
+const CONFIG_DIR_ENV = 'REACTOR_CONFIG_DIR';
+
+/**
+ * The persisted machine-config schema. EXACTLY these keys (00-POLICY.md /
+ * 02-IMPLEMENTATION-PLAN.md §5): the anonymous install id, an optional
+ * machine-level telemetry opt-out, and the version at which the first-run notice
+ * was last shown.
+ */
+export interface MachineConfig {
+  /** The anonymous, content-free per-machine UUID. */
+  installId: string;
+  /** Machine-level opt-out (set by `reactor telemetry disable`). */
+  telemetryEnabled?: boolean;
+  /** The CLI version at which the doctor first-run notice was shown. */
+  noticeShownVersion?: string;
+}
+
+/**
+ * Resolve the Reactor config directory. Honors the {@link CONFIG_DIR_ENV}
+ * override (the test seam); otherwise `<os.homedir()>/.reactor`.
+ */
+export function machineConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[CONFIG_DIR_ENV];
+  if (typeof override === 'string' && override.length > 0) {
+    return override;
+  }
+  return path.join(os.homedir(), CONFIG_DIR_NAME);
+}
+
+/**
+ * The absolute path to the machine-config file
+ * (`<config-dir>/config.json`). Siblings (`./gate`, `./notice`) read the same
+ * file through {@link readMachineConfig} rather than re-deriving this path.
+ */
+export function machineConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(machineConfigDir(env), CONFIG_FILE);
+}
+
+/**
+ * Read + parse the machine config. Returns `undefined` when the file is absent,
+ * unreadable, not valid JSON, or not an object — every such case is a soft miss,
+ * never a throw. A present-but-partial object is returned as-is (callers treat a
+ * missing/blank `installId` as "no id yet").
+ */
+export function readMachineConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): MachineConfig | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(machineConfigPath(env), 'utf8');
+  } catch {
+    // Absent / unreadable -> soft miss.
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Corrupt JSON -> soft miss (the caller regenerates).
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const obj = parsed as Record<string, unknown>;
+  const config: MachineConfig = {
+    installId: typeof obj.installId === 'string' ? obj.installId : '',
+  };
+  if (typeof obj.telemetryEnabled === 'boolean') {
+    config.telemetryEnabled = obj.telemetryEnabled;
+  }
+  if (typeof obj.noticeShownVersion === 'string') {
+    config.noticeShownVersion = obj.noticeShownVersion;
+  }
+  return config;
+}
+
+/**
+ * Persist the machine config (creating the config dir if needed). Best-effort:
+ * any filesystem failure is swallowed so a read-only / unwritable home never
+ * breaks the CLI. Returns `true` on a confirmed write, `false` otherwise — the
+ * boolean is advisory; callers proceed regardless.
+ */
+export function writeMachineConfig(
+  config: MachineConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  try {
+    const dir = machineConfigDir(env);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      machineConfigPath(env),
+      `${JSON.stringify(config, null, 2)}\n`,
+      'utf8',
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get-or-create the anonymous machine install id (contract: NO args; reads the
+ * config dir via the env seam internally).
+ *
+ * - First call on a machine: mints a `crypto.randomUUID()`, persists it
+ *   (preserving any existing `telemetryEnabled` / `noticeShownVersion`), and
+ *   returns it.
+ * - Subsequent calls: returns the persisted id unchanged.
+ * - Corrupt / unreadable / id-less config: regenerates a fresh id and attempts
+ *   to repair the file — never throws. If the write fails the id is still
+ *   returned (in-memory), so the caller always gets a usable anonymous id.
+ */
+export function getOrCreateInstallId(env: NodeJS.ProcessEnv = process.env): string {
+  const existing = readMachineConfig(env);
+  if (existing && typeof existing.installId === 'string' && existing.installId.length > 0) {
+    return existing.installId;
+  }
+  const installId = randomUUID();
+  // Preserve any sibling-owned fields when repairing a partial/corrupt config.
+  const next: MachineConfig = { installId };
+  if (existing?.telemetryEnabled !== undefined) {
+    next.telemetryEnabled = existing.telemetryEnabled;
+  }
+  if (existing?.noticeShownVersion !== undefined) {
+    next.noticeShownVersion = existing.noticeShownVersion;
+  }
+  writeMachineConfig(next, env);
+  return installId;
+}

--- a/packages/reactor-cli/src/telemetry/index.ts
+++ b/packages/reactor-cli/src/telemetry/index.ts
@@ -1,0 +1,187 @@
+/**
+ * Telemetry public contract — the ONLY surface the CLI commands import.
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): the offline entrypoint (`cli.ts`) loads this
+ * module, so it MUST NOT static-import any model-bearing dependency
+ * (`@openai/agents`, `zod`) or any model-bearing SDK barrel. It composes the
+ * keyless leaf modules (`./gate`, `./identity`, `./endpoint`, `./client`,
+ * `./notice`, `./events`) and reads only env + `~/.reactor/config.json`.
+ *
+ * TRUST POSTURE (00-POLICY.md): anonymous, opt-out, CLI-only, content-free,
+ * fire-and-forget. {@link initTelemetry} consults the opt-out gate and returns a
+ * NO-OP when telemetry is disabled (CI / non-TTY / DO_NOT_TRACK / REACTOR_*
+ * env / config flags), so a disabled run performs ZERO work and ZERO egress. The
+ * SDK (`@openprose/reactor`) stays silent — telemetry lives only here.
+ *
+ * The leaf modules referenced below (`./gate`, `./identity`, `./endpoint`,
+ * `./client`, `./notice`) are authored in the NEXT phase to the EXACT signatures
+ * re-exported + consumed here; until they exist this file references not-yet-
+ * present symbols and only fully typechecks once the leaves land. It is wired
+ * fully on purpose — it is NOT stubbed down to a no-op.
+ */
+
+import { isTelemetryEnabled, type GateInput } from './gate';
+import { getOrCreateInstallId } from './identity';
+import { resolveEndpoint } from './endpoint';
+import { createHttpTelemetry } from './client';
+import { TelemetryEvent, type TelemetryEventName, type EventProperties } from './events';
+
+export {
+  TelemetryEvent,
+  type TelemetryEventName,
+  type EventProperties,
+  type Outcome,
+  type ErrorCategory,
+  type ObserveSub,
+  type CountBucket,
+  type DurationBucket,
+  type SharedProperties,
+  type GraphProperties,
+  type ObserveProperties,
+  type ServeProperties,
+  type ErrorProperties,
+  SCHEMA_VERSION,
+  bucketCount,
+  bucketMs,
+  providerClass,
+  isCi,
+  buildSharedProperties,
+} from './events';
+
+export { maybeShowDoctorNotice } from './notice';
+
+export {
+  readMachineConfig,
+  writeMachineConfig,
+  getOrCreateInstallId,
+  machineConfigPath,
+  machineConfigDir,
+  type MachineConfig,
+} from './identity';
+
+export {
+  buildEventProperties,
+  buildGraphProperties,
+  tallyDispositions,
+  errorCategory,
+  type GraphPropertyInput,
+  type DispositionKind,
+} from './command';
+
+/**
+ * The fire-and-forget telemetry sink the commands hold. Both methods are
+ * total + non-throwing by contract: `event` enqueues without blocking and
+ * `flush` resolves even when the endpoint is slow/down (the client bounds itself
+ * and swallows all transport errors). A command may call either freely without
+ * guarding — a disabled run is the {@link NOOP_TELEMETRY}, where both are no-ops.
+ */
+export interface Telemetry {
+  /**
+   * Enqueue one `reactor.*` event with its content-free properties. Never
+   * blocks, never throws. The properties object is the full {@link EventProperties}
+   * (shared block + per-event extras) the caller assembled via `./events`.
+   */
+  event(name: TelemetryEventName, properties: EventProperties): void;
+  /**
+   * Drain the queue with a bounded best-effort POST. Resolves quickly even if
+   * the endpoint is unreachable (the client uses `AbortSignal.timeout`), so a
+   * caller may `await` it on the CLI exit path without risking a hang.
+   */
+  flush(): Promise<void>;
+}
+
+/**
+ * The disabled sink. Both methods do nothing; `flush` resolves immediately. This
+ * is what every opt-out path returns, so injecting it (the test default) makes
+ * telemetry a true zero-cost, zero-egress no-op.
+ */
+export const NOOP_TELEMETRY: Telemetry = Object.freeze({
+  event(_name: TelemetryEventName, _properties: EventProperties): void {
+    // intentionally nothing
+  },
+  flush(): Promise<void> {
+    return Promise.resolve();
+  },
+});
+
+/** Inputs to {@link initTelemetry} — the gate decision sources. */
+export interface InitTelemetryOptions {
+  /**
+   * The process env to consult (defaults to `process.env`). The gate reads
+   * `DO_NOT_TRACK`, `REACTOR_TELEMETRY`, `REACTOR_TELEMETRY_DISABLED`,
+   * `REACTOR_OFFLINE`, `CI`, and the endpoint override here.
+   */
+  readonly env?: NodeJS.ProcessEnv;
+  /**
+   * Whether stdout is a TTY (defaults to `process.stdout.isTTY === true`). A
+   * non-TTY stdout disables telemetry (don't track piped/automated runs).
+   */
+  readonly isTty?: boolean;
+  /**
+   * The project-level telemetry config parsed from `reactor.yml`
+   * (`telemetry.enabled` / `telemetry.endpoint`). Optional — absent means the
+   * project expresses no preference.
+   */
+  readonly projectTelemetry?: { readonly enabled?: boolean; readonly endpoint?: string };
+}
+
+/** The result of {@link initTelemetry}: the sink plus why it is enabled/disabled. */
+export interface InitTelemetryResult {
+  readonly telemetry: Telemetry;
+  readonly enabled: boolean;
+  /** A short reason when disabled (e.g. `"do_not_track"`, `"ci"`), for `--dump`. */
+  readonly reason?: string;
+}
+
+/**
+ * Build the telemetry sink. Consults the opt-out gate first; if telemetry is
+ * disabled by ANY condition it returns the {@link NOOP_TELEMETRY} (no install-id
+ * is created, no endpoint is resolved, no network is touched). Otherwise it
+ * resolves the endpoint, gets-or-creates the anonymous machine install id, and
+ * returns the real bounded `fetch` client. Never throws: any failure resolving
+ * identity/endpoint degrades to the no-op rather than perturbing the CLI.
+ */
+export async function initTelemetry(
+  options: InitTelemetryOptions = {},
+): Promise<InitTelemetryResult> {
+  const env = options.env ?? process.env;
+  const isTty = options.isTty ?? process.stdout.isTTY === true;
+
+  const gateInput: GateInput = {
+    env,
+    isTty,
+    ...(options.projectTelemetry !== undefined
+      ? { projectTelemetry: options.projectTelemetry }
+      : {}),
+  };
+
+  let decision: ReturnType<typeof isTelemetryEnabled>;
+  try {
+    decision = isTelemetryEnabled(gateInput);
+  } catch {
+    // A gate fault must never block the CLI — fail closed (disabled).
+    return { telemetry: NOOP_TELEMETRY, enabled: false, reason: 'gate_error' };
+  }
+
+  if (!decision.enabled) {
+    return {
+      telemetry: NOOP_TELEMETRY,
+      enabled: false,
+      ...(decision.reason !== undefined ? { reason: decision.reason } : {}),
+    };
+  }
+
+  try {
+    // The project-level `telemetry.endpoint` (when set) takes precedence over the
+    // env/published-default resolution `resolveEndpoint()` performs; either way an
+    // absolute URL is handed to the client.
+    const endpoint =
+      options.projectTelemetry?.endpoint ?? resolveEndpoint();
+    const installId = getOrCreateInstallId();
+    const telemetry = createHttpTelemetry({ endpoint, installId });
+    return { telemetry, enabled: true };
+  } catch {
+    // Identity/endpoint/client construction must never break the CLI.
+    return { telemetry: NOOP_TELEMETRY, enabled: false, reason: 'init_error' };
+  }
+}

--- a/packages/reactor-cli/src/telemetry/notice.test.ts
+++ b/packages/reactor-cli/src/telemetry/notice.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { maybeShowDoctorNotice } from './notice';
+import { readMachineConfig, machineConfigPath } from './identity';
+
+/**
+ * The notice tracks "shown once per machine" via `noticeShownVersion` in the
+ * machine config. We isolate each test through the REACTOR_CONFIG_DIR seam — the
+ * SAME seam `./identity` (and therefore `doctor`'s first-run detection, the gate,
+ * and `reactor telemetry`) honors. Exercising the seam (rather than mocking
+ * `os.homedir()` via HOME) is the point: it proves the notice stamp and the
+ * first-run read agree on one config file in redirected-config environments.
+ */
+describe('maybeShowDoctorNotice', () => {
+  let dir: string;
+  const prevConfigDir = process.env.REACTOR_CONFIG_DIR;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'reactor-notice-'));
+    process.env.REACTOR_CONFIG_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (prevConfigDir === undefined) delete process.env.REACTOR_CONFIG_DIR;
+    else process.env.REACTOR_CONFIG_DIR = prevConfigDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const collect = (): string[] => {
+    const lines: string[] = [];
+    maybeShowDoctorNotice((line) => lines.push(line));
+    return lines;
+  };
+
+  it('prints the disclosure on the first machine run', () => {
+    const lines = collect();
+    assert.ok(lines.length > 0, 'expected the notice to be written on first run');
+    const text = lines.join('\n');
+    // Respectful, anonymous, opt-out-first copy with the documented escape hatches.
+    assert.match(text, /anonymous/i);
+    assert.match(text, /DO_NOT_TRACK/);
+    assert.match(text, /reactor telemetry disable/);
+    assert.match(text, /TELEMETRY\.md/);
+  });
+
+  it('stamps noticeShownVersion into the SAME file readMachineConfig reads', () => {
+    collect();
+    // The stamp must land in the seam-resolved file — i.e. the exact file the
+    // identity leaf (and doctor's first-run check) reads. Asserting via
+    // readMachineConfig() proves they agree, which the HOME-mocked test never did.
+    const config = readMachineConfig();
+    assert.ok(config, 'expected a readable config at the seam path');
+    assert.equal(typeof config?.noticeShownVersion, 'string');
+    assert.ok((config?.noticeShownVersion ?? '').length > 0);
+    // And it must physically be the REACTOR_CONFIG_DIR file, not ~/.reactor.
+    assert.equal(machineConfigPath(), join(dir, 'config.json'));
+    const raw = readFileSync(join(dir, 'config.json'), 'utf8');
+    assert.match(raw, /noticeShownVersion/);
+  });
+
+  it('is suppressed on the second run (shown exactly once)', () => {
+    const first = collect();
+    assert.ok(first.length > 0);
+    const second = collect();
+    assert.deepEqual(second, [], 'expected no output on the second run');
+  });
+
+  it('preserves existing config keys when stamping (does not clobber installId)', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'config.json'),
+      JSON.stringify({ installId: 'fixed-id', telemetryEnabled: true }),
+      'utf8',
+    );
+    collect();
+    const config = readMachineConfig();
+    assert.equal(config?.installId, 'fixed-id');
+    assert.equal(config?.telemetryEnabled, true);
+    assert.equal(typeof config?.noticeShownVersion, 'string');
+  });
+
+  it('suppresses on a run when noticeShownVersion is already current/newer', () => {
+    mkdirSync(dir, { recursive: true });
+    // A far-future stamp must never re-trigger the notice.
+    writeFileSync(
+      join(dir, 'config.json'),
+      JSON.stringify({ installId: 'x', noticeShownVersion: '999.999.999' }),
+      'utf8',
+    );
+    assert.deepEqual(collect(), []);
+  });
+
+  it('never throws on a corrupt config file and shows the notice', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{ not valid json', 'utf8');
+    let lines: string[] = [];
+    assert.doesNotThrow(() => {
+      lines = collect();
+    });
+    assert.ok(lines.length > 0, 'a corrupt config is treated as not-yet-shown');
+  });
+});

--- a/packages/reactor-cli/src/telemetry/notice.ts
+++ b/packages/reactor-cli/src/telemetry/notice.ts
@@ -1,0 +1,140 @@
+/**
+ * First-run telemetry disclosure — surfaced ONLY inside `reactor doctor`.
+ *
+ * OFFLINE-SAFE / KEYLESS (N2): reachable from the telemetry barrel that the
+ * offline entrypoint loads, so this module MUST NOT static-import any
+ * model-bearing dependency (`@openai/agents`, `zod`) or any SDK barrel. It reads
+ * only `node:os` / `node:fs` / `node:path` and the keyless `../meta` helper.
+ *
+ * TRUST POSTURE (00-POLICY.md principle #2, 03-DECISIONS.md #3): the disclosure
+ * is short, prominent, and shown exactly ONCE per machine. It states what we
+ * collect, that it is anonymous, the permanent one-liner to turn it off, and a
+ * link to the published schema (`TELEMETRY.md`). It is printed to STDOUT via the
+ * command's `write` callback (NOT stderr, NOT a standalone banner at CLI entry).
+ *
+ * "Once per machine" is tracked by `noticeShownVersion` in the machine config
+ * (`~/.reactor/config.json`, schema `{ installId, telemetryEnabled?,
+ * noticeShownVersion }`). This leaf owns ONLY the `noticeShownVersion` field; it
+ * reads/merges the surrounding config object verbatim so it composes cleanly with
+ * the install-id / opt-out fields written by `./identity`.
+ *
+ * SINGLE SOURCE OF TRUTH: the config location is resolved EXCLUSIVELY through the
+ * `./identity` leaf (`readMachineConfig` / `writeMachineConfig`), which honors the
+ * `REACTOR_CONFIG_DIR` test seam. This is deliberate: `doctor`'s first-run
+ * detection reads `readMachineConfig()` and the notice stamps via this leaf, so
+ * both MUST point at the same file in every environment (tests, CI, redirected
+ * config). Re-deriving `~/.reactor` from `os.homedir()` here would diverge from
+ * the seam and desync the first-run flag from the once-per-machine stamp.
+ *
+ * FAIL-CLOSED: every filesystem touch is wrapped (in the identity leaf) — a read
+ * or write fault must never throw out of `doctor` and never block the CLI. A
+ * fault simply suppresses the notice (we never print twice, and we tolerate not
+ * printing at all).
+ */
+
+import { cliVersion } from '../meta';
+import { readMachineConfig, writeMachineConfig, type MachineConfig } from './identity';
+
+/**
+ * The disclosure copy. Respectful, anonymous, opt-out-first. Returned as an
+ * array of lines so the caller can route every line through its `write`
+ * callback (the command's stdout sink) without us assuming a newline policy.
+ */
+function noticeLines(): string[] {
+  return [
+    '',
+    'Reactor collects anonymous, content-free usage telemetry to help us',
+    'understand how the CLI is used (versions, OS/arch, command + outcome, and',
+    'coarse bucketed counts — never your prose, file paths, names, prompts, keys,',
+    'or model input/output). It is sent only by the CLI; the SDK stays silent.',
+    '',
+    'Turn it off any time — any one of these is permanent:',
+    '  • set DO_NOT_TRACK=1 in your environment, or',
+    '  • set REACTOR_TELEMETRY=0, or',
+    '  • run: reactor telemetry disable',
+    '',
+    'Exactly what is sent, and how to inspect it, is documented in TELEMETRY.md',
+    '(see `reactor telemetry --dump` to print precisely what would be sent).',
+    '',
+  ];
+}
+
+/**
+ * Show the first-run telemetry disclosure at most ONCE per machine.
+ *
+ * Idempotent: if `noticeShownVersion` is already stamped at (or above) the
+ * current CLI version the notice is suppressed and nothing is written. On the
+ * first eligible run it writes the disclosure through `write` (the doctor
+ * command's stdout sink) and stamps `noticeShownVersion` so subsequent runs stay
+ * silent.
+ *
+ * Never throws and never blocks: all filesystem access is fail-closed. This is
+ * the ONLY export of this leaf and the exact symbol `index.ts` re-exports.
+ *
+ * @param write - the command's stdout line sink (one line per call, no newline).
+ */
+export function maybeShowDoctorNotice(write: (line: string) => void): void {
+  const version = cliVersion();
+  // Read through the identity leaf so the `REACTOR_CONFIG_DIR` seam is honored —
+  // this is the SAME file `doctor`'s first-run check reads via `readMachineConfig`.
+  // `undefined` (absent / unreadable / corrupt) is treated as "not yet shown".
+  const config = readMachineConfig();
+
+  // Already shown for this (or a newer) version → suppress. We re-show only when
+  // the field is absent or stamped at an OLDER version, so a notable schema/
+  // copy change can re-disclose on upgrade while a same-version rerun stays mute.
+  if (
+    typeof config?.noticeShownVersion === 'string' &&
+    !isOlderVersion(config.noticeShownVersion, version)
+  ) {
+    return;
+  }
+
+  for (const line of noticeLines()) {
+    write(line);
+  }
+
+  // Preserve sibling-owned fields verbatim; author only `noticeShownVersion`. The
+  // identity leaf's `MachineConfig` requires a string `installId`, so default to
+  // `''` when no id exists yet (a later `getOrCreateInstallId()` mints the real
+  // one — a blank id here is treated as "no id yet" by that leaf).
+  const next: MachineConfig = {
+    installId: config?.installId ?? '',
+    ...(config?.telemetryEnabled !== undefined
+      ? { telemetryEnabled: config.telemetryEnabled }
+      : {}),
+    noticeShownVersion: version,
+  };
+  writeMachineConfig(next);
+}
+
+/**
+ * Coarse semver-ish "is `shown` older than `current`?" comparison. Compares the
+ * dot-separated numeric components left-to-right; any non-numeric/garbage
+ * component is treated as 0. A malformed stamp that does not parse as strictly
+ * older is treated as "not older" (i.e. suppress) so a bad value can never cause
+ * the notice to print on every run.
+ */
+function isOlderVersion(shown: string, current: string): boolean {
+  if (shown === current) return false;
+  const a = parseVersion(shown);
+  const b = parseVersion(current);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x < y) return true;
+    if (x > y) return false;
+  }
+  return false;
+}
+
+/** Split a version into its leading numeric components (non-numeric → 0). */
+function parseVersion(v: string): number[] {
+  return v
+    .split('.')
+    .map((part) => {
+      const n = Number.parseInt(part, 10);
+      return Number.isFinite(n) && n >= 0 ? n : 0;
+    });
+}


### PR DESCRIPTION
## What

Adds anonymous, content-free **product telemetry** to `@openprose/reactor-cli` so we can see how many people use Reactor and for what — without being invasive. On by default for interactive runs, off in CI, one line to turn off for good.

## Design

- **CLI-only.** The `@openprose/reactor` SDK stays silent — zero network egress on import. Telemetry lives entirely in `reactor-cli`. **Zero new runtime deps** (Node 20 global `fetch`).
- **Zero backend change.** Reuses the already-live `POST /analytics` Segment endpoint. The new event class is isolated by `context.library="@openprose/reactor-cli"` + `reactor.*` event names. All payload lives in `properties`; `context` carries only the whitelisted `library` key (the server validates `context` with `forbidNonWhitelisted`).
- **Content-free.** Anonymous per-machine install id, versions, os/arch, ci, command, outcome, and **bucketed** counts/durations only. Never paths, content, prompts, names, keys, or model I/O.
- **Opt-out gate** disables if any of: `DO_NOT_TRACK`, `REACTOR_TELEMETRY=0`/`REACTOR_TELEMETRY_DISABLED`, `REACTOR_OFFLINE=1`, `CI`/non-TTY, `reactor.yml` `telemetry.enabled:false`, or `~/.reactor/config.json` `telemetryEnabled:false`.
- **Bespoke fire-and-forget** `fetch` client (2s timeout, never blocks or throws).
- **First-run disclosure** surfaced once per machine inside `reactor doctor` (stdout).
- **New `reactor telemetry status|enable|disable|--dump`** — the published, inspectable opt-out + transparency surface (`--dump` is read-only and prints the exact payload that would be sent).

### Endpoints
- Prod (published default): `https://api.openprose.ai/analytics`
- Dev: `https://api.dev.openprose.ai/analytics`
- Override: `REACTOR_TELEMETRY_ENDPOINT`

## Testing

`REACTOR_OFFLINE=1 pnpm test` → **174 pass / 0 fail**, typecheck + prod build clean. Coverage includes: zero egress when disabled/offline/non-TTY and at import; a positive enabled-path egress test; the full gate truth table; per-command fire-points (injected fakes); install-id create/reuse/corrupt; once-only doctor notice.

## Distinguishing the event class (analyst query)
```sql
SELECT * FROM analytics_events
WHERE type='TRACK' AND event_name LIKE 'reactor.%'
  AND context->>'library'='@openprose/reactor-cli';
```

## Notes / follow-ups
- Docs (`TELEMETRY.md` in-package; a docs-site `telemetry.mdx` page) accompany this — the docs-site page lands via the docs repo.
- Deferred minor: `telemetry status`/`--dump` don't yet load a project-level `reactor.yml` `telemetry.endpoint`/`enabled` override, so their *reporting* can be inaccurate for a project that sets one (runtime enforcement is correct).

Plan + research: `planning/plans/2026-06-02-reactor-telemetry/`.