### PR TITLE
chore(release): decouple skill & CLI version tracks; release skill 0.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-prose",
   "description": "Write a Markdown contract (`.prose.md`). Your agent reads it, wires services, runs subagents, and leaves an auditable trace.",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "MIT",
   "homepage": "https://github.com/openprose/prose",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-prose",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Write a Markdown contract (`.prose.md`). Your agent reads it, wires services, runs subagents, and leaves an auditable trace.",
   "license": "MIT",
   "homepage": "https://github.com/openprose/prose",

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,9 +1,20 @@
 {
-  "files": [
-    { "path": ".claude-plugin/plugin.json", "kind": "json", "field": "version" },
-    { "path": ".codex-plugin/plugin.json", "kind": "json", "field": "version" },
-    { "path": "skills/open-prose/SKILL.md", "kind": "yaml", "field": "version" },
-    { "path": "tools/cli/package.json", "kind": "json", "field": "version" },
-    { "path": "tools/cli/install.sh", "kind": "shell-var", "field": "DEFAULT_VERSION" }
-  ]
+  "$comment": "OpenProse version surfaces, grouped into independently-released TRACKS. bump-version.sh keeps each track internally consistent but lets tracks move independently. See RELEASE.md.",
+  "tracks": {
+    "skill": {
+      "description": "The open-prose SKILL and the Claude + Codex plugin envelopes that deliver it. Locked together because the Claude Code marketplace deduplicates by manifest version: skill changes only reach plugin users when the manifest version advances, so the two plugin.json files and SKILL.md must move as one. Machine compatibility is carried separately by SKILL.md's runtime_contract, not by this X.Y.Z.",
+      "files": [
+        { "path": ".claude-plugin/plugin.json", "kind": "json", "field": "version" },
+        { "path": ".codex-plugin/plugin.json", "kind": "json", "field": "version" },
+        { "path": "skills/open-prose/SKILL.md", "kind": "yaml", "field": "version" }
+      ]
+    },
+    "cli": {
+      "description": "The prose CLI npm package (@openprose/prose-cli) and its tarball installer default. Versioned independently of the skill/plugin and published through the OpenProse Release workflow.",
+      "files": [
+        { "path": "tools/cli/package.json", "kind": "json", "field": "version" },
+        { "path": "tools/cli/install.sh", "kind": "shell-var", "field": "DEFAULT_VERSION" }
+      ]
+    }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-04 — open-prose skill & plugin
+
+Skill/plugin-track release. The `@openprose/prose-cli` CLI is unaffected and
+stays at 0.14.0: the SKILL, the Claude/Codex plugin manifests, and the CLI now
+version on independent release tracks (see `RELEASE.md`).
+
+### Changed
+
+- **Intelligent React overhaul (`runtime_contract: 1 → 2`).** The
+  judge → verdict → pressure → fulfillment loop is retired for a deterministic
+  reconciler: a render runs only when a node's subscribed input fingerprints or
+  its own contract fingerprint move, and each commit is a `Receipt`
+  (`rendered | skipped | failed`) with no LLM in the wake/commit decision. The
+  kind taxonomy is re-cleaved around the single render atom — `kind: service` →
+  `kind: function`, `kind: system` removed, `kind: responsibility` reshaped with
+  `### Requires` / `### Maintains`, and `### Ensures` → `### Maintains`.
+  ProseScript and the `prose compile`/`serve`/`run` command surface are
+  unchanged in shape. Full migration map and `prose upgrade` rewrites live in
+  `skills/open-prose/changelog.md`.
+
+### Release process
+
+- **Decoupled version tracks.** `.version-bump.json` now groups version surfaces
+  into independent tracks — `skill` (both plugin manifests + `SKILL.md`, locked
+  together for Claude Code marketplace dedup) and `cli` (`@openprose/prose-cli` +
+  installer). `bump-version.sh` gains `--track <name> <X.Y.Z>` and per-track
+  `--check`/`--list`; the CLI release preflight validates only the `cli` track.
+  Restores the plugin↔CLI independence the packaging originally intended and
+  lets the skill release without a CLI bump.
+
 ## [0.14.0] - 2026-05-19
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,21 +1,49 @@
 # OpenProse Release Process
 
-OpenProse uses one release train. The SKILL/plugin metadata, CLI npm package,
-package lock, and tarball installer all share the same `X.Y.Z` version and ship
-through the protected **OpenProse Release** GitHub Actions workflow.
+OpenProse releases on **two independent tracks**, declared in
+`.version-bump.json`:
 
-## Prepare
+- **`skill`** — the open-prose SKILL plus the Claude + Codex plugin manifests
+  that deliver it (`skills/open-prose/SKILL.md`, `.claude-plugin/plugin.json`,
+  `.codex-plugin/plugin.json`). These move **together**: the Claude Code
+  marketplace deduplicates by manifest version, so a skill change only reaches
+  plugin users when the manifest version advances. Machine compatibility is a
+  separate signal — `SKILL.md`'s `runtime_contract` — not this `X.Y.Z`.
+- **`cli`** — the `@openprose/prose-cli` npm package and its tarball installer
+  (`tools/cli/package.json`, `tools/cli/install.sh`), published through the
+  protected **OpenProse Release** GitHub Actions workflow.
 
-1. Choose the next SemVer version.
+The two tracks version and ship **independently** — a skill release does not
+require a CLI bump, and vice versa. (The `@openprose/reactor*` packages are a
+third, fully separate train under `reactor-v*` tags; see their own flow.)
+
+Bump one track at a time and verify:
+
+```bash
+./scripts/bump-version.sh --track <skill|cli> X.Y.Z   # bump that track's files
+./scripts/bump-version.sh --check                     # every track internally consistent
+./scripts/bump-version.sh --list                      # print each track's version
+```
+
+`--check` passes as long as each track is internally consistent; the tracks may
+(and usually do) sit at different versions.
+
+## Prepare (cli track)
+
+1. Choose the next SemVer version for the CLI.
 2. Move relevant `CHANGELOG.md` notes into `## [X.Y.Z] - YYYY-MM-DD`.
-3. Bump every declared version surface:
+3. Bump the `cli` track and run preflight:
 
    ```bash
-   ./scripts/bump-version.sh X.Y.Z
+   ./scripts/bump-version.sh --track cli X.Y.Z
    ./scripts/bump-version.sh --check
    ./scripts/sync-copy.sh --check
    ./scripts/release-preflight.sh --version X.Y.Z --npm-tag latest
    ```
+
+   `release-preflight.sh` validates the **`cli`** track only; the `skill` track
+   is checked for internal consistency but is not required to match the CLI
+   version.
 
 4. Open and merge a release-prep PR after CI passes.
 
@@ -71,6 +99,44 @@ PROSE_INSTALL_DIR="$tmpdir/install" \
 For broader release validation, run the maintainer playtest in
 [tools/cli/POST_RELEASE_PLAYTEST.md](tools/cli/POST_RELEASE_PLAYTEST.md).
 
+## Releasing the skill / plugin track
+
+The skill ships from the repository (the `skills` CLI reads it directly) and
+through the plugin marketplace (which reads the manifests). There is no npm
+publish for this track, so its release is a version bump + tag + marketplace
+resubmission — independent of any CLI release.
+
+1. Land the skill changes on `main`, then bump the `skill` track:
+
+   ```bash
+   ./scripts/bump-version.sh --track skill X.Y.Z
+   ./scripts/bump-version.sh --check
+   ```
+
+   Bump the **major** of `runtime_contract` in `SKILL.md` as well only when the
+   skill's machine contract changes incompatibly (it is independent of `X.Y.Z`).
+
+2. Add a `## [X.Y.Z]` section to `CHANGELOG.md` and the migration notes to
+   `skills/open-prose/changelog.md` (the deferred upgrade brain consumed by
+   `prose upgrade`).
+
+3. Merge the PR. The `Plugin Manifest` workflow enforces `--check` and the
+   manifest structure on every PR.
+
+4. Tag and publish a GitHub Release for provenance (this tag triggers **no**
+   workflow — it is a marker, kept distinct from the CLI's `v*` tags):
+
+   ```bash
+   git tag -a "skill-vX.Y.Z" -m "open-prose skill X.Y.Z"
+   git push origin "skill-vX.Y.Z"
+   gh release create "skill-vX.Y.Z" --title "open-prose skill X.Y.Z" \
+     --notes-file <(./scripts/extract-changelog.sh X.Y.Z)
+   ```
+
+5. Resubmit the plugin to the marketplaces (manual — see below), referencing the
+   `skill-vX.Y.Z` tag SHA. Until the manifest version advances in the
+   marketplace, plugin users stay on the previous cached copy.
+
 ## Marketplace Submission
 
 Marketplace publication remains manual after the GitHub Release exists.
@@ -81,7 +147,7 @@ Claude Code marketplace:
 - Plugin path: leave blank; `.claude-plugin/` is auto-detected
 - Marketplace name: `openprose`
 - Plugin name: `open-prose`
-- Version: the `vX.Y.Z` tag SHA
+- Version: the `skill-vX.Y.Z` tag SHA
 
 Codex Plugin Directory submission is staged through `.codex-plugin/`,
 `.agents/plugins/marketplace.json`, and `assets/plugin/` once the public

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-# Bump the OpenProse release version atomically across declared files.
+# Bump OpenProse version surfaces, one independently-released TRACK at a time.
+#
+# Tracks are declared in .version-bump.json. Each track's files are kept in
+# lockstep with each other; tracks move independently of one another (e.g. the
+# `skill` plugin/SKILL track and the `cli` package track release separately).
 #
 # Usage:
-#   ./scripts/bump-version.sh 0.13.0     # bump every declared file to 0.13.0
-#   ./scripts/bump-version.sh --check    # exit 0 iff every declared file matches
+#   ./scripts/bump-version.sh --track skill 0.15.0  # bump one track's files
+#   ./scripts/bump-version.sh --check               # every track internally consistent
+#   ./scripts/bump-version.sh --check --track cli   # one track internally consistent
+#   ./scripts/bump-version.sh --list                # print each track's resolved version
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -14,11 +20,14 @@ if [[ ! -f "$CONFIG" ]]; then
   exit 2
 fi
 
-mode="${1:-}"
-if [[ -z "$mode" ]]; then
-  echo "usage: $0 <version> | --check" >&2
-  exit 2
-fi
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  bump-version.sh --track <name> <X.Y.Z>   bump one track's files
+  bump-version.sh --check [--track <name>] check tracks are internally consistent
+  bump-version.sh --list                   print each track's resolved version
+EOF
+}
 
 json_expr() {
   printf '.%s' "$1"
@@ -68,46 +77,116 @@ write_field() {
   esac
 }
 
-case "$mode" in
-  --check)
-    declared_versions=()
-    while IFS= read -r entry; do
-      path="$(jq -r '.path'  <<<"$entry")"
-      field="$(jq -r '.field' <<<"$entry")"
-      kind="$(jq -r '.kind // "json"' <<<"$entry")"
-      v="$(read_field "$path" "$kind" "$field")"
-      if [[ -z "$v" || "$v" == "null" ]]; then
-        echo "error: could not read $path:$field" >&2
-        exit 1
-      fi
-      echo "$path:$field = $v"
-      declared_versions+=("$v")
-    done < <(jq -c '.files[]' "$CONFIG")
-    first="${declared_versions[0]}"
-    for v in "${declared_versions[@]}"; do
-      if [[ "$v" != "$first" ]]; then
-        echo "error: declared versions disagree (saw $v, expected $first)" >&2
-        exit 1
-      fi
-    done
-    echo "ok: all declared files at $first"
-    ;;
-  --*)
-    echo "unknown mode: $mode" >&2
+track_exists() {
+  jq -e --arg t "$1" '.tracks | has($t)' "$CONFIG" >/dev/null 2>&1
+}
+
+all_tracks() {
+  jq -r '.tracks | keys[]' "$CONFIG"
+}
+
+# Read every file in a track, printing `path:field = version` lines, and assert
+# they all agree. Echoes the agreed version on success; exits 1 on disagreement.
+check_track() {
+  local track="$1"
+  local versions=() path field kind v first
+  while IFS= read -r entry; do
+    path="$(jq -r '.path'  <<<"$entry")"
+    field="$(jq -r '.field' <<<"$entry")"
+    kind="$(jq -r '.kind // "json"' <<<"$entry")"
+    v="$(read_field "$path" "$kind" "$field")"
+    if [[ -z "$v" || "$v" == "null" ]]; then
+      echo "error: could not read $path:$field" >&2
+      exit 1
+    fi
+    echo "$path:$field = $v"
+    versions+=("$v")
+  done < <(jq -c --arg t "$track" '.tracks[$t].files[]' "$CONFIG")
+  first="${versions[0]}"
+  for v in "${versions[@]}"; do
+    if [[ "$v" != "$first" ]]; then
+      echo "error: track '$track' versions disagree (saw $v, expected $first)" >&2
+      exit 1
+    fi
+  done
+  echo "ok: track '$track' at $first"
+}
+
+bump_track() {
+  local track="$1" new="$2" path field kind
+  if [[ ! "$new" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version must be X.Y.Z (got $new)" >&2
     exit 2
+  fi
+  while IFS= read -r entry; do
+    path="$(jq -r '.path'  <<<"$entry")"
+    field="$(jq -r '.field' <<<"$entry")"
+    kind="$(jq -r '.kind // "json"' <<<"$entry")"
+    write_field "$path" "$kind" "$field" "$new"
+    echo "bumped $path:$field = $new"
+  done < <(jq -c --arg t "$track" '.tracks[$t].files[]' "$CONFIG")
+}
+
+# ---------------------------------------------------------------------------
+# Parse args: --check, --track <name>, --list, or a bare X.Y.Z version.
+# ---------------------------------------------------------------------------
+mode=""
+track=""
+version=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) mode="check"; shift ;;
+    --list)  mode="list";  shift ;;
+    --track)
+      track="${2:-}"
+      [[ -n "$track" ]] || { echo "error: --track needs a name" >&2; exit 2; }
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown flag: $1" >&2; usage; exit 2 ;;
+    *)
+      [[ -z "$version" ]] || { echo "error: unexpected argument: $1" >&2; exit 2; }
+      version="$1"; shift
+      ;;
+  esac
+done
+
+if [[ -n "$track" ]] && ! track_exists "$track"; then
+  echo "error: unknown track '$track' (have: $(all_tracks | paste -sd, -))" >&2
+  exit 2
+fi
+
+# A bare version means a bump; it now REQUIRES a track (tracks release separately).
+if [[ -z "$mode" && -n "$version" ]]; then
+  mode="bump"
+fi
+
+case "$mode" in
+  check)
+    if [[ -n "$track" ]]; then
+      check_track "$track"
+    else
+      while IFS= read -r t; do
+        check_track "$t"
+      done < <(all_tracks)
+    fi
     ;;
-  *)
-    new="$mode"
-    if [[ ! "$new" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      echo "error: version must be X.Y.Z (got $new)" >&2
+  list)
+    while IFS= read -r t; do
+      v="$(check_track "$t" | sed -n "s/^ok: track '$t' at //p")"
+      printf '%s = %s\n' "$t" "$v"
+    done < <(all_tracks)
+    ;;
+  bump)
+    if [[ -z "$track" ]]; then
+      echo "error: a bump needs an explicit --track (tracks release independently)" >&2
+      usage
       exit 2
     fi
-    while IFS= read -r entry; do
-      path="$(jq -r '.path'  <<<"$entry")"
-      field="$(jq -r '.field' <<<"$entry")"
-      kind="$(jq -r '.kind // "json"' <<<"$entry")"
-      write_field "$path" "$kind" "$field" "$new"
-      echo "bumped $path:$field = $new"
-    done < <(jq -c '.files[]' "$CONFIG")
+    bump_track "$track" "$version"
+    ;;
+  *)
+    usage
+    exit 2
     ;;
 esac

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -79,9 +79,12 @@ if [[ "$require_main" -eq 1 ]]; then
   fi
 fi
 
+# This preflight publishes @openprose/prose-cli, so it validates the `cli` track
+# only. The `skill` plugin/SKILL track versions independently (see RELEASE.md) and
+# must not be required to match a CLI release version.
 (
   cd "$REPO_ROOT"
-  ./scripts/bump-version.sh --check >/tmp/openprose-release-version-check.txt
+  ./scripts/bump-version.sh --check --track cli >/tmp/openprose-release-version-check.txt
 )
 cat /tmp/openprose-release-version-check.txt
 


### PR DESCRIPTION
## Why

The SKILL, the Claude/Codex plugin manifests, and the `@openprose/prose-cli` CLI were pinned to one shared `X.Y.Z` by PR #63 ("unify release flow"). But there's **no runtime coupling** — the skill carries its own `runtime_contract` compatibility signal, and nothing reads or asserts a matching version between CLI and skill. So the shared version was process convention, not necessity. PR #46 originally kept *"plugin and CLI versions independent"*; this restores that.

The lockstep was also actively harmful right now: a partial bump (`SKILL.md` 0.15.0 vs everything-else 0.14.0, from the reactor-harness release) left the **`Plugin Manifest` check red on `main`**. Decoupling fixes that by design.

## What

**Decouple into two independent tracks** (`.version-bump.json`):
- **`skill`** — both plugin manifests + `SKILL.md`, locked together (the plugin marketplace dedupes by manifest version, so a skill change only reaches plugin users when the manifest advances).
- **`cli`** — `@openprose/prose-cli` + `install.sh`.

(The `@openprose/reactor*` packages remain a third, already-separate train under `reactor-v*` tags.)

- `bump-version.sh` is now **track-aware**: `--track <name> <X.Y.Z>` to bump one track, per-track `--check`, and `--list`. `--check` (no track) asserts each track is internally consistent; tracks may differ.
- `release-preflight.sh` validates **only the `cli` track**, so a CLI release is no longer blocked by the skill version.
- `RELEASE.md` documents both tracks + a dedicated skill-release flow; `CHANGELOG.md` gets a `0.15.0` skill entry.

**Release the skill track at 0.15.0** in the same PR (plugin manifests 0.14.0 → 0.15.0; `SKILL.md` already there): the Intelligent React overhaul, `runtime_contract` 1 → 2. **The CLI stays 0.14.0.**

## Verification (all run locally)

- `bump-version.sh --check` → both tracks consistent (cli 0.14.0, skill 0.15.0); `--list` confirms.
- `bash -n scripts/bump-version.sh` clean.
- **Regression:** `release-preflight.sh --version 0.14.0` passes with the skill at 0.15.0 — a CLI release is not broken by the decoupled skill version.
- Full `Plugin Manifest` workflow locally green: both manifest validators, `--check`, `sync-copy --check`, asset + interface + registry checks.

## Not in scope (follow-up)

Adding a CLI→skill `runtime_contract` runtime check. Today nothing enforces compatibility either (the shared version was a human proxy), so this is no worse than `main`; it'd be a strict improvement to add next.

Post-merge: tag `skill-v0.15.0` + GitHub Release; marketplace resubmission is manual.