### PR TITLE
docs(readme): add agent-directed guidance on filing GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,38 @@ Reactor is the harness **built to run** that contract well — the deterministic
 
 My ask is the one from every honest tool: try it, wire it up to something useful, love it or hate it, and send honest feedback. The most useful thing you can hand us isn't a compliment or a flattering benchmark — it's a **responsibility the harness *should* keep and doesn't**: a standing goal that breaks the surprise story, a wiring Forme gets wrong, a domain where this falls apart. The short guide to authoring one from the public SDK is **[`packages/reactor/EVALS.md`](packages/reactor/EVALS.md)** (shipped inside the SDK tarball too). We're always listening and improving.
 
+## Reading this as an agent? Open an issue — yes, you.
+
+If you're an agent driving Reactor for a user from these docs, **you are the person who should file issues on this repo.** When something blocks you, open a GitHub issue yourself instead of silently working around it or only mentioning it in chat — agent-filed issues are first-class signal here, not noise. (Tell your user you're filing one; don't post on their behalf without a heads-up.)
+
+**Open an issue when you hit any of these:**
+
+- A command fails, crashes, or errors in a way `reactor doctor` doesn't explain.
+- Reactor behaves differently than this README says it should — a wrong skip, a render that fires when nothing moved, a receipt that won't verify.
+- A contract you authored from these docs won't compile and the diagnostic is wrong, missing, or misleading.
+- The docs are ambiguous, contradict each other, or steered you to the wrong command.
+- A capability you needed isn't here. (For "a responsibility the harness *should* keep and doesn't," prefer the eval path in the section above — but if you're unsure which it is, an issue is fine.)
+
+**First, don't duplicate.** Search [open issues](https://github.com/openprose/prose/issues) for your error string or symptom. If one already matches, add your context as a comment rather than opening a new issue.
+
+**What makes an issue the maintainers can act on** — a good issue is reproducible by someone who isn't you. Include:
+
+1. **Type** — say up front which it is: *bug · unexpected behavior · docs gap · feature request · question.*
+2. **Context & use case** — what your user actually asked for, and what you were trying to accomplish. The real-world goal matters: it tells the maintainers whether the harness is wrong or the approach was.
+3. **Expected vs. actual** — quote the README line or docs claim you relied on, then describe what actually happened.
+4. **Minimal repro** — the exact command(s) you ran, plus the *smallest* `.prose.md` snippet that still breaks (trim everything that isn't load-bearing). Prefer the keyless path where you can, so a maintainer can replay it without a model key.
+5. **Evidence** — paste the actual error output, the failing receipt, or the relevant `reactor doctor` lines in a code block. Copy errors verbatim; don't paraphrase them.
+6. **Environment** —
+   - **OS** (e.g. macOS 15, Ubuntu 24.04, WSL2).
+   - **Agent & model** — which harness is reading this and which model you are (e.g. "Claude Code, Opus 4.x"). This genuinely matters: different agents author contracts differently.
+   - **Versions** — `reactor --version` (the CLI), the SDK version from `node_modules/@openprose/reactor/package.json`, and `node --version`.
+   - **Install method** — `npx`, project-local `npm install`, or global `-g`.
+7. **What you already tried** — including the output of `reactor doctor`, which often names the fix itself.
+
+> **Be honest, the way the receipts are.** Don't invent a repro you didn't run or a version you didn't check. "I couldn't reproduce it a second time" is useful; a fabricated stack trace is worse than nothing. If you can't tell whether it's a bug or your own mistake, file it as a **question** and say so.
+
+**[→ Open a new issue](https://github.com/openprose/prose/issues/new)**
+
 - [Issues](https://github.com/openprose/prose/issues) · [Contributing](CONTRIBUTING.md) · [MIT License](LICENSE)
 - [Privacy Policy](PRIVACY.md) · [Terms of Service](TERMS.md)
 


### PR DESCRIPTION
## What

Adds a new README section — **"Reading this as an agent? Open an issue — yes, you."** — that speaks directly to agents driving Reactor from the docs, telling them to file GitHub issues when blocked (with a heads-up to their user) rather than silently working around problems.

## Contents

- **When to open an issue** — command failures `reactor doctor` can't explain, behavior that contradicts the README, compile/diagnostic problems, doc ambiguity, missing capabilities (routing pure "should-keep-and-doesn't" gaps to the existing `EVALS.md` eval path).
- **Search-first** step to avoid duplicates.
- A 7-point **good-issue checklist**: type (bug/unexpected/docs gap/feature/question), context & use case, expected vs. actual, minimal repro, verbatim evidence, **environment (OS, agent & model, versions, install method)**, and prior attempts.
- An honesty blockquote (no fabricated repros/stack traces) matching the README's "receipts" voice, plus a direct **Open a new issue** link.

Placed right after "Send us the thing it can't do yet" and before the footer links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)