### PR TITLE
feat(reactor-cli): native Anthropic Messages API for provider: anthropic

### DIFF
--- a/packages/reactor-cli/package.json
+++ b/packages/reactor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/reactor-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openprose/prose.git",
@@ -32,8 +32,11 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "commander": "^12.0.0",
-    "@openprose/reactor": "workspace:*"
+    "@ai-sdk/anthropic": "3.0.81",
+    "@openai/agents-extensions": "0.11.6",
+    "@openprose/reactor": "workspace:*",
+    "ai": "6.0.195",
+    "commander": "^12.0.0"
   },
   "peerDependencies": {
     "@openai/agents": "*",

--- a/packages/reactor-cli/src/__tests__/anthropic-native.live.test.ts
+++ b/packages/reactor-cli/src/__tests__/anthropic-native.live.test.ts
@@ -1,0 +1,95 @@
+// Native Anthropic provider, LIVE — proves `provider: anthropic` drives a real
+// STRUCTURED render through the `@openai/agents` AI-SDK adapter over
+// `@ai-sdk/anthropic`, hitting Anthropic's native Messages API.
+//
+// This is the test that actually matters for the BYO-provider feature: Anthropic's
+// OpenAI-compatible endpoint is "for testing, not production", IGNORES
+// `response_format`, and rejects our JSON-schema structured outputs with
+// `400 …json_schema.strict`. Compile sessions and the render's done/failed signal
+// are BOTH structured, and renders drive tools (the world-model write), so this
+// test exercises a zod `outputType` AND a function tool together — the shape a real
+// render takes — through the EXACT factory the CLI uses (`buildLiveProvider`), not a
+// hand-rolled provider. A passing run proves the native route does what the compat
+// route cannot.
+//
+// Gated like every live test: it skips when `REACTOR_OFFLINE` is forced OR
+// `ANTHROPIC_API_KEY` is absent, so the offline gate (`pnpm test:offline`) reports a
+// passing skipped body and NEVER touches the network. The key is resolved the SAME
+// way the CLI resolves it (`readModelKey` — process env first, then a `.env`
+// discovered from cwd upward).
+
+import { ok, equal } from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { Agent, Runner, tool, setTracingDisabled } from '@openai/agents';
+import { z } from 'zod';
+
+import { resolveProviderPlan } from '../model/provider-plan';
+import { buildLiveProvider } from '../model/live-provider';
+import { isOfflineForced, readModelKey } from '../env';
+
+const ANTHROPIC_KEY_ENV = 'ANTHROPIC_API_KEY';
+const NATIVE_MODEL = 'claude-haiku-4-5';
+
+const offline = isOfflineForced();
+const key = offline ? undefined : readModelKey(ANTHROPIC_KEY_ENV);
+const skip = offline
+  ? 'REACTOR_OFFLINE forced'
+  : key === undefined
+    ? `no ${ANTHROPIC_KEY_ENV}`
+    : false;
+
+test(
+  `provider: anthropic builds the native adapter and drives a STRUCTURED render + tool (${NATIVE_MODEL})`,
+  { skip },
+  async () => {
+    setTracingDisabled(true);
+
+    // The keyless plan the CLI computes for `provider: anthropic` — it MUST select
+    // the native transport, never the OpenAI-compat URL.
+    const plan = resolveProviderPlan({ provider: 'anthropic' });
+    equal(plan.transport, 'anthropic-native');
+
+    // The EXACT scoped provider the live compile/run path injects.
+    const provider = buildLiveProvider(plan, key!);
+
+    // The render's real shape: a done/failed structured signal PLUS a workspace
+    // tool the agent must call. Both must coexist on the native path.
+    let toolCalled = false;
+    const writeWorkspace = tool({
+      name: 'wm_write_workspace',
+      description: 'Write the world-model file to the render workspace.',
+      parameters: z.object({ path: z.string(), contents: z.string() }),
+      execute: async ({ path }) => {
+        toolCalled = true;
+        return `wrote ${path}`;
+      },
+    });
+
+    const outputSchema = z.object({
+      status: z.enum(['done', 'failed']),
+      reason: z.string().optional(),
+    });
+
+    const agent = new Agent({
+      name: 'reactor-anthropic-native-smoke',
+      instructions:
+        'You are a render probe. FIRST call wm_write_workspace with path ' +
+        '"world-model.md" and contents "ok". THEN return status "done".',
+      model: NATIVE_MODEL,
+      modelSettings: { temperature: 0 },
+      tools: [writeWorkspace],
+      outputType: outputSchema,
+    });
+
+    const runner = new Runner({ modelProvider: provider });
+    const result = await runner.run(agent, 'Do the render.', { maxTurns: 6 });
+
+    // The structured output parsed (no `400 json_schema.strict`), the tool ran, and
+    // tokens were counted — the round-trip reached native Anthropic and came back.
+    const parsed = outputSchema.parse(result.finalOutput);
+    equal(parsed.status, 'done');
+    ok(toolCalled, 'the render tool was never called on the native path');
+    ok(result.state.usage.totalTokens > 0, 'native Anthropic reported zero tokens');
+  },
+);

--- a/packages/reactor-cli/src/__tests__/provider-plan.test.ts
+++ b/packages/reactor-cli/src/__tests__/provider-plan.test.ts
@@ -13,20 +13,17 @@ describe('resolveProviderPlan', () => {
     assert.equal(plan.provider, 'openrouter');
     assert.equal(plan.baseURL, 'https://openrouter.ai/api/v1');
     assert.equal(plan.apiKeyEnv, 'OPENROUTER_API_KEY');
+    assert.equal(plan.transport, 'openai-compat');
     // Non-custom: the SDK builds its scoped provider lazily, unchanged.
     assert.equal(plan.custom, false);
   });
 
-  it('resolves each built-in provider to the right base URL + key env, all custom', () => {
+  it('resolves the OpenAI-compat built-ins to the right base URL + key env, all custom', () => {
     const openai = resolveProviderPlan({ provider: 'openai' });
     assert.equal(openai.baseURL, 'https://api.openai.com/v1');
     assert.equal(openai.apiKeyEnv, 'OPENAI_API_KEY');
+    assert.equal(openai.transport, 'openai-compat');
     assert.equal(openai.custom, true);
-
-    const anthropic = resolveProviderPlan({ provider: 'anthropic' });
-    assert.equal(anthropic.baseURL, 'https://api.anthropic.com/v1/');
-    assert.equal(anthropic.apiKeyEnv, 'ANTHROPIC_API_KEY');
-    assert.equal(anthropic.custom, true);
 
     const google = resolveProviderPlan({ provider: 'google' });
     assert.equal(
@@ -34,7 +31,27 @@ describe('resolveProviderPlan', () => {
       'https://generativelanguage.googleapis.com/v1beta/openai/',
     );
     assert.equal(google.apiKeyEnv, 'GEMINI_API_KEY');
+    assert.equal(google.transport, 'openai-compat');
     assert.equal(google.custom, true);
+  });
+
+  it('routes the anthropic built-in through the NATIVE adapter (no compat base URL)', () => {
+    const anthropic = resolveProviderPlan({ provider: 'anthropic' });
+    assert.equal(anthropic.apiKeyEnv, 'ANTHROPIC_API_KEY');
+    assert.equal(anthropic.transport, 'anthropic-native');
+    assert.equal(anthropic.custom, true);
+    // The OpenAI-compat URL is NEVER handed to the AI-SDK adapter; with no
+    // explicit override the adapter uses its own Messages API base (`''`).
+    assert.equal(anthropic.baseURL, '');
+  });
+
+  it('passes an explicit base_url through to the native anthropic adapter (a proxy)', () => {
+    const anthropic = resolveProviderPlan({
+      provider: 'anthropic',
+      base_url: 'https://anthropic-proxy.internal/v1',
+    });
+    assert.equal(anthropic.transport, 'anthropic-native');
+    assert.equal(anthropic.baseURL, 'https://anthropic-proxy.internal/v1');
   });
 
   it('is case-insensitive and treats an empty provider as the OpenRouter default', () => {

--- a/packages/reactor-cli/src/commands/doctor.ts
+++ b/packages/reactor-cli/src/commands/doctor.ts
@@ -46,6 +46,10 @@ import {
  * engines.node ">=20.0.0"). */
 export const MIN_NODE_MAJOR = 20;
 
+/** The model the `--live` smoke uses for a native-Anthropic project with no
+ * explicit `render_model` configured. */
+const DEFAULT_NATIVE_ANTHROPIC_MODEL = 'claude-haiku-4-5';
+
 /** The compiled-IR freshness disposition reported for the project. */
 export type IrFreshness = 'fresh' | 'stale' | 'absent' | 'no-contracts';
 
@@ -231,6 +235,7 @@ export async function collectDoctorReport(
       provider: config.model.provider || 'openrouter',
       baseURL: '',
       apiKeyEnv: 'OPENROUTER_API_KEY',
+      transport: 'openai-compat',
       custom: false,
     };
   }
@@ -330,6 +335,7 @@ export async function runLiveSmoke(
       provider: 'openrouter',
       baseURL: 'https://openrouter.ai/api/v1',
       apiKeyEnv: 'OPENROUTER_API_KEY',
+      transport: 'openai-compat',
       custom: false,
     };
   // Forced offline → never reach for a key or the network. This keeps the offline
@@ -363,6 +369,7 @@ export async function runLiveSmoke(
         readonly baseURL?: string;
         readonly model?: string;
         readonly input?: string;
+        readonly provider?: unknown;
       }) => Promise<{
         readonly text: string;
         readonly totalTokens: number;
@@ -373,9 +380,7 @@ export async function runLiveSmoke(
       provider.assertSkillBundleInstalled();
     }
     // Drive ONE real bounded render against the CONFIGURED endpoint (cli.md §3:
-    // `--live` proves provider reachability via a single live render). We pass the
-    // resolved `apiKey` + `baseURL` + `model` so `smokeRun` builds a scoped provider
-    // for whatever vendor `reactor.yml` selected — not just OpenRouter. The key was
+    // `--live` proves provider reachability via a single live render). The key was
     // confirmed present above, so this is safe to invoke.
     if (typeof provider.smokeRun !== 'function') {
       return {
@@ -384,11 +389,33 @@ export async function runLiveSmoke(
         detail: 'live render smoke unavailable (smokeRun not exported by the render barrel)',
       };
     }
-    const smoke = await provider.smokeRun({
-      apiKey,
-      ...(plan.baseURL.length > 0 ? { baseURL: plan.baseURL } : {}),
-      model: config.renderModel ?? 'google/gemini-3.5-flash',
-    });
+    // The native Anthropic path can't be smoked via a base-URL'd OpenAIProvider —
+    // it routes through the AI-SDK adapter. Build the SAME scoped provider the live
+    // compile/run would use and hand it to `smokeRun`, so the smoke proves the
+    // ACTUAL Claude wiring. Every other vendor passes apiKey + baseURL and lets
+    // `smokeRun` build the scoped OpenAIProvider itself.
+    let smokeConfig: {
+      apiKey?: string;
+      baseURL?: string;
+      model?: string;
+      provider?: unknown;
+    };
+    if (plan.transport === 'anthropic-native') {
+      // Build the SAME scoped AI-SDK provider the live compile/run would use, via
+      // a dynamic import so the model-bearing module never loads on the offline path.
+      const { buildLiveProvider } = await import('../model/live-provider');
+      smokeConfig = {
+        provider: buildLiveProvider(plan, apiKey),
+        model: config.renderModel ?? DEFAULT_NATIVE_ANTHROPIC_MODEL,
+      };
+    } else {
+      smokeConfig = {
+        apiKey,
+        ...(plan.baseURL.length > 0 ? { baseURL: plan.baseURL } : {}),
+        model: config.renderModel ?? 'google/gemini-3.5-flash',
+      };
+    }
+    const smoke = await provider.smokeRun(smokeConfig);
     if (typeof smoke.text !== 'string' || smoke.totalTokens <= 0) {
       return {
         ran: true,

--- a/packages/reactor-cli/src/model/live-provider.ts
+++ b/packages/reactor-cli/src/model/live-provider.ts
@@ -2,26 +2,58 @@
  * The MODEL-BEARING live-provider factory — build a scoped `@openai/agents`
  * `ModelProvider` from a keyless {@link ProviderPlan}.
  *
- * N2 OFFLINE BOUNDARY: this module static-imports `@openai/agents`. It is reached
- * ONLY from modules that are themselves behind the dynamic-import boundary
- * (`run-compile.ts`, `load-run-project.ts`), never from the offline command
- * entrypoints. The handlers compute the keyless {@link ProviderPlan} and read the
- * key (both offline-safe), then cross the boundary and call this to mint the
- * provider.
+ * N2 OFFLINE BOUNDARY: this module static-imports `@openai/agents` (and, for the
+ * native Anthropic path, the AI-SDK adapter). It is reached ONLY from modules that
+ * are themselves behind the dynamic-import boundary (`run-compile.ts`,
+ * `load-run-project.ts`, and doctor's `--live` smoke), never from the offline
+ * command entrypoints. The handlers compute the keyless {@link ProviderPlan} and
+ * read the key (both offline-safe), then cross the boundary and call this to mint
+ * the provider.
+ *
+ * Two transports (see {@link ProviderPlan.transport}):
+ *   - `openai-compat`    — a scoped `OpenAIProvider` on the Chat Completions path
+ *                          (OpenRouter, OpenAI, Google, any custom `base_url`).
+ *   - `anthropic-native` — the AI-SDK adapter over `@ai-sdk/anthropic`, hitting
+ *                          Anthropic's native Messages API. This is the SUPPORTED
+ *                          Claude path: Anthropic's OpenAI-compat endpoint is
+ *                          "for testing, not production" and ignores
+ *                          `response_format`, so it rejects our JSON-schema
+ *                          structured outputs (`400 …json_schema.strict`). The
+ *                          native adapter speaks the Messages API, where
+ *                          structured outputs + tools work.
  */
 
-import { OpenAIProvider, type ModelProvider } from '@openai/agents';
+import { OpenAIProvider, type Model, type ModelProvider } from '@openai/agents';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
+import { createAnthropic } from '@ai-sdk/anthropic';
 
 import type { ProviderPlan } from './provider-plan';
 
+/** The default Anthropic model when an agent carries no explicit model id. */
+const DEFAULT_ANTHROPIC_MODEL = 'claude-haiku-4-5';
+
 /**
- * Build a SCOPED `OpenAIProvider` for the plan + key. `useResponses: false`
- * selects Chat Completions — the surface every built-in vendor (OpenRouter,
- * OpenAI, Anthropic, Google) implements; the Responses API is OpenAI-only and
- * 404s elsewhere. Scoped (never `setDefaultOpenAIClient`), so two reactors in one
- * process can target two different vendors, mirroring the SDK's own discipline.
+ * Build a scoped `ModelProvider` for the plan + key. Dispatches on the plan's
+ * transport; both paths are SCOPED (never `setDefaultOpenAIClient`), so two
+ * reactors in one process can target two different vendors, mirroring the SDK's
+ * own discipline.
  */
 export function buildLiveProvider(
+  plan: ProviderPlan,
+  apiKey: string,
+): ModelProvider {
+  if (plan.transport === 'anthropic-native') {
+    return buildAnthropicNativeProvider(plan, apiKey);
+  }
+  return buildOpenAICompatProvider(plan, apiKey);
+}
+
+/**
+ * The OpenAI-compatible path. `useResponses: false` selects Chat Completions —
+ * the surface OpenRouter, OpenAI, Google (and custom gateways) implement; the
+ * Responses API is OpenAI-only and 404s elsewhere.
+ */
+function buildOpenAICompatProvider(
   plan: ProviderPlan,
   apiKey: string,
 ): ModelProvider {
@@ -30,4 +62,37 @@ export function buildLiveProvider(
     baseURL: plan.baseURL,
     useResponses: false,
   });
+}
+
+/**
+ * The native Anthropic path: wrap `@ai-sdk/anthropic` in the `@openai/agents`
+ * AI-SDK adapter and expose it as a `ModelProvider`. The harness keeps its
+ * instruction composition, tools, harvest, and cost capture — only the model
+ * session is swapped to the Messages API. Models are cached per id so repeated
+ * renders reuse one adapter instance. An explicit `base_url` (a proxy) is honored;
+ * otherwise the adapter uses its own Messages API base.
+ */
+function buildAnthropicNativeProvider(
+  plan: ProviderPlan,
+  apiKey: string,
+): ModelProvider {
+  const anthropic = createAnthropic({
+    apiKey,
+    ...(plan.baseURL.length > 0 ? { baseURL: plan.baseURL } : {}),
+  });
+  const cache = new Map<string, Model>();
+  return {
+    getModel(modelName?: string): Model {
+      const id =
+        modelName !== undefined && modelName.length > 0
+          ? modelName
+          : DEFAULT_ANTHROPIC_MODEL;
+      let model = cache.get(id);
+      if (model === undefined) {
+        model = aisdk(anthropic(id)) as unknown as Model;
+        cache.set(id, model);
+      }
+      return model;
+    },
+  };
 }

--- a/packages/reactor-cli/src/model/provider-plan.ts
+++ b/packages/reactor-cli/src/model/provider-plan.ts
@@ -13,14 +13,36 @@
  *      or a CUSTOM path the CLI must build + inject itself?
  */
 
+/**
+ * How the live provider is constructed for this plan:
+ *   - `openai-compat`    — a scoped `OpenAIProvider` pointed at an OpenAI-compatible
+ *                          Chat Completions surface (OpenRouter, OpenAI, Google, or
+ *                          any custom `base_url`). The default for every vendor.
+ *   - `anthropic-native` — the OFFICIAL Anthropic route: the `@openai/agents`
+ *                          AI-SDK adapter over `@ai-sdk/anthropic`, hitting the
+ *                          native Messages API. Anthropic's OpenAI-compat endpoint
+ *                          is "for testing, not production" and IGNORES
+ *                          `response_format` (it rejects our JSON-schema
+ *                          structured outputs with `400 …json_schema.strict`), so
+ *                          `provider: anthropic` routes natively instead.
+ */
+export type ProviderTransport = 'openai-compat' | 'anthropic-native';
+
 /** A resolved provider plan: the endpoint + key env + whether the CLI builds it. */
 export interface ProviderPlan {
   /** The normalized provider label (e.g. `openrouter`, `anthropic`, `custom`). */
   readonly provider: string;
-  /** The OpenAI-compatible base URL the live provider points at. */
+  /**
+   * The OpenAI-compatible base URL the live provider points at (for
+   * `openai-compat`). For `anthropic-native` this is the EXPLICIT `base_url`
+   * override only (e.g. a proxy), or `''` to let the AI-SDK adapter use its own
+   * Messages API base — the OpenAI-compat URL is never handed to the adapter.
+   */
   readonly baseURL: string;
   /** The env var (and `.env` key) carrying this provider's API key. */
   readonly apiKeyEnv: string;
+  /** How the live provider is built (see {@link ProviderTransport}). */
+  readonly transport: ProviderTransport;
   /**
    * True when the CLI must construct + inject the provider itself (any non-default
    * provider, or an explicit `base_url`/`api_key_env` override). False is the
@@ -40,13 +62,18 @@ export interface ProviderPlanInput {
 interface KnownProvider {
   readonly baseURL: string;
   readonly apiKeyEnv: string;
+  /** Defaults to `openai-compat`; `anthropic` overrides to `anthropic-native`. */
+  readonly transport?: ProviderTransport;
 }
 
 /**
- * The built-in OpenAI-compatible surfaces. Every one of these speaks Chat
- * Completions, the surface the live provider selects (`useResponses: false`). Add
- * a row here as new vendors are asked for in the wild; an unknown provider is
- * still reachable by setting `base_url` + `api_key_env` explicitly.
+ * The built-in providers. Every `openai-compat` one speaks Chat Completions, the
+ * surface the live provider selects (`useResponses: false`). `anthropic` is the
+ * exception: it routes through the native AI-SDK adapter (see
+ * {@link ProviderTransport}), so its `baseURL` here is informational only — the
+ * adapter supplies its own Messages API base unless `base_url` is overridden. Add
+ * a row as new vendors are asked for in the wild; an unknown provider is still
+ * reachable by setting `base_url` + `api_key_env` explicitly.
  */
 const KNOWN_PROVIDERS: Readonly<Record<string, KnownProvider>> = Object.freeze({
   openrouter: {
@@ -58,8 +85,9 @@ const KNOWN_PROVIDERS: Readonly<Record<string, KnownProvider>> = Object.freeze({
     apiKeyEnv: 'OPENAI_API_KEY',
   },
   anthropic: {
-    baseURL: 'https://api.anthropic.com/v1/',
+    baseURL: 'https://api.anthropic.com/v1',
     apiKeyEnv: 'ANTHROPIC_API_KEY',
+    transport: 'anthropic-native',
   },
   google: {
     baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
@@ -82,18 +110,28 @@ export function resolveProviderPlan(input: ProviderPlanInput): ProviderPlan {
   const label = (input.provider || 'openrouter').trim().toLowerCase();
   const known = KNOWN_PROVIDERS[label];
 
-  const baseURL = input.base_url ?? known?.baseURL;
+  const resolvedBaseURL = input.base_url ?? known?.baseURL;
   const apiKeyEnv = input.api_key_env ?? known?.apiKeyEnv;
 
-  if (baseURL === undefined || apiKeyEnv === undefined) {
+  if (resolvedBaseURL === undefined || apiKeyEnv === undefined) {
     throw new Error(
       `reactor: unknown model.provider '${input.provider}'. Use a built-in provider ` +
         `(${KNOWN_PROVIDER_NAMES.join(', ')}) in reactor.yml, or set BOTH model.base_url ` +
         `and model.api_key_env to point at any OpenAI-compatible endpoint. ` +
-        `${baseURL === undefined ? 'Missing base_url. ' : ''}` +
+        `${resolvedBaseURL === undefined ? 'Missing base_url. ' : ''}` +
         `${apiKeyEnv === undefined ? 'Missing api_key_env.' : ''}`.trim(),
     );
   }
+
+  // A custom vendor (unknown name + explicit base_url/api_key_env) speaks the
+  // OpenAI-compat surface; only the built-in `anthropic` routes natively.
+  const transport: ProviderTransport = known?.transport ?? 'openai-compat';
+
+  // For the native Anthropic adapter the OpenAI-compat URL is the WRONG surface —
+  // the adapter owns its Messages API base. Carry only an explicit `base_url`
+  // override (e.g. a proxy); `''` means "let the adapter use its default base".
+  const baseURL =
+    transport === 'anthropic-native' ? input.base_url ?? '' : resolvedBaseURL;
 
   // The DEFAULT path = OpenRouter with no explicit overrides. Leave it to the SDK
   // (the scoped lazy provider, unchanged byte-for-byte). Anything else, the CLI
@@ -103,7 +141,7 @@ export function resolveProviderPlan(input: ProviderPlanInput): ProviderPlan {
     input.base_url !== undefined ||
     input.api_key_env !== undefined;
 
-  return { provider: label, baseURL, apiKeyEnv, custom };
+  return { provider: label, baseURL, apiKeyEnv, transport, custom };
 }
 
 /**

--- a/packages/reactor/src/adapters/agent-render/__tests__/provider-byo.live.test.ts
+++ b/packages/reactor/src/adapters/agent-render/__tests__/provider-byo.live.test.ts
@@ -58,6 +58,11 @@ const VENDORS: readonly Vendor[] = [
     baseURL: "https://api.openai.com/v1",
     model: "gpt-4o-mini",
   },
+  // Anthropic's OpenAI-COMPAT surface. This proves plain-text reachability ONLY:
+  // the compat endpoint ignores `response_format` and rejects our JSON-schema
+  // structured outputs (`400 …json_schema.strict`), so it is NOT the production
+  // Claude path. The SUPPORTED structured route is the native AI-SDK adapter,
+  // covered by reactor-cli's `anthropic-native.live.test.ts` (`provider: anthropic`).
   {
     label: "anthropic",
     keyEnv: "ANTHROPIC_API_KEY",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,21 @@ importers:
 
   packages/reactor-cli:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.81
+        version: 3.0.81(zod@4.4.3)
       '@openai/agents':
         specifier: '*'
         version: 0.11.6(ws@8.21.0)(zod@4.4.3)
+      '@openai/agents-extensions':
+        specifier: 0.11.6
+        version: 0.11.6(@ai-sdk/provider@3.0.10)(@openai/agents@0.11.6(ws@8.21.0)(zod@4.4.3))(@openai/codex-sdk@0.125.0)(ai@6.0.195(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@openprose/reactor':
         specifier: workspace:*
         version: link:../reactor
+      ai:
+        specifier: 6.0.195
+        version: 6.0.195(zod@4.4.3)
       commander:
         specifier: ^12.0.0
         version: 12.1.0
@@ -103,6 +112,28 @@ importers:
         version: 3.2.4(@types/node@20.19.41)(tsx@4.22.3)
 
 packages:
+
+  '@ai-sdk/anthropic@3.0.81':
+    resolution: {integrity: sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.123':
+    resolution: {integrity: sha512-rL+3Sp9crOlfE7MwguFPS30qVp6HFcr9na0KYMb4CcQdxAIjBJec3EEdCjc94UyRVZWLmgQ6Yr605FmPlFIi0w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
     resolution: {integrity: sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==}
@@ -506,6 +537,44 @@ packages:
       zod:
         optional: true
 
+  '@openai/agents-extensions@0.11.6':
+    resolution: {integrity: sha512-lTWr0kFos15PXEqs/gbTPLjVHblFvYx/YKVYy3fK89g56vdW78Tusgvjh9enIFLdmqnzPacTBA3GB2V8V7pr7g==}
+    peerDependencies:
+      '@ai-sdk/provider': ^2.0.0 || ^3.0.0
+      '@blaxel/core': ^0.2.82
+      '@daytonaio/sdk': ^0.162.0
+      '@e2b/code-interpreter': ^2.3.3
+      '@openai/agents': '>=0.0.0'
+      '@openai/codex-sdk': '>=0.86.0'
+      '@runloop/api-client': ^1.16.2
+      '@vercel/sandbox': ^1.9.3
+      ai: ^6.0.0
+      e2b: ^2.14.1
+      modal: ^0.7.4
+      ws: ^8.18.1
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      '@ai-sdk/provider':
+        optional: true
+      '@blaxel/core':
+        optional: true
+      '@daytonaio/sdk':
+        optional: true
+      '@e2b/code-interpreter':
+        optional: true
+      '@openai/codex-sdk':
+        optional: true
+      '@runloop/api-client':
+        optional: true
+      '@vercel/sandbox':
+        optional: true
+      ai:
+        optional: true
+      e2b:
+        optional: true
+      modal:
+        optional: true
+
   '@openai/agents-openai@0.11.6':
     resolution: {integrity: sha512-63zXy+EPmg3WErLO12jLEjCTqGBZ/f0ApsW/t5wpccqUYCtImIT6IYZDgGM+zSEafHNGJmNOwGtEqHjz/Pyl+A==}
     peerDependencies:
@@ -565,6 +634,10 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -691,6 +764,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -711,6 +787,10 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -744,6 +824,12 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  ai@6.0.195:
+    resolution: {integrity: sha512-IYZpuVz0boWbpIQYyinfWFrvQ1N0dG+EVB63it45B2YAU/MxxCnwz4zBswjYnPtHnJBedpMPNrwVbeczbl2GKg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1102,6 +1188,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1504,6 +1593,30 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@3.0.81(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.123(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
     optional: true
 
@@ -1771,6 +1884,22 @@ snapshots:
       - supports-color
       - ws
 
+  '@openai/agents-extensions@0.11.6(@ai-sdk/provider@3.0.10)(@openai/agents@0.11.6(ws@8.21.0)(zod@4.4.3))(@openai/codex-sdk@0.125.0)(ai@6.0.195(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@openai/agents': 0.11.6(ws@8.21.0)(zod@4.4.3)
+      '@openai/agents-core': 0.11.6(ws@8.21.0)(zod@4.4.3)
+      '@types/ws': 8.18.1
+      debug: 4.4.3(supports-color@8.1.1)
+      ws: 8.21.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@openai/codex-sdk': 0.125.0
+      ai: 6.0.195(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@openai/agents-openai@0.11.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@openai/agents-core': 0.11.6(ws@8.21.0)(zod@4.4.3)
@@ -1840,6 +1969,8 @@ snapshots:
 
   '@openai/codex@0.125.0-win32-x64':
     optional: true
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -1916,6 +2047,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1938,6 +2071,8 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.41
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -1985,6 +2120,14 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  ai@6.0.195(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.123(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -2365,6 +2508,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
 
   lilconfig@3.1.3: {}
 


### PR DESCRIPTION
## What

`provider: anthropic` in `reactor.yml` now routes through Anthropic's **native Messages API** (the official `@openai/agents` AI-SDK adapter over `@ai-sdk/anthropic`) instead of Anthropic's OpenAI-compat endpoint.

## Why

Anthropic documents its [OpenAI-compat layer](https://platform.claude.com/docs/en/api/openai-sdk) as "primarily for testing": it ignores `response_format` and rejects our JSON-schema structured outputs with `400 response_format.json_schema.strict`. Compile sessions and the render done/failed signal are both structured, and renders drive tools — so `provider: anthropic` (compat) was a footgun for the tool's core path. The native Messages API supports structured outputs **and** tools.

## Mechanism

- **Keyless `transport` discriminator** on `ProviderPlan` (`openai-compat | anthropic-native`); the `anthropic` built-in resolves to `anthropic-native`. `provider-plan.ts` stays keyless — the N2 offline boundary holds.
- **`live-provider.ts`** builds an AI-SDK-backed `ModelProvider` for the native transport; every other vendor keeps the scoped `OpenAIProvider` Chat-Completions path. Both scoped (no global mutation). The `compile`/`run`/`serve` call sites are unchanged — they already call `buildLiveProvider(plan, apiKey)`.
- **`doctor --live`** builds and smokes the native provider for an `anthropic` project (verified live: `live render OK (model …, 38 tokens)`).
- Bundles `@openai/agents-extensions`, `ai`, `@ai-sdk/anthropic` as CLI deps — an installed `reactor` needs no extra setup.

## Tests

- New gated **live** test drives a structured render **+ a tool call** through the native adapter via the real `buildLiveProvider` factory. Proven live (structured output parsed, tool called, tokens counted); offline-skips like every live test.
- `provider-plan` unit tests cover the new `transport` field (native for anthropic, compat for the rest, base_url override → proxy).
- The reactor BYO live test now notes its anthropic compat subtest is **plain-text reachability only**.
- Full offline suite green from a clean checkout (187 pass / 0 fail / 1 skip).

## Version

`@openprose/reactor-cli` 0.2.1 → 0.2.2. SDK (`@openprose/reactor`) unchanged at 0.3.1.

Companion docs change ships in `openprose/docs` (SDK BYO-provider guide + CLI configuration).