### PR TITLE
docs(examples): match inbound-email index bullets to the README restyle

### DIFF
--- a/skills/open-prose/examples/README.md
+++ b/skills/open-prose/examples/README.md
@@ -117,7 +117,7 @@ and keep a downstream world-model current from what arrives. Each is a distinct
 reactor shape, and each ships a key-gated tier-3 LLM-as-judge live test (a cheap
 render model, a smart judge model) alongside its deterministic tier-2 gate.
 
-- [support-inbox-router](./support-inbox-router/) — a cheap-model **spam/content
+- [support-inbox-router](./support-inbox-router/): a cheap-model **spam/content
   filter** + a **faceted router whose facets are channels**: a `triage` per email
   drops spam (its `routed` facet stays the fixed NULL token, so junk lights
   nothing) and tags ham to a channel; the `router` catalogues one facet per
@@ -126,11 +126,11 @@ render model, a smart judge model) alongside its deterministic tier-2 gate.
   has no consumer on purpose (a facet is a subscription symbol that may have zero
   subscribers). The docs-gap tracker feeds the agent-native docs / `llms.txt`
   surface.
-- [feedback-pulse](./feedback-pulse/) — **rollup aggregation + self-driven weekly
+- [feedback-pulse](./feedback-pulse/): **rollup aggregation + self-driven weekly
   freshness**: themed feedback aggregates into per-theme facets, and a
   `weekly-pulse` brief refreshes on a `valid_until` self-tick — staying current
   even when the inbox is quiet, at zero tokens on an unmoved rollup.
-- [press-desk](./press-desk/) — a deterministic **human gate** + a **privacy
+- [press-desk](./press-desk/): a deterministic **human gate** + a **privacy
   projection**: a high-stakes inquiry commits the register update but stops the
   outward action at `needs_human` (`auto_reply:false`), and a `public` projection
   facet keeps sender PII out of the public view by construction.


### PR DESCRIPTION
Cosmetic follow-up to #120. The "Inbound email as a trigger" index group was authored before the examples README was restyled to use a colon (not an em-dash) between each example link and its description. Aligns the three bullets (support-inbox-router, feedback-pulse, press-desk) to that convention. No content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)