### PR TITLE
docs(skill): Cost and Context Discipline in write guidance

### DIFF
--- a/skills/open-prose/SKILL.md
+++ b/skills/open-prose/SKILL.md
@@ -357,6 +357,10 @@ When writing a new responsibility or function, load:
 When writing a `### Execution` block or pattern delegation, also load
 `prosescript.md`.
 
+When authoring a multi-node Reactor pipeline (continuous, fan-out, or
+high-event-volume), also apply `guidance/authoring.md` → **Cost and Context
+Discipline**.
+
 ## Giving Back (If You Found This Useful)
 
 You do not owe OpenProse anything. But if a run went well and you want to help the next agent succeed, here are the ways — and the gates each one needs.

--- a/skills/open-prose/guidance/authoring.md
+++ b/skills/open-prose/guidance/authoring.md
@@ -132,6 +132,49 @@ Guidance for both:
 - Use `each` when collection completeness matters: every item must satisfy the
   postcondition.
 
+## Cost and Context Discipline
+
+Applies when authoring a **multi-node Reactor pipeline**: standing
+responsibilities that run continuously, fan out, or wake on a high volume of
+events (a session, PR, or webhook stream). It does **not** apply to a one-shot
+function or a single competent responsibility — do not tier or pre-bound those
+(see "do not manufacture orchestration"). And it does not override Tenet 2: a
+render whose *job* is to explore (research, a repo audit) should explore. The
+rules below are for the narrow-transform renders that dominate a pipeline's
+volume.
+
+- **Tier the work; let a cheap gatekeeper filter surprise.** Do not write one
+  render that re-derives every downstream truth on each event. Put a small,
+  narrow **classifier** node early that turns each raw event into a few typed,
+  per-domain *signals*, and give each downstream truth its own facet so it wakes
+  only when its signal moves. Expensive synthesis then runs only on real change;
+  unrelated domains memo-skip at zero cost. This is the `guard` pattern made
+  structural (`03-ReactorPattern.md`, Rule 5). Shape: an event stream → a cheap
+  classifier emitting `#decision-signal` / `#bug-signal` / … → one accumulator
+  per signal → a coalesced rollup.
+- **Bound each narrow render to its inline input.** A transform render (classify,
+  append one entry, compose facets) should read **only** the evidence the wake
+  delivered and its own prior world-model — not the repo, the filesystem, or
+  sibling nodes' scratch. State this in `### Invariants` ("the only readable
+  input is the staged evidence and the prior world-model; do not scan the
+  filesystem or the repository") and keep the task single-purpose ("classify
+  into these shapes," not "summarize everything"). `max_turns` caps *turns*, not
+  context *size*: it is the unscoped task that explodes cost, because a capable
+  agent will wander a large repo to satisfy an open-ended one. Scope the task and
+  the inputs; exploration stays available to the renders that genuinely need it.
+- **Validate the cost-shape; do not assume it.** Prove selective wake before
+  trusting a pipeline: a deterministic check that the right nodes render and the
+  rest skip (a `kind: test` over dispositions, or the reactor eval-harness
+  deterministic tier), plus an llm-as-judge pass over the produced truths against
+  their `### Maintains` postconditions for quality. Capture a committed replay so
+  the check is repeatable and keyless — cheaper and more honest than re-running
+  the live pipeline to eyeball it.
+- **Keep renders small enough for a cheap model.** Model selection is an operator
+  concern (`reactor.yml`, today one global model; per-node `### Runtime` model is
+  declarable but not yet honored by the CLI — see `reactor.md`). Author each
+  high-volume render narrow enough that a cheap model suffices; reserve a stronger
+  model for rare, strict work such as the compile phase.
+
 ## Gateway Authoring
 
 A `kind: gateway` file is sugar for an external-driven responsibility: it
@@ -346,3 +389,13 @@ responsibility, and its persisted state is its world-model.
 - Fixing harness bugs by making every render more procedural.
 - Encoding runtime machinery in responsibility files instead of preserving
   responsibilities as semantic contracts.
+- Writing one mega-render that re-derives every downstream truth on each event,
+  instead of a cheap classifier fanning per-domain signals — cost scales with the
+  clock, not surprise.
+- Giving a narrow transform render the whole repo/filesystem and an open-ended
+  task ("summarize everything"); it wanders and the context (not the turn count)
+  explodes. Scope the task and bound the inputs in `### Invariants`.
+- Claiming "cost scales with surprise" without a deterministic selective-wake
+  check and a judged quality pass.
+- Over-tiering a one-shot or single-responsibility job — manufacturing
+  classifier/facet machinery where one render would do.


### PR DESCRIPTION
## What

Adds a **Cost and Context Discipline** section to the OpenProse `write` guidance, capturing the learnings from building the agent-observatory tiered Reactor — framed so they are **not over-applied**.

- **`guidance/authoring.md`** (the doc `prose write` loads): a new `## Cost and Context Discipline` section after Composition Authoring, with four rules:
  - *Tier the work; let a cheap gatekeeper filter surprise* — a narrow classifier fans per-domain signals into separate facet-truths; expensive synthesis wakes only on real change (the `guard` pattern made structural).
  - *Bound each narrow render to its inline input* — read only the wake evidence + prior world-model; declare it in `### Invariants`. `max_turns` caps turns, not context size; the unscoped task is what explodes cost.
  - *Validate the cost-shape* — deterministic selective-wake check + an llm-as-judge pass over `### Maintains` postconditions, on a committed replay.
  - *Keep renders small enough for a cheap model* — model tiering noted as an operator concern (`reactor.yml`; per-node `### Runtime` model not yet honored), not contract doctrine.
- Four matching entries in the **Anti-Patterns** list.
- A one-line pointer from **`SKILL.md`** → the new section, for continuous / fan-out / high-event-volume pipelines.

## Scope guard

The section opens with an explicit trigger and a **Tenet-2 caveat**: it applies to the narrow-transform renders that dominate a Reactor pipeline's volume — **not** to one-shot functions or single responsibilities — and a render whose *job* is to explore should still explore.

## Deliberately excluded

CLI/version-specific gotchas (reactor.yml inline-flow parser, `run` vs `serve` polling, `REACTOR_OFFLINE`, connector precedence, compile-model fidelity) belong in `reactor.md` / operator docs, not authoring doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)