### PR TITLE
docs: use opengraph-image for README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://openprose.ai/readme-header.png" alt="OpenProse — Reactor" width="100%" />
+  <img src="https://openprose.ai/opengraph-image" alt="OpenProse — Reactor" width="100%" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
The `readme-header.png` render had overlapping headline text in the rendered PNG. Point the README header image at the `opengraph-image` route instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)