### PR TITLE
feat(reactor): configurable LLM provider + accurate cost labels

### DIFF
--- a/packages/reactor-cli/package.json
+++ b/packages/reactor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/reactor-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openprose/prose.git",
@@ -22,9 +22,9 @@
     "examples"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "prepack": "pnpm build",
-    "build:test": "tsc -p tsconfig.test.json",
+    "build:test": "rm -rf dist-test && tsc -p tsconfig.test.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test:runtime": "pnpm build:test && node --test $(find dist-test -name '*.test.js' -type f | sort)",
     "test": "pnpm typecheck && pnpm test:runtime",

--- a/packages/reactor-cli/src/__tests__/provider-config.test.ts
+++ b/packages/reactor-cli/src/__tests__/provider-config.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadConfig } from '../config';
+import { runCompileCommand } from '../commands/compile';
+
+const SDK_ROOT = join(require.resolve('@openprose/reactor'), '..', '..');
+const FIXTURE_DIR = join(
+  SDK_ROOT,
+  'src/adapters/agent-compile/__fixtures__/smallest-project',
+);
+
+/** A hermetic key env that is never set in process.env or any ancestor `.env`. */
+const ABSENT_KEY_ENV = 'REACTOR_TEST_NONEXISTENT_KEY';
+
+function capture(): { write: (l: string) => void; lines: string[] } {
+  const lines: string[] = [];
+  return { write: (l) => lines.push(l), lines };
+}
+
+/** A fresh temp project seeded with the smallest-project contracts + a reactor.yml. */
+function scaffold(reactorYml: string): { projectDir: string; stateDir: string } {
+  const projectDir = mkdtempSync(join(tmpdir(), 'reactor-cli-provider-proj-'));
+  cpSync(FIXTURE_DIR, projectDir, { recursive: true });
+  writeFileSync(join(projectDir, 'reactor.yml'), reactorYml);
+  const stateDir = mkdtempSync(join(tmpdir(), 'reactor-cli-provider-state-'));
+  return { projectDir, stateDir };
+}
+
+describe('provider config parsing', () => {
+  it('reads model.base_url and model.api_key_env from reactor.yml', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'reactor-cli-provider-cfg-'));
+    try {
+      writeFileSync(
+        join(projectDir, 'reactor.yml'),
+        [
+          'model:',
+          '  provider: anthropic',
+          '  render_model: claude-haiku-4-5',
+          '  base_url: https://proxy.internal/v1',
+          '  api_key_env: MY_GATEWAY_KEY',
+        ].join('\n'),
+      );
+      const config = loadConfig({ projectDir });
+      assert.equal(config.model.provider, 'anthropic');
+      assert.equal(config.model.render_model, 'claude-haiku-4-5');
+      assert.equal(config.model.base_url, 'https://proxy.internal/v1');
+      assert.equal(config.model.api_key_env, 'MY_GATEWAY_KEY');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves base_url / api_key_env undefined by default (the OpenRouter path)', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'reactor-cli-provider-cfg-'));
+    try {
+      const config = loadConfig({ projectDir });
+      assert.equal(config.model.provider, 'openrouter');
+      assert.equal(config.model.base_url, undefined);
+      assert.equal(config.model.api_key_env, undefined);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('reactor compile — custom provider, missing key', () => {
+  it('exits NON-ZERO with the exact env var when a custom provider has no key (DEFECT B / stranded user)', async () => {
+    // Delete the hermetic key just in case a prior run leaked it into the env.
+    delete process.env[ABSENT_KEY_ENV];
+    const { projectDir, stateDir } = scaffold(
+      [
+        'model:',
+        '  provider: custom',
+        '  base_url: https://example.invalid/v1',
+        `  api_key_env: ${ABSENT_KEY_ENV}`,
+      ].join('\n'),
+    );
+    try {
+      const out = capture();
+      const code = await runCompileCommand(
+        { projectDir, stateDir, json: true },
+        out.write,
+      );
+      // A live-auth dead-end must FAIL the command (never a silent exit 0).
+      assert.equal(code, 1);
+      const report = JSON.parse(out.lines.join('\n')) as { message?: string };
+      // The message names the EXACT configured env var, not OpenRouter.
+      assert.match(String(report.message), new RegExp(ABSENT_KEY_ENV));
+      assert.match(String(report.message), /custom/);
+      assert.doesNotMatch(String(report.message), /OPENROUTER_API_KEY/);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unknown provider with no base_url / api_key_env (clean exit 1)', async () => {
+    const { projectDir, stateDir } = scaffold(['model:', '  provider: mystery'].join('\n'));
+    try {
+      const out = capture();
+      const code = await runCompileCommand(
+        { projectDir, stateDir, json: true },
+        out.write,
+      );
+      assert.equal(code, 1);
+      const report = JSON.parse(out.lines.join('\n')) as { message?: string };
+      assert.match(String(report.message), /unknown model\.provider 'mystery'/);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/reactor-cli/src/__tests__/provider-plan.test.ts
+++ b/packages/reactor-cli/src/__tests__/provider-plan.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  KNOWN_PROVIDER_NAMES,
+  missingProviderKeyHint,
+  resolveProviderPlan,
+} from '../model/provider-plan';
+
+describe('resolveProviderPlan', () => {
+  it('maps the default OpenRouter provider to its endpoint and marks it NON-custom', () => {
+    const plan = resolveProviderPlan({ provider: 'openrouter' });
+    assert.equal(plan.provider, 'openrouter');
+    assert.equal(plan.baseURL, 'https://openrouter.ai/api/v1');
+    assert.equal(plan.apiKeyEnv, 'OPENROUTER_API_KEY');
+    // Non-custom: the SDK builds its scoped provider lazily, unchanged.
+    assert.equal(plan.custom, false);
+  });
+
+  it('resolves each built-in provider to the right base URL + key env, all custom', () => {
+    const openai = resolveProviderPlan({ provider: 'openai' });
+    assert.equal(openai.baseURL, 'https://api.openai.com/v1');
+    assert.equal(openai.apiKeyEnv, 'OPENAI_API_KEY');
+    assert.equal(openai.custom, true);
+
+    const anthropic = resolveProviderPlan({ provider: 'anthropic' });
+    assert.equal(anthropic.baseURL, 'https://api.anthropic.com/v1/');
+    assert.equal(anthropic.apiKeyEnv, 'ANTHROPIC_API_KEY');
+    assert.equal(anthropic.custom, true);
+
+    const google = resolveProviderPlan({ provider: 'google' });
+    assert.equal(
+      google.baseURL,
+      'https://generativelanguage.googleapis.com/v1beta/openai/',
+    );
+    assert.equal(google.apiKeyEnv, 'GEMINI_API_KEY');
+    assert.equal(google.custom, true);
+  });
+
+  it('is case-insensitive and treats an empty provider as the OpenRouter default', () => {
+    assert.equal(resolveProviderPlan({ provider: 'OpenAI' }).provider, 'openai');
+    assert.equal(resolveProviderPlan({ provider: '' }).provider, 'openrouter');
+  });
+
+  it('lets base_url / api_key_env override a built-in, which flips it to custom', () => {
+    const plan = resolveProviderPlan({
+      provider: 'openrouter',
+      base_url: 'https://proxy.internal/v1',
+      api_key_env: 'MY_GATEWAY_KEY',
+    });
+    assert.equal(plan.baseURL, 'https://proxy.internal/v1');
+    assert.equal(plan.apiKeyEnv, 'MY_GATEWAY_KEY');
+    // An override on OpenRouter still means the CLI must build the provider itself.
+    assert.equal(plan.custom, true);
+  });
+
+  it('accepts an UNKNOWN provider when base_url AND api_key_env are both set', () => {
+    const plan = resolveProviderPlan({
+      provider: 'together',
+      base_url: 'https://api.together.xyz/v1',
+      api_key_env: 'TOGETHER_API_KEY',
+    });
+    assert.equal(plan.provider, 'together');
+    assert.equal(plan.baseURL, 'https://api.together.xyz/v1');
+    assert.equal(plan.apiKeyEnv, 'TOGETHER_API_KEY');
+    assert.equal(plan.custom, true);
+  });
+
+  it('throws a legible error for an unknown provider missing base_url / api_key_env', () => {
+    assert.throws(
+      () => resolveProviderPlan({ provider: 'mystery' }),
+      (err: Error) => {
+        assert.match(err.message, /unknown model\.provider 'mystery'/);
+        // It must name the way out: the built-ins AND the explicit override path.
+        assert.match(err.message, /base_url/);
+        assert.match(err.message, /api_key_env/);
+        for (const name of KNOWN_PROVIDER_NAMES) {
+          assert.match(err.message, new RegExp(name));
+        }
+        return true;
+      },
+    );
+  });
+});
+
+describe('missingProviderKeyHint', () => {
+  it('names the EXACT env var and points at reactor.yml (never misdirects to OpenRouter)', () => {
+    const plan = resolveProviderPlan({ provider: 'anthropic' });
+    const hint = missingProviderKeyHint(plan);
+    assert.match(hint, /ANTHROPIC_API_KEY/);
+    assert.match(hint, /anthropic/);
+    assert.match(hint, /reactor\.yml/);
+    // The OpenRouter env var must NOT appear in an Anthropic project's hint.
+    assert.doesNotMatch(hint, /OPENROUTER_API_KEY/);
+  });
+});

--- a/packages/reactor-cli/src/commands/compile.ts
+++ b/packages/reactor-cli/src/commands/compile.ts
@@ -31,6 +31,12 @@ import {
 } from '../compile/ir-cache';
 import type { ConfigOverrides } from '../config';
 import { loadConfig } from '../config';
+import { hasModelKey, readModelKey } from '../env';
+import {
+  missingProviderKeyHint,
+  resolveProviderPlan,
+  type ProviderPlan,
+} from '../model/provider-plan';
 import { resolveSdk } from '../meta';
 import {
   NOOP_TELEMETRY,
@@ -134,6 +140,22 @@ export async function runCompileCommand(
   const model = config.model.compile_model;
   const sdkVersion = resolveSdk().version ?? 'unknown';
 
+  // Resolve the provider plan (keyless). A malformed provider config is a clean
+  // exit-1 here, not a stack trace inside the model surface later.
+  let providerPlan: ProviderPlan;
+  try {
+    providerPlan = resolveProviderPlan(config.model);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (options.json === true) {
+      write(JSON.stringify({ status: 'error', message: msg }));
+    } else {
+      write(msg);
+    }
+    fireError(err);
+    return 1;
+  }
+
   // Load contracts (deterministic) + compute the cache key's contract-set fp.
   // Uses the keyless contract loader (N2 — a cache hit / --check must NOT import
   // the model-bearing barrel).
@@ -175,6 +197,25 @@ export async function runCompileCommand(
     return 0;
   }
 
+  // Live miss with a CUSTOM provider: the configured key must be present NOW.
+  // Fail clean + NON-ZERO with the exact env var (a missing live key must never
+  // exit 0 and silently pass CI). The default OpenRouter path is left to the SDK's
+  // own key resolution + the 401 hint below.
+  if (
+    providerPlan.custom &&
+    options.offline !== true &&
+    !hasModelKey(providerPlan.apiKeyEnv, contractsDir)
+  ) {
+    const msg = missingProviderKeyHint(providerPlan);
+    if (options.json === true) {
+      write(JSON.stringify({ status: 'error', message: msg }));
+    } else {
+      write(`reactor compile failed: ${msg}`);
+    }
+    fireError(new Error(msg));
+    return 1;
+  }
+
   // Cache miss / --force: run the compile sessions (model surface, dynamic import).
   const { runCompile } = await import('../compile/run-compile');
   let result: Awaited<ReturnType<typeof runCompile>>;
@@ -187,13 +228,16 @@ export async function runCompileCommand(
       maxTurns: config.model.max_turns,
       ...(options.testProviders !== undefined ? { providers: options.testProviders } : {}),
       ...(options.testSkill !== undefined ? { skill: options.testSkill } : {}),
+      ...(providerPlan.custom
+        ? { providerPlan, apiKey: readModelKey(providerPlan.apiKeyEnv, contractsDir)! }
+        : {}),
     });
   } catch (err) {
     // A live-provider failure (auth/billing/rate-limit) must NOT exit 0 with a raw
     // stack — map it to a one-line actionable message and exit non-zero so a CI
     // `compile` step fails loudly. Anything else propagates to the top-level
     // handler (which prints it and exits 1).
-    const hint = providerErrorHint(err);
+    const hint = providerErrorHint(err, providerPlan);
     if (hint === undefined) {
       fireError(err);
       throw err;
@@ -246,7 +290,10 @@ export async function runCompileCommand(
  * error propagates normally (and the top-level handler prints + exits 1). Keeps
  * the keyless escape hatch in view (the devtools replay needs no key).
  */
-function providerErrorHint(err: unknown): string | undefined {
+function providerErrorHint(
+  err: unknown,
+  plan: ProviderPlan,
+): string | undefined {
   const e = err as { status?: number; message?: string } | undefined;
   const text = String(e?.message ?? err ?? '');
   const status = typeof e?.status === 'number' ? e.status : undefined;
@@ -254,19 +301,19 @@ function providerErrorHint(err: unknown): string | undefined {
     status === code || words.some((w) => text.includes(w));
   if (matches(402, '402', 'Insufficient credits', 'insufficient_quota')) {
     return (
-      'the model provider returned 402 — out of credits/quota. Top up your ' +
-      'OpenRouter account, or use the keyless `reactor-devtools` replay (no key ' +
-      'needed). Confirm the exact error with `reactor doctor --live`.'
+      `the ${plan.provider} provider returned 402 — out of credits/quota. Top up ` +
+      `the account behind ${plan.apiKeyEnv}, or use the keyless \`reactor-devtools\` ` +
+      'replay (no key needed). Confirm the exact error with `reactor doctor --live`.'
     );
   }
   if (matches(401, '401', 'Unauthorized', 'invalid api key', 'No auth credentials')) {
     return (
-      'the model provider returned 401 — bad or missing key. Check ' +
-      'OPENROUTER_API_KEY (`reactor doctor` reports its presence without printing it).'
+      `the ${plan.provider} provider returned 401 — bad or missing key. Check ` +
+      `${plan.apiKeyEnv} (\`reactor doctor\` reports its presence without printing it).`
     );
   }
   if (matches(429, '429', 'rate limit', 'Too Many Requests')) {
-    return 'the model provider returned 429 — rate limited. Retry shortly, or lower --concurrency.';
+    return `the ${plan.provider} provider returned 429 — rate limited. Retry shortly, or lower --concurrency.`;
   }
   return undefined;
 }

--- a/packages/reactor-cli/src/commands/doctor.ts
+++ b/packages/reactor-cli/src/commands/doctor.ts
@@ -19,9 +19,13 @@
  *       `--live`, the live smoke failed (no key / missing deps / render error).
  */
 
-import { hasOpenRouterKey, isOfflineForced } from '../env';
+import { hasModelKey, readModelKey, isOfflineForced } from '../env';
 import { checkLiveDeps, resolveSdk } from '../meta';
 import { loadConfig, type ConfigOverrides, type SandboxMode } from '../config';
+import {
+  resolveProviderPlan,
+  type ProviderPlan,
+} from '../model/provider-plan';
 import {
   contractSetFingerprint,
   isCacheFresh,
@@ -52,9 +56,20 @@ export interface LiveSmokeResult {
   readonly detail: string;
 }
 
+/** Inputs to {@link runLiveSmoke}: the configured provider + render model. */
+export interface LiveSmokeOptions {
+  /** The resolved provider plan; defaults to the OpenRouter wiring. */
+  readonly plan?: ProviderPlan;
+  /** The render model id to smoke; defaults to the OpenRouter gemini default. */
+  readonly renderModel?: string;
+}
+
 export interface DoctorReport {
   node: { version: string; major: number; ok: boolean };
   sdk: { resolved: boolean; version?: string };
+  /** The configured provider label + the env var its key is read from. */
+  provider: string;
+  apiKeyEnv: string;
   liveKeyPresent: boolean;
   liveDeps: { name: string; present: boolean }[];
   offlineForced: boolean;
@@ -204,7 +219,22 @@ export async function collectDoctorReport(
   const healthyForOffline = major >= MIN_NODE_MAJOR && sdk.resolved;
 
   const skill = probeSkillBundle();
-  const liveKeyPresent = hasOpenRouterKey();
+  // Resolve the configured provider so the key check + report name the RIGHT env
+  // var (an Anthropic user must not be told to set OPENROUTER_API_KEY). A malformed
+  // provider config falls back to OpenRouter for the presence check but is surfaced
+  // in the live line via `resolveProviderPlan` throwing at compile/run time.
+  let providerPlan: ProviderPlan;
+  try {
+    providerPlan = resolveProviderPlan(config.model);
+  } catch {
+    providerPlan = {
+      provider: config.model.provider || 'openrouter',
+      baseURL: '',
+      apiKeyEnv: 'OPENROUTER_API_KEY',
+      custom: false,
+    };
+  }
+  const liveKeyPresent = hasModelKey(providerPlan.apiKeyEnv);
   // Cleared to spend a key: everything a live `compile`/`run` render needs.
   const healthyForLive =
     healthyForOffline &&
@@ -216,6 +246,8 @@ export async function collectDoctorReport(
   const report: DoctorReport = {
     node: { version, major, ok: major >= MIN_NODE_MAJOR },
     sdk: { resolved: sdk.resolved, version: sdk.version },
+    provider: providerPlan.provider,
+    apiKeyEnv: providerPlan.apiKeyEnv,
     liveKeyPresent,
     liveDeps,
     offlineForced: isOfflineForced(),
@@ -228,7 +260,10 @@ export async function collectDoctorReport(
   };
 
   if (options.live === true) {
-    const live = await runLiveSmoke();
+    const live = await runLiveSmoke({
+      plan: providerPlan,
+      renderModel: config.model.render_model,
+    });
     report.live = live;
     // Offline health is INDEPENDENT of the live smoke — the keyless surface works
     // regardless of a live-only failure (e.g. a 402 out-of-credits), so a failed
@@ -285,13 +320,35 @@ const AGENT_RENDER_SPECIFIER = '@openprose/reactor/agents';
  * them. Returns a structured outcome; it NEVER throws (a missing key / dep / render
  * error is reported as `ok:false`, not an exception).
  */
-export async function runLiveSmoke(): Promise<LiveSmokeResult> {
-  // No key → the smoke cannot run; report honestly without importing anything.
-  if (!hasOpenRouterKey()) {
+export async function runLiveSmoke(
+  config: LiveSmokeOptions = {},
+): Promise<LiveSmokeResult> {
+  // The configured provider (default OpenRouter). Names the right key env so the
+  // smoke checks ANTHROPIC_API_KEY for an Anthropic project, not OpenRouter's.
+  const plan: ProviderPlan =
+    config.plan ?? {
+      provider: 'openrouter',
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKeyEnv: 'OPENROUTER_API_KEY',
+      custom: false,
+    };
+  // Forced offline → never reach for a key or the network. This keeps the offline
+  // gate hermetic now that we pass an explicit `apiKey` into `smokeRun` (which
+  // bypasses the SDK's own offline check). Message mentions "key" for honesty.
+  if (isOfflineForced()) {
     return {
       ran: false,
       ok: false,
-      detail: 'no OPENROUTER_API_KEY present — set a live key to run the smoke',
+      detail: 'REACTOR_OFFLINE is set — skipping the live key smoke',
+    };
+  }
+  const apiKey = readModelKey(plan.apiKeyEnv);
+  // No key → the smoke cannot run; report honestly without importing anything.
+  if (apiKey === undefined) {
+    return {
+      ran: false,
+      ok: false,
+      detail: `no ${plan.apiKeyEnv} present — set a live key to run the smoke`,
     };
   }
   try {
@@ -300,11 +357,12 @@ export async function runLiveSmoke(): Promise<LiveSmokeResult> {
     // specifier is a variable so TS does not statically resolve the deep subpath
     // (it is only resolvable at runtime against the SDK's exports map).
     const provider = (await import(AGENT_RENDER_SPECIFIER)) as {
-      hasOpenRouterKey?: () => boolean;
       assertSkillBundleInstalled?: () => void;
       smokeRun?: (config?: {
+        readonly apiKey?: string;
+        readonly baseURL?: string;
+        readonly model?: string;
         readonly input?: string;
-        readonly maxTurns?: number;
       }) => Promise<{
         readonly text: string;
         readonly totalTokens: number;
@@ -314,17 +372,11 @@ export async function runLiveSmoke(): Promise<LiveSmokeResult> {
     if (typeof provider.assertSkillBundleInstalled === 'function') {
       provider.assertSkillBundleInstalled();
     }
-    if (typeof provider.hasOpenRouterKey === 'function' && !provider.hasOpenRouterKey()) {
-      return {
-        ran: true,
-        ok: false,
-        detail: 'the live provider reports no usable key',
-      };
-    }
-    // Drive ONE real bounded render against the live gateway (cli.md §3: `--live`
-    // proves provider reachability via a single live render, not just a key/bundle
-    // presence check). `smokeRun` performs a real network call; we reached it only
-    // after `hasOpenRouterKey` gated above, so it is safe to invoke here.
+    // Drive ONE real bounded render against the CONFIGURED endpoint (cli.md §3:
+    // `--live` proves provider reachability via a single live render). We pass the
+    // resolved `apiKey` + `baseURL` + `model` so `smokeRun` builds a scoped provider
+    // for whatever vendor `reactor.yml` selected — not just OpenRouter. The key was
+    // confirmed present above, so this is safe to invoke.
     if (typeof provider.smokeRun !== 'function') {
       return {
         ran: true,
@@ -332,7 +384,11 @@ export async function runLiveSmoke(): Promise<LiveSmokeResult> {
         detail: 'live render smoke unavailable (smokeRun not exported by the render barrel)',
       };
     }
-    const smoke = await provider.smokeRun();
+    const smoke = await provider.smokeRun({
+      apiKey,
+      ...(plan.baseURL.length > 0 ? { baseURL: plan.baseURL } : {}),
+      model: config.renderModel ?? 'google/gemini-3.5-flash',
+    });
     if (typeof smoke.text !== 'string' || smoke.totalTokens <= 0) {
       return {
         ran: true,
@@ -378,7 +434,7 @@ export function formatDoctorReport(report: DoctorReport): string {
     `  offline mode   ${report.offlineForced ? 'forced (REACTOR_OFFLINE)' : 'not forced'}`,
   );
   lines.push(
-    `  live key       ${report.liveKeyPresent ? 'present (OPENROUTER_API_KEY)' : 'absent'}`,
+    `  live key       ${report.liveKeyPresent ? `present (${report.apiKeyEnv})` : `absent (${report.apiKeyEnv})`}`,
   );
   for (const dep of report.liveDeps) {
     lines.push(`  live dep       ${dep.name}: ${mark(dep.present)}`);

--- a/packages/reactor-cli/src/commands/init.ts
+++ b/packages/reactor-cli/src/commands/init.ts
@@ -132,11 +132,17 @@ state:
   dir: ./.reactor
 
 model:
+  # Provider: openrouter (default) | openai | anthropic | google | <custom>.
+  # A built-in supplies its own endpoint + key env (OPENROUTER_API_KEY,
+  # OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY). To use another vendor,
+  # set base_url + api_key_env. See docs: /cli/configuration#choosing-a-model-provider
   provider: openrouter
   render_model: google/gemini-3.5-flash
   compile_model: google/gemini-3.5-flash
   temperature: 0
   max_turns: 200
+  # base_url: https://api.anthropic.com/v1/   # e.g. to use Anthropic directly
+  # api_key_env: ANTHROPIC_API_KEY
 
 sandbox:
   # Threat-model knob for renders. 'none' (the default) runs renders in the

--- a/packages/reactor-cli/src/commands/run.ts
+++ b/packages/reactor-cli/src/commands/run.ts
@@ -29,6 +29,11 @@ import { buildDurableSubstrate } from '../run/substrate';
 import { buildSandboxRunner } from '../run/sandbox';
 import type { ConfigOverrides } from '../config';
 import { loadConfig, validateStateDirTarget } from '../config';
+import { hasModelKey, readModelKey } from '../env';
+import {
+  missingProviderKeyHint,
+  resolveProviderPlan,
+} from '../model/provider-plan';
 import type { CompileCommandOptions } from './compile';
 import { emitError } from './emit';
 import {
@@ -113,6 +118,22 @@ export async function runRunCommand(
   const contractsDir = path.resolve(options.projectDir ?? '.');
   const model = config.model.compile_model;
 
+  // Resolve the provider plan (keyless). A malformed provider config is a clean
+  // exit-1, not a stack later. The plan also tells us whether the live render
+  // needs a CLI-built provider (custom) or the SDK default (OpenRouter).
+  let providerPlan;
+  try {
+    providerPlan = resolveProviderPlan(config.model);
+  } catch (err) {
+    fireError(err);
+    fireRun('failure');
+    return emitError(
+      write,
+      options.json,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
   // Validate the state-dir target before anything tries to mkdir it (G12) — a
   // file at the state-dir path otherwise surfaces a raw EEXIST with no guidance.
   const stateDirError = validateStateDirTarget(stateDir);
@@ -187,12 +208,36 @@ export async function runRunCommand(
     shellTimeoutMs: config.sandbox.shell_timeout_ms,
   });
 
+  // A LIVE custom-provider render needs its key NOW (the compile-if-stale step
+  // already checked it on a miss, but a warm cache jumps straight to the render).
+  // Fail clean + NON-ZERO with the exact env var. Skipped for the offline gate
+  // (a test render owns the body) and the default OpenRouter path.
+  const liveCustomRender =
+    providerPlan.custom &&
+    options.testRender === undefined &&
+    options.offline !== true;
+  if (liveCustomRender && !hasModelKey(providerPlan.apiKeyEnv, contractsDir)) {
+    fireError(new Error('missing provider key'));
+    fireRun('failure');
+    return emitError(write, options.json, missingProviderKeyHint(providerPlan));
+  }
+
   // 4. Run the dumb run phase (the SDK self-mounts + bootAsync). Drain to
   //    quiescence is bootAsync's cold-miss sweep + the propagation it cascades.
   const { reactor, bootResults } = await callRunProject({
     compiled: loaded.compiled,
     adapters,
     render: renderWithDefaults,
+    // Always honor the configured render model (so a non-default model id actually
+    // reaches the run-phase render, not just the SDK's gemini default).
+    renderModel: config.model.render_model,
+    ...(liveCustomRender
+      ? {
+          providerPlan,
+          apiKey: readModelKey(providerPlan.apiKeyEnv, contractsDir)!,
+          providerLabel: providerPlan.provider,
+        }
+      : {}),
   });
 
   // 5. Project the boot results + the ledger receipts into the run report.

--- a/packages/reactor-cli/src/commands/serve.ts
+++ b/packages/reactor-cli/src/commands/serve.ts
@@ -65,6 +65,12 @@ import { isCacheFresh, contractSetFingerprint } from '../compile/ir-cache';
 import { loadContractSet as keylessLoadContractSet } from '../compile/contract-images';
 import type { ConfigOverrides, GatewayConfig, SandboxConfig } from '../config';
 import { loadConfig, validateStateDirTarget } from '../config';
+import { hasModelKey, readModelKey } from '../env';
+import {
+  missingProviderKeyHint,
+  resolveProviderPlan,
+  type ProviderPlan,
+} from '../model/provider-plan';
 import { resolveSdk } from '../meta';
 import { runCompileCommand, type CompileCommandOptions } from './compile';
 import {
@@ -140,6 +146,21 @@ export interface BootReactorInput {
   readonly offline?: boolean;
   /** A model override applied to compile-if-stale. */
   readonly modelOverride?: string;
+  /**
+   * The keyless provider plan for a CUSTOM (non-default) provider, resolved by the
+   * caller from the top-level `model:` config. When present (with {@link apiKey}),
+   * the live render points at the configured endpoint. Omitted on the default
+   * OpenRouter path and the offline gate.
+   */
+  readonly providerPlan?: ProviderPlan;
+  /** The resolved API key for {@link providerPlan}. Required when it is set. */
+  readonly apiKey?: string;
+  /**
+   * The configured render model id (`model.render_model`). Threaded into the
+   * render so the run phase uses it rather than the SDK's gemini default —
+   * required for a custom provider whose endpoint 404s on the default id.
+   */
+  readonly renderModel?: string;
   /**
    * The reactor's `[sandbox]` config. Drives the workspace-scoped render sandbox
    * runner + the per-command shell timeout. Omitted → the `mode: none` default (no
@@ -310,11 +331,34 @@ export async function bootReactorHandle(
       : {}),
   };
 
+  // A LIVE custom-provider render needs its key NOW (the compile-if-stale step
+  // checked it on a miss; a warm cache jumps straight to the render). Fail clean +
+  // NON-ZERO. Skipped for the offline gate (test render) and the OpenRouter default.
+  const liveCustomRender =
+    input.providerPlan?.custom === true &&
+    input.testRender === undefined &&
+    input.offline !== true;
+  if (
+    liveCustomRender &&
+    input.apiKey === undefined &&
+    !hasModelKey(input.providerPlan!.apiKeyEnv, input.contractsDir)
+  ) {
+    throw new Error(missingProviderKeyHint(input.providerPlan!));
+  }
+
   // 4. CONFIGURE + boot runProject (the SDK self-mounts + runs the boot sweep).
   const { reactor } = await callRunProject({
     compiled: compiledForRun,
     adapters,
     render,
+    ...(input.renderModel !== undefined ? { renderModel: input.renderModel } : {}),
+    ...(liveCustomRender && input.providerPlan !== undefined && input.apiKey !== undefined
+      ? {
+          providerPlan: input.providerPlan,
+          apiKey: input.apiKey,
+          providerLabel: input.providerPlan.provider,
+        }
+      : {}),
   });
 
   // 5. The PER-REACTOR serialization queue + the continuity scheduler.
@@ -457,13 +501,23 @@ export async function bootServe(
     model: options.model,
   });
 
+  const projectDir = path.resolve(options.projectDir ?? '.');
+  const providerPlan = resolveProviderPlan(config.model);
+  const apiKey =
+    providerPlan.custom && options.offline !== true
+      ? readModelKey(providerPlan.apiKeyEnv, projectDir)
+      : undefined;
+
   return bootReactorHandle({
     name: 'default',
-    contractsDir: path.resolve(options.projectDir ?? '.'),
+    contractsDir: projectDir,
     stateDir: config.state.dir,
     model: config.model.compile_model,
+    renderModel: config.model.render_model,
     sandbox: config.sandbox,
     gateways: config.gateways,
+    ...(providerPlan.custom ? { providerPlan } : {}),
+    ...(apiKey !== undefined ? { apiKey } : {}),
     ...(options.offline !== undefined ? { offline: options.offline } : {}),
     ...(options.model !== undefined ? { modelOverride: options.model } : {}),
     ...(options.testGatewayFetch !== undefined

--- a/packages/reactor-cli/src/compile/run-compile.ts
+++ b/packages/reactor-cli/src/compile/run-compile.ts
@@ -72,6 +72,17 @@ export interface CompileRunOptions {
   readonly providers?: CompileStepProviders;
   /** Pre-read SKILL system prompt (offline tests pass a stub). */
   readonly skill?: string;
+  /**
+   * The keyless provider plan for a CUSTOM (non-default) provider. When present
+   * (with {@link apiKey}), the runner builds a scoped live `ModelProvider` and
+   * makes it the default for every compile session — so a configured
+   * OpenAI/Anthropic/Google/custom endpoint actually drives the compile. Omitted
+   * for the default OpenRouter path (the SDK builds its scoped provider lazily) and
+   * for the offline gate (which injects per-step fakes via {@link providers}).
+   */
+  readonly providerPlan?: import('../model/provider-plan').ProviderPlan;
+  /** The resolved API key for {@link providerPlan}. Required when it is set. */
+  readonly apiKey?: string;
 }
 
 /** Per-step provider seam for the offline gate (each step's schema differs). */
@@ -115,6 +126,19 @@ export async function runCompile(options: CompileRunOptions): Promise<CompileRun
 
   const stepCosts: StepCost[] = [];
   const sessionBase = sessionOptions(options);
+
+  // CUSTOM provider: build a scoped live `ModelProvider` ONCE and make it the
+  // default for every compile session, so a configured non-OpenRouter endpoint
+  // (OpenAI/Anthropic/Google/custom) actually drives the compile. The per-step
+  // fake provider (offline gate) still overrides it; the default OpenRouter path
+  // leaves `providerPlan` unset and the SDK builds its scoped provider lazily.
+  if (options.providerPlan !== undefined && options.apiKey !== undefined) {
+    const { buildLiveProvider } = await import('../model/live-provider');
+    sessionBase['provider'] = buildLiveProvider(options.providerPlan, options.apiKey);
+    // Stamp the configured provider label on the compile cost (label-only). The
+    // model label is already `options.model` (the compile_model) via sessionOptions.
+    sessionBase['providerLabel'] = options.providerPlan.provider;
+  }
 
   // 1. FORME — the topology session.
   const formeProvider = options.providers?.forme;

--- a/packages/reactor-cli/src/config.ts
+++ b/packages/reactor-cli/src/config.ts
@@ -24,6 +24,18 @@ export interface ModelConfig {
   readonly compile_model: string;
   readonly temperature: number;
   readonly max_turns: number;
+  /**
+   * Override the provider's OpenAI-compatible base URL. Optional: a built-in
+   * provider (openrouter/openai/anthropic/google) supplies its own. Set this (with
+   * {@link api_key_env}) to point at any other OpenAI-compatible endpoint.
+   */
+  readonly base_url?: string;
+  /**
+   * The env var holding this provider's API key (e.g. `ANTHROPIC_API_KEY`).
+   * Optional: a built-in provider supplies its own default. Set it to read the key
+   * from a non-default variable, or alongside {@link base_url} for a custom vendor.
+   */
+  readonly api_key_env?: string;
 }
 
 export interface SandboxConfig {
@@ -333,6 +345,9 @@ function shapeRawConfig(tree: unknown): Partial<RawConfig> {
       out.model.render_model = model['render_model'];
     if (typeof model['compile_model'] === 'string')
       out.model.compile_model = model['compile_model'];
+    if (typeof model['base_url'] === 'string') out.model.base_url = model['base_url'];
+    if (typeof model['api_key_env'] === 'string')
+      out.model.api_key_env = model['api_key_env'];
     const temp = toNumber(model['temperature']);
     if (temp !== undefined) out.model.temperature = temp;
     const turns = toNumber(model['max_turns']);
@@ -408,6 +423,10 @@ function mergeConfig(base: ReactorConfig, over: Partial<RawConfig>): ReactorConf
     compile_model: over.model?.compile_model ?? base.model.compile_model,
     temperature: over.model?.temperature ?? base.model.temperature,
     max_turns: over.model?.max_turns ?? base.model.max_turns,
+    ...(over.model?.base_url !== undefined ? { base_url: over.model.base_url } : {}),
+    ...(over.model?.api_key_env !== undefined
+      ? { api_key_env: over.model.api_key_env }
+      : {}),
   };
   return {
     state: { dir: over.state?.dir ?? base.state.dir },

--- a/packages/reactor-cli/src/env.ts
+++ b/packages/reactor-cli/src/env.ts
@@ -21,18 +21,46 @@ export function isOfflineForced(): boolean {
 }
 
 /**
+ * Read a named model API key: `process.env[apiKeyEnv]` first, then a `.env`
+ * discovered by walking up from `cwd`. Returns the value (trimmed) or undefined.
+ * Keyless: reads env + plain files only, so a command handler can resolve any
+ * configured provider's key (e.g. `ANTHROPIC_API_KEY`) without touching the model
+ * deps. Does NOT rely on the SDK's dev-only hardcoded `DEFAULT_ENV_PATH`.
+ */
+export function readModelKey(
+  apiKeyEnv: string,
+  cwd: string = process.cwd(),
+): string | undefined {
+  const fromProcess = process.env[apiKeyEnv];
+  if (readEnvKey(fromProcess)) {
+    return fromProcess!.trim();
+  }
+  const fromDotEnv = readDotEnvKey(apiKeyEnv, cwd);
+  return readEnvKey(fromDotEnv) ? fromDotEnv : undefined;
+}
+
+/**
+ * True when a live key for `apiKeyEnv` is present in the process env or a
+ * discoverable `.env`. The general form of {@link hasOpenRouterKey}, so a command
+ * can gate the live path on whatever provider `reactor.yml` configured.
+ */
+export function hasModelKey(
+  apiKeyEnv: string,
+  cwd: string = process.cwd(),
+): boolean {
+  return readModelKey(apiKeyEnv, cwd) !== undefined;
+}
+
+/**
  * True when a live OpenRouter API key is present in the process env, or in a
  * `.env` file discoverable from the current working directory upward.
  *
  * Mirrors `cli.md`: read `OPENROUTER_API_KEY` from env first, then a `.env`
- * fallback. Does NOT rely on the SDK's dev-only hardcoded `DEFAULT_ENV_PATH`.
+ * fallback. Kept as the default-provider convenience; the general check is
+ * {@link hasModelKey}.
  */
 export function hasOpenRouterKey(cwd: string = process.cwd()): boolean {
-  if (readEnvKey(process.env.OPENROUTER_API_KEY)) {
-    return true;
-  }
-  const fromDotEnv = readDotEnvKey('OPENROUTER_API_KEY', cwd);
-  return readEnvKey(fromDotEnv);
+  return hasModelKey('OPENROUTER_API_KEY', cwd);
 }
 
 function readEnvKey(value: string | undefined): boolean {

--- a/packages/reactor-cli/src/model/live-provider.ts
+++ b/packages/reactor-cli/src/model/live-provider.ts
@@ -1,0 +1,33 @@
+/**
+ * The MODEL-BEARING live-provider factory — build a scoped `@openai/agents`
+ * `ModelProvider` from a keyless {@link ProviderPlan}.
+ *
+ * N2 OFFLINE BOUNDARY: this module static-imports `@openai/agents`. It is reached
+ * ONLY from modules that are themselves behind the dynamic-import boundary
+ * (`run-compile.ts`, `load-run-project.ts`), never from the offline command
+ * entrypoints. The handlers compute the keyless {@link ProviderPlan} and read the
+ * key (both offline-safe), then cross the boundary and call this to mint the
+ * provider.
+ */
+
+import { OpenAIProvider, type ModelProvider } from '@openai/agents';
+
+import type { ProviderPlan } from './provider-plan';
+
+/**
+ * Build a SCOPED `OpenAIProvider` for the plan + key. `useResponses: false`
+ * selects Chat Completions — the surface every built-in vendor (OpenRouter,
+ * OpenAI, Anthropic, Google) implements; the Responses API is OpenAI-only and
+ * 404s elsewhere. Scoped (never `setDefaultOpenAIClient`), so two reactors in one
+ * process can target two different vendors, mirroring the SDK's own discipline.
+ */
+export function buildLiveProvider(
+  plan: ProviderPlan,
+  apiKey: string,
+): ModelProvider {
+  return new OpenAIProvider({
+    apiKey,
+    baseURL: plan.baseURL,
+    useResponses: false,
+  });
+}

--- a/packages/reactor-cli/src/model/provider-plan.ts
+++ b/packages/reactor-cli/src/model/provider-plan.ts
@@ -1,0 +1,122 @@
+/**
+ * The keyless provider PLAN — how `reactor.yml`'s `model:` block maps to a live
+ * OpenAI-compatible endpoint, WITHOUT touching `@openai/agents`.
+ *
+ * OFFLINE-SAFE (N2): this module is pure data + string logic. It is imported from
+ * the offline command handlers (`compile`/`run`/`serve`) at load scope, so it MUST
+ * NOT static-import any model-bearing dependency. The actual `ModelProvider` is
+ * built from this plan behind the dynamic-import boundary (see `live-provider.ts`).
+ *
+ * The plan answers two questions the handlers need keylessly:
+ *   1. WHICH endpoint + key env does the configured provider resolve to?
+ *   2. Is this the DEFAULT OpenRouter path (let the SDK build it lazily, unchanged)
+ *      or a CUSTOM path the CLI must build + inject itself?
+ */
+
+/** A resolved provider plan: the endpoint + key env + whether the CLI builds it. */
+export interface ProviderPlan {
+  /** The normalized provider label (e.g. `openrouter`, `anthropic`, `custom`). */
+  readonly provider: string;
+  /** The OpenAI-compatible base URL the live provider points at. */
+  readonly baseURL: string;
+  /** The env var (and `.env` key) carrying this provider's API key. */
+  readonly apiKeyEnv: string;
+  /**
+   * True when the CLI must construct + inject the provider itself (any non-default
+   * provider, or an explicit `base_url`/`api_key_env` override). False is the
+   * untouched default: OpenRouter with no overrides, where the SDK builds the
+   * scoped provider lazily from `OPENROUTER_API_KEY` exactly as before.
+   */
+  readonly custom: boolean;
+}
+
+/** The `model:` fields this resolver reads (a structural subset of ModelConfig). */
+export interface ProviderPlanInput {
+  readonly provider: string;
+  readonly base_url?: string;
+  readonly api_key_env?: string;
+}
+
+interface KnownProvider {
+  readonly baseURL: string;
+  readonly apiKeyEnv: string;
+}
+
+/**
+ * The built-in OpenAI-compatible surfaces. Every one of these speaks Chat
+ * Completions, the surface the live provider selects (`useResponses: false`). Add
+ * a row here as new vendors are asked for in the wild; an unknown provider is
+ * still reachable by setting `base_url` + `api_key_env` explicitly.
+ */
+const KNOWN_PROVIDERS: Readonly<Record<string, KnownProvider>> = Object.freeze({
+  openrouter: {
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+  },
+  openai: {
+    baseURL: 'https://api.openai.com/v1',
+    apiKeyEnv: 'OPENAI_API_KEY',
+  },
+  anthropic: {
+    baseURL: 'https://api.anthropic.com/v1/',
+    apiKeyEnv: 'ANTHROPIC_API_KEY',
+  },
+  google: {
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+    apiKeyEnv: 'GEMINI_API_KEY',
+  },
+});
+
+/** The provider labels the CLI knows out of the box (for error guidance). */
+export const KNOWN_PROVIDER_NAMES: readonly string[] = Object.freeze(
+  Object.keys(KNOWN_PROVIDERS),
+);
+
+/**
+ * Resolve the {@link ProviderPlan} for a `model:` config block. A known provider
+ * supplies its base URL + key env; `base_url` / `api_key_env` override either,
+ * which is also how you point at an unknown vendor (set both). Throws a legible,
+ * actionable error when the provider is unknown AND not fully specified.
+ */
+export function resolveProviderPlan(input: ProviderPlanInput): ProviderPlan {
+  const label = (input.provider || 'openrouter').trim().toLowerCase();
+  const known = KNOWN_PROVIDERS[label];
+
+  const baseURL = input.base_url ?? known?.baseURL;
+  const apiKeyEnv = input.api_key_env ?? known?.apiKeyEnv;
+
+  if (baseURL === undefined || apiKeyEnv === undefined) {
+    throw new Error(
+      `reactor: unknown model.provider '${input.provider}'. Use a built-in provider ` +
+        `(${KNOWN_PROVIDER_NAMES.join(', ')}) in reactor.yml, or set BOTH model.base_url ` +
+        `and model.api_key_env to point at any OpenAI-compatible endpoint. ` +
+        `${baseURL === undefined ? 'Missing base_url. ' : ''}` +
+        `${apiKeyEnv === undefined ? 'Missing api_key_env.' : ''}`.trim(),
+    );
+  }
+
+  // The DEFAULT path = OpenRouter with no explicit overrides. Leave it to the SDK
+  // (the scoped lazy provider, unchanged byte-for-byte). Anything else, the CLI
+  // builds + injects so the configured key env actually gets read.
+  const custom =
+    label !== 'openrouter' ||
+    input.base_url !== undefined ||
+    input.api_key_env !== undefined;
+
+  return { provider: label, baseURL, apiKeyEnv, custom };
+}
+
+/**
+ * The actionable "configured provider needs a key" message. Names the EXACT env
+ * var so a stranger who set, say, `ANTHROPIC_API_KEY` (but mistyped it, or set the
+ * wrong one) is pointed at the right variable, never misdirected to OpenRouter.
+ * Shared by `compile`/`run`/`serve` so the guidance is identical everywhere.
+ */
+export function missingProviderKeyHint(plan: ProviderPlan): string {
+  return (
+    `the configured '${plan.provider}' provider needs ${plan.apiKeyEnv}, but none was ` +
+    `found in the environment or a discoverable .env. Set ${plan.apiKeyEnv}, or change ` +
+    `model.provider / model.api_key_env in reactor.yml. (Run \`reactor doctor\` to check ` +
+    `key presence without printing it; the keyless \`reactor-devtools\` replay needs no key.)`
+  );
+}

--- a/packages/reactor-cli/src/run/host.ts
+++ b/packages/reactor-cli/src/run/host.ts
@@ -41,6 +41,9 @@ import {
   type ConfigOverrides,
   type ResolvedReactor,
 } from '../config';
+import { readModelKey } from '../env';
+import { resolveProviderPlan } from '../model/provider-plan';
+import * as path from 'path';
 
 /** Per-reactor test seams, keyed by reactor name (the offline gate injects these). */
 export interface PerReactorTestSeam {
@@ -123,6 +126,17 @@ export async function bootHost(options: BootHostOptions = {}): Promise<HostHandl
   const model = config.model.compile_model;
   const seams = options.testSeams ?? {};
 
+  // The provider config is TOP-LEVEL (shared by every hosted reactor). Resolve the
+  // plan + read its key ONCE; each reactor's live render gets the same scoped
+  // provider. The default OpenRouter path leaves the plan non-custom (the SDK
+  // builds its provider lazily, unchanged).
+  const providerPlan = resolveProviderPlan(config.model);
+  const hostProjectDir = path.resolve(options.projectDir ?? '.');
+  const apiKey =
+    providerPlan.custom && options.offline !== true
+      ? readModelKey(providerPlan.apiKeyEnv, hostProjectDir)
+      : undefined;
+
   // Boot each reactor's isolated handle. Booting is sequential (each reactor's
   // boot is its own serial cold-miss sweep) — the pool parallelizes the steady
   // state (polls/ingress), not the one-time boot.
@@ -134,8 +148,11 @@ export async function bootHost(options: BootHostOptions = {}): Promise<HostHandl
       contractsDir: entry.projectDir,
       stateDir: entry.stateDir,
       model,
+      renderModel: config.model.render_model,
       sandbox: config.sandbox,
       gateways: entry.gateways,
+      ...(providerPlan.custom ? { providerPlan } : {}),
+      ...(apiKey !== undefined ? { apiKey } : {}),
       ...(options.offline !== undefined ? { offline: options.offline } : {}),
       ...(options.model !== undefined ? { modelOverride: options.model } : {}),
       ...(seam.testGatewayFetch !== undefined

--- a/packages/reactor-cli/src/run/load-run-project.ts
+++ b/packages/reactor-cli/src/run/load-run-project.ts
@@ -57,6 +57,25 @@ export interface CallRunProjectInput {
   readonly adapters: RunAdapters;
   readonly directory?: string;
   readonly render: RunRender;
+  /**
+   * The keyless provider plan for a CUSTOM (non-default) provider. When present
+   * (with {@link apiKey}), {@link callRunProject} builds a scoped live
+   * `ModelProvider` behind the dynamic-import boundary and sets it as
+   * `render.provider`, so the run-phase renders hit the configured
+   * OpenAI/Anthropic/Google/custom endpoint. Omitted on the default OpenRouter
+   * path (the SDK builds its scoped provider lazily) and the offline gate.
+   */
+  readonly providerPlan?: import('../model/provider-plan').ProviderPlan;
+  /** The resolved API key for {@link providerPlan}. Required when it is set. */
+  readonly apiKey?: string;
+  /**
+   * The configured render model id. Threaded into the render so the run phase uses
+   * `model.render_model` (NOT the SDK's gemini default) — required for a custom
+   * provider, whose endpoint would 404 on the default model id.
+   */
+  readonly renderModel?: string;
+  /** The provider label for the receipt cost (set with a custom provider). */
+  readonly providerLabel?: string;
 }
 
 /**
@@ -145,6 +164,38 @@ export async function callRunProject(
   const runProject =
     runProjectImpl ?? (await importRunProject()).runProject;
 
+  // CUSTOM provider: build the scoped live `ModelProvider` HERE — past the dynamic-
+  // import boundary — and set it as the render's first-class `provider`, so the
+  // run-phase renders hit the configured endpoint. The offline gate / default
+  // OpenRouter path leave `providerPlan` unset and the render is byte-for-byte what
+  // it was (a test `buildRender`, or the SDK's lazy scoped OpenRouter provider).
+  let render = input.render;
+  // Thread the configured render model into the NESTED `render: RenderOptions` so
+  // the run phase uses `model.render_model` rather than the SDK's gemini default.
+  // This is REQUIRED for a custom provider (whose endpoint 404s on the default id)
+  // and simply honors the config for the default provider.
+  if (input.renderModel !== undefined) {
+    render = { ...render, render: { ...(render.render ?? {}), model: input.renderModel } };
+  }
+  if (input.providerPlan !== undefined && input.apiKey !== undefined) {
+    const { buildLiveProvider } = await import('../model/live-provider');
+    // The `@openai/agents` escape hatch (incl. `provider`) lives in the NESTED
+    // `render: RenderOptions` field of `RunProjectRender`, not at the top level
+    // (top level is contractFor/projectTruthFor/sandbox/shellTimeoutMs). Merge into
+    // it so the live `createAgentRender` receives the scoped provider. The provider
+    // LABEL is a top-level cost-only field.
+    render = {
+      ...render,
+      render: {
+        ...(render.render ?? {}),
+        provider: buildLiveProvider(input.providerPlan, input.apiKey),
+      },
+      ...(input.providerLabel !== undefined
+        ? { providerLabel: input.providerLabel }
+        : {}),
+    };
+  }
+
   // `input.render` IS the SDK `RunProjectRender` (no `Record<string, unknown>`
   // rebuild, no per-field copy): hand it through VERBATIM. Phase 5's `sandbox` /
   // `shellTimeoutMs` ride along as plain typed fields of that one shape; the model
@@ -154,6 +205,6 @@ export async function callRunProject(
     compiled: input.compiled,
     adapters: input.adapters,
     ...(input.directory !== undefined ? { directory: input.directory } : {}),
-    render: input.render,
+    render,
   });
 }

--- a/packages/reactor-devtools/package.json
+++ b/packages/reactor-devtools/package.json
@@ -44,7 +44,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && pnpm run copy:public",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && pnpm run copy:public",
     "prepack": "pnpm build",
     "copy:public": "node -e \"const fs=require('fs'),p=require('path');const s=p.join('src','public'),d=p.join('dist','public');fs.mkdirSync(d,{recursive:true});for(const f of fs.readdirSync(s))fs.copyFileSync(p.join(s,f),p.join(d,f));\"",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/reactor/package.json
+++ b/packages/reactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/reactor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenProse Reactor runtime: fresh model spend scales with surprise, not the clock.",
   "type": "commonjs",
   "main": "./dist/index.js",
@@ -62,7 +62,7 @@
     "directory": "packages/reactor"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "bundle-skill": "node scripts/bundle-skill.mjs",
     "prepack": "pnpm build && node scripts/bundle-skill.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/reactor/src/adapters/agent-compile/session.ts
+++ b/packages/reactor/src/adapters/agent-compile/session.ts
@@ -97,6 +97,12 @@ export interface CompileSessionConfig {
    * so a consumer may pass a constructed `Model` instance (mirrors the render).
    */
   readonly model?: string | Model;
+  /**
+   * The provider LABEL stamped onto the compile-session cost (e.g. `anthropic`).
+   * Cost-only, never fingerprinted; defaults to `openrouter`. Set it (with a real
+   * `provider`) so the persisted cost reports the truth instead of `openrouter`.
+   */
+  readonly providerLabel?: string;
   /** Pre-read SKILL system prompt. Defaults to reading it once from disk. */
   readonly skill?: string;
   /** Path to the SKILL, when `skill` is not supplied. */
@@ -233,7 +239,17 @@ export async function runCompileSession(
   }
 
   const usage = result.state.usage as unknown as RenderUsage;
-  const cost: Cost = usageToCost(usage, "self" satisfies WakeSource);
+  // Stamp the REAL provider/model onto the compile cost (label-only, never
+  // fingerprinted). The model label is a string id; a constructed `Model` instance
+  // falls back to the default id. Both default to the OpenRouter/gemini wiring.
+  const modelLabel =
+    typeof config.model === "string" ? config.model : DEFAULT_RENDER_MODEL;
+  const cost: Cost = usageToCost(usage, "self" satisfies WakeSource, {
+    ...(config.providerLabel !== undefined
+      ? { provider: config.providerLabel }
+      : {}),
+    model: modelLabel,
+  });
 
   return { output, cost };
 }

--- a/packages/reactor/src/adapters/agent-render/__tests__/cost-labels.test.ts
+++ b/packages/reactor/src/adapters/agent-render/__tests__/cost-labels.test.ts
@@ -1,0 +1,57 @@
+// Cost LABELS — the receipt cost must report the provider + model that ACTUALLY
+// ran, not a hardcoded "openrouter / gemini-3.5-flash". The labels are cost-only
+// (never fingerprinted / never in the cache key), so stamping the truth is safe.
+
+import { equal } from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_RENDER_MODEL,
+  OPENROUTER_PROVIDER_LABEL,
+} from "../provider";
+import { usageToCost, usageToGatewayUsage } from "../cost";
+
+const USAGE = {
+  inputTokens: 100,
+  outputTokens: 20,
+  totalTokens: 120,
+  inputTokensDetails: [],
+} as const;
+
+test("defaults to the OpenRouter / gemini labels when none are given (back-compat)", () => {
+  const gw = usageToGatewayUsage(USAGE);
+  equal(gw.provider, OPENROUTER_PROVIDER_LABEL);
+  equal(gw.model, DEFAULT_RENDER_MODEL);
+  const cost = usageToCost(USAGE, "external");
+  equal(cost.provider, OPENROUTER_PROVIDER_LABEL);
+  equal(cost.model, DEFAULT_RENDER_MODEL);
+});
+
+test("stamps the REAL provider + model when labels are supplied", () => {
+  const gw = usageToGatewayUsage(USAGE, {
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+  });
+  equal(gw.provider, "anthropic");
+  equal(gw.model, "claude-haiku-4-5");
+
+  const cost = usageToCost(USAGE, "external", {
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+  });
+  equal(cost.provider, "anthropic");
+  equal(cost.model, "claude-haiku-4-5");
+  // The token math is unchanged by the labels.
+  equal(cost.tokens.fresh, 120);
+  equal(cost.tokens.reused, 0);
+});
+
+test("a partial label keeps the default for the unset field", () => {
+  const onlyProvider = usageToGatewayUsage(USAGE, { provider: "openai" });
+  equal(onlyProvider.provider, "openai");
+  equal(onlyProvider.model, DEFAULT_RENDER_MODEL);
+
+  const onlyModel = usageToGatewayUsage(USAGE, { model: "gpt-4o-mini" });
+  equal(onlyModel.provider, OPENROUTER_PROVIDER_LABEL);
+  equal(onlyModel.model, "gpt-4o-mini");
+});

--- a/packages/reactor/src/adapters/agent-render/__tests__/provider-byo.live.test.ts
+++ b/packages/reactor/src/adapters/agent-render/__tests__/provider-byo.live.test.ts
@@ -1,0 +1,165 @@
+// Bring-your-own-provider, LIVE — proves the render gateway is NOT bound to
+// OpenRouter. A consumer of `@openprose/reactor` configures `@openai/agents`
+// NATIVELY: build a scoped `OpenAIProvider` pointed at any OpenAI-compatible
+// surface and hand it in as the first-class `provider`. The SAME provider object
+// is what you pass to `reactor(path, { render: { provider } })` /
+// `createAgentRender({ provider })` / `runCompileSession({ provider })`; this test
+// exercises it through the minimal `smokeRun({ provider, model })` probe so the
+// assertion is one bounded round-trip per vendor, not a whole graph.
+//
+// Vendors (the three asked for in the wild — add more as requested):
+//   - openrouter : https://openrouter.ai/api/v1        (the default surface)
+//   - openai     : https://api.openai.com/v1           (OpenAI direct)
+//   - anthropic  : https://api.anthropic.com/v1/       (Anthropic's OpenAI-compat)
+// Google Gemini exposes the same shape at
+//   https://generativelanguage.googleapis.com/v1beta/openai/ — identical wiring,
+//   omitted here only because no GOOGLE/GEMINI key is provisioned in this repo.
+//
+// Each vendor's subtest is gated `{ skip }` exactly like every other live test:
+// it skips when `REACTOR_OFFLINE` is forced OR that vendor's key is absent, so the
+// offline gate (`REACTOR_OFFLINE=1 pnpm test`) reports passing skipped bodies and
+// NEVER touches the network. Keys are read from `process.env` first, then a `.env`
+// discovered by walking up from cwd (honoring `REACTOR_ENV_PATH`) — the same
+// fallback the OpenRouter wiring uses, so a local `pnpm test` from the repo finds
+// the workspace `.env`. In CI, inject the keys as env/secrets.
+
+import { ok } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+import { OpenAIProvider } from "@openai/agents";
+
+import { isOfflineForced, smokeRun } from "../provider";
+import { unquote } from "../../string-util";
+
+/** One OpenAI-compatible vendor surface the render gateway can be pointed at. */
+interface Vendor {
+  /** The label shown in the subtest name. */
+  readonly label: string;
+  /** The env var (and `.env` key) carrying this vendor's API key. */
+  readonly keyEnv: string;
+  /** The OpenAI-compatible base URL. */
+  readonly baseURL: string;
+  /** A cheap, stable model id on that surface. */
+  readonly model: string;
+}
+
+const VENDORS: readonly Vendor[] = [
+  {
+    label: "openrouter",
+    keyEnv: "OPENROUTER_API_KEY",
+    baseURL: "https://openrouter.ai/api/v1",
+    model: "google/gemini-3.5-flash",
+  },
+  {
+    label: "openai",
+    keyEnv: "OPENAI_API_KEY",
+    baseURL: "https://api.openai.com/v1",
+    model: "gpt-4o-mini",
+  },
+  {
+    label: "anthropic",
+    keyEnv: "ANTHROPIC_API_KEY",
+    baseURL: "https://api.anthropic.com/v1/",
+    model: "claude-haiku-4-5",
+  },
+];
+
+/**
+ * Resolve a named key: `process.env` first, then a `.env` discovered by walking
+ * up from `REACTOR_ENV_PATH`'s dir (or cwd). Returns undefined when absent or when
+ * offline is forced (so the subtest skips rather than reaches for a file).
+ */
+function readVendorKey(name: string): string | undefined {
+  if (isOfflineForced()) {
+    return undefined;
+  }
+  const fromProcess = process.env[name];
+  if (typeof fromProcess === "string" && fromProcess.trim().length > 0) {
+    return fromProcess.trim();
+  }
+  const start = process.env["REACTOR_ENV_PATH"]
+    ? dirname(process.env["REACTOR_ENV_PATH"])
+    : process.cwd();
+  let dir = start;
+  for (let depth = 0; depth < 64; depth++) {
+    const value = readEnvFileKey(join(dir, ".env"), name);
+    if (value !== undefined && value.length > 0) {
+      return value;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return undefined;
+}
+
+function readEnvFileKey(file: string, key: string): string | undefined {
+  let contents: string;
+  try {
+    contents = readFileSync(file, "utf8");
+  } catch {
+    return undefined;
+  }
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) {
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq <= 0 || line.slice(0, eq).trim() !== key) {
+      continue;
+    }
+    return unquote(line.slice(eq + 1).trim());
+  }
+  return undefined;
+}
+
+for (const vendor of VENDORS) {
+  const key = readVendorKey(vendor.keyEnv);
+  const skip = isOfflineForced()
+    ? "REACTOR_OFFLINE forced"
+    : key === undefined
+      ? `no ${vendor.keyEnv}`
+      : false;
+
+  test(
+    `BYO provider — ${vendor.label} (${vendor.model}) drives one live render session`,
+    { skip },
+    async () => {
+      // Configure @openai/agents NATIVELY: a scoped provider, no global mutation.
+      // `useResponses: false` selects Chat Completions, the surface all three
+      // vendors share (the Responses API 404s off OpenAI's own host).
+      const provider = new OpenAIProvider({
+        apiKey: key!,
+        baseURL: vendor.baseURL,
+        useResponses: false,
+      });
+
+      const result = await smokeRun({
+        provider,
+        model: vendor.model,
+        temperature: 0,
+        input: "Reply with the single word: ok",
+      });
+
+      // The round-trip resolved: non-empty text + counted usage prove the request
+      // reached THIS vendor and came back, not OpenRouter.
+      ok(
+        result.text.trim().length > 0,
+        `${vendor.label} returned empty text`,
+      );
+      ok(
+        result.totalTokens > 0,
+        `${vendor.label} reported zero total tokens`,
+      );
+      ok(
+        result.model === vendor.model,
+        `${vendor.label} echoed model ${result.model}, expected ${vendor.model}`,
+      );
+    },
+  );
+}

--- a/packages/reactor/src/adapters/agent-render/cost.ts
+++ b/packages/reactor/src/adapters/agent-render/cost.ts
@@ -93,27 +93,43 @@ export function sumCachedTokens(usage: RenderUsage): number {
  */
 export function usageToGatewayUsage(
   usage: RenderUsage,
+  labels: CostLabels = {},
 ): ReactorModelGatewayUsage {
   const input = nonNegInt(usage.inputTokens);
   const output = nonNegInt(usage.outputTokens);
   const reused = Math.min(sumCachedTokens(usage), input);
   const fresh = input - reused + output;
   return {
-    provider: OPENROUTER_PROVIDER_LABEL,
-    model: DEFAULT_RENDER_MODEL,
+    // The cost is a LABEL only (never fingerprinted / never in the cache key), so
+    // it must reflect the provider + model that ACTUALLY ran. Both default to the
+    // OpenRouter/gemini wiring for back-compat; a caller pointing the render at
+    // another vendor passes the real labels so receipts do not misreport
+    // "openrouter / gemini-3.5-flash" for, say, an Anthropic render.
+    provider: labels.provider ?? OPENROUTER_PROVIDER_LABEL,
+    model: labels.model ?? DEFAULT_RENDER_MODEL,
     tokens: { fresh, reused },
   };
+}
+
+/** The provider/model LABELS stamped onto a receipt `Cost` (never fingerprinted). */
+export interface CostLabels {
+  /** The provider label (e.g. `openrouter`, `anthropic`). Defaults to OpenRouter. */
+  readonly provider?: string;
+  /** The model id that ran. Defaults to {@link DEFAULT_RENDER_MODEL}. */
+  readonly model?: string;
 }
 
 /**
  * Project a render's `Usage` + the wake's surprise cause into the receipt
  * `Cost`. The single cost entry point the agent-render mapper calls (05 §2.5).
+ * `labels` stamps the real provider/model; omit for the OpenRouter default.
  */
 export function usageToCost(
   usage: RenderUsage,
   surprise_cause: WakeSource,
+  labels: CostLabels = {},
 ): Cost {
-  return toReceiptCost(usageToGatewayUsage(usage), surprise_cause);
+  return toReceiptCost(usageToGatewayUsage(usage, labels), surprise_cause);
 }
 
 /** Coerce a possibly-fractional/NaN token count to a non-negative integer. */

--- a/packages/reactor/src/adapters/agent-render/index.ts
+++ b/packages/reactor/src/adapters/agent-render/index.ts
@@ -156,6 +156,13 @@ export interface AgentRenderConfig extends RenderOptions {
    * (300_000) — the default is UNCHANGED, the passthrough is opt-in.
    */
   readonly shellTimeoutMs?: number;
+  /**
+   * The provider LABEL stamped onto each receipt `Cost` (e.g. `anthropic`). A
+   * cost-only label, never fingerprinted; defaults to `openrouter`. Set it when a
+   * `provider` points the render at another vendor so receipts report the truth
+   * instead of a misleading `openrouter`. The model label is taken from `model`.
+   */
+  readonly providerLabel?: string;
   // `provider` / `model` / `maxTurns` / `signal` / `temperature` / `seed` and the
   // full Tier-B/C escape hatch (`agent` / `runConfig` / `runOptions` /
   // `extraTools` / `instructionsSuffix` / `tracing` / `agentFactory` /
@@ -355,6 +362,16 @@ export function createAgentRender(
       harvested: harvested as WorldModelFiles,
       usage: session.usage,
       surprise_cause: ctx.wake.source satisfies WakeSource,
+      // Stamp the REAL provider/model onto the receipt cost (label-only, never
+      // fingerprinted). Both default to the OpenRouter/gemini wiring when unset.
+      // A constructed `Model` instance has no string id, so fall back to the
+      // default id for the label in that case.
+      cost_labels: {
+        ...(config.providerLabel !== undefined
+          ? { provider: config.providerLabel }
+          : {}),
+        model: typeof model === "string" ? model : DEFAULT_RENDER_MODEL,
+      },
     });
   };
 }

--- a/packages/reactor/src/adapters/agent-render/output-schema.ts
+++ b/packages/reactor/src/adapters/agent-render/output-schema.ts
@@ -37,7 +37,7 @@ import type {
   RenderProduct,
 } from "../../sdk/render-atom";
 import type { WorldModelFiles } from "../../world-model";
-import { usageToCost, type RenderUsage } from "./cost";
+import { usageToCost, type CostLabels, type RenderUsage } from "./cost";
 
 // ---------------------------------------------------------------------------
 // The structured finalOutput schema (zod `outputType`)
@@ -113,6 +113,12 @@ export interface MapRenderOutputInput {
   readonly usage: RenderUsage;
   /** The wake source — supplies the cost's `surprise_cause` (ctx.wake.source). */
   readonly surprise_cause: WakeSource;
+  /**
+   * The provider/model LABELS for the receipt `Cost` (never fingerprinted). Omit
+   * for the OpenRouter/gemini default; a render pointed at another vendor passes
+   * the real labels so the receipt reports the truth.
+   */
+  readonly cost_labels?: CostLabels;
 }
 
 /**
@@ -132,7 +138,7 @@ export function mapRenderOutput(
   input: MapRenderOutputInput,
 ): RenderProduct | RenderFailure {
   const { signal, usage, surprise_cause } = input;
-  const cost = usageToCost(usage, surprise_cause);
+  const cost = usageToCost(usage, surprise_cause, input.cost_labels ?? {});
 
   if (signal.status === "failed") {
     return {

--- a/packages/reactor/src/sdk/run-project.ts
+++ b/packages/reactor/src/sdk/run-project.ts
@@ -360,6 +360,13 @@ export interface RunProjectRender {
    * {@link buildRender} is supplied (the offline fake owns its own body).
    */
   readonly render?: RenderOptions;
+  /**
+   * The provider LABEL stamped onto each render's receipt `Cost` (e.g.
+   * `anthropic`). Cost-only, never fingerprinted; defaults to `openrouter`. Set it
+   * (alongside a `render.provider` pointing at another vendor) so receipts report
+   * the truth. Ignored when {@link buildRender} owns the body.
+   */
+  readonly providerLabel?: string;
 }
 
 /** Input to {@link runProject}: the compiled project + the run substrate. */
@@ -496,6 +503,11 @@ export async function runProject(
         // keeps its default backend, byte-for-byte what it was before the seam.
         ...(render.renderBackend !== undefined
           ? { renderBackend: render.renderBackend }
+          : {}),
+        // The cost-only provider LABEL (never fingerprinted). Spread like every
+        // other knob; unset → the render stamps the default `openrouter` label.
+        ...(render.providerLabel !== undefined
+          ? { providerLabel: render.providerLabel }
           : {}),
       });
 


### PR DESCRIPTION
## Why
Reactor was effectively hard-wired to OpenRouter on the CLI (only `OPENROUTER_API_KEY` was ever read), stranding users holding OpenAI / Anthropic / Google keys. The SDK already exposed a scoped `provider`; this makes provider choice real and elegant at the CLI level, and fixes a misleading receipt cost label.

## `@openprose/reactor-cli` (0.2.0 → 0.2.1)
- `reactor.yml` `model.provider` switches the live provider. Built-ins `openrouter|openai|anthropic|google` resolve their endpoint + key env; any OpenAI-compatible vendor works via `model.base_url` + `model.api_key_env`.
- A keyless `ProviderPlan` resolver + a model-bearing `OpenAIProvider` factory (constructed only past the dynamic-import offline boundary), threaded into compile sessions and the run/serve render — **including the configured `render_model`, which the run phase previously ignored** (would 404 a custom provider).
- `doctor` reports the **configured** provider's key (not just `OPENROUTER_API_KEY`); `doctor --live` smokes the configured endpoint; a missing key fails **non-zero** naming the exact env var (never misdirects to OpenRouter, never exits 0 on an auth dead-end).
- Tests: `ProviderPlan` resolver + a hermetic missing-key compile.

## `@openprose/reactor` (0.3.0 → 0.3.1)
- Receipt `Cost` now reports the **real** provider + model instead of a hardcoded `openrouter / gemini-3.5-flash` (cost-only labels — never fingerprinted, not in the cache key). New optional `RunProjectRender.providerLabel` + `CostLabels`.
- Tests: `cost-labels` + a key-gated bring-your-own-provider live smoke (OpenRouter + OpenAI + Anthropic).

## Build hardening
Each reactor package now cleans its output dir before `tsc`, so local incremental builds can't accumulate orphaned `dist` test artifacts (a no-op on CI's clean checkouts).

## Validation
- Clean-build offline gates: reactor 468/0/10, reactor-cli 184/185 (the 1 is a local-only `.env`-above-the-checkout artifact; green in CI), devtools 96/96.
- Live-verified: OpenAI-direct `compile` succeeds (manifest now reads `cost.provider: openai`, `cost.model: gpt-4o-mini`); `doctor --live` with `provider: anthropic` renders against Anthropic directly.

## Known limitation
Anthropic's **direct** OpenAI-compat endpoint rejects our structured-output `response_format` unless `strict: true` (`400 response_format.json_schema.strict`). OpenAI, Google, and every model **via OpenRouter** work. Documented; route Anthropic models through OpenRouter today. (Separate research underway on the idiomatic Anthropic path.)