### PR TITLE
docs(spec): bring Part I/II/III into parity (ideal / actual / path)

### DIFF
--- a/spec/00-Tenets.md
+++ b/spec/00-Tenets.md
@@ -8,13 +8,23 @@ evaluated before any new capability is considered.
 
 When the system is in tension with a tenet, the tenet wins. When two tenets
 collide, the lower-numbered tenet wins — the order below is descending
-precedence. That ordering — correctness over safety over cost, with minimizing
-how often a human is interrupted a downstream goal rather than an authority the
-other tenets bend around — is enforced where decisions are actually made: at
-compile time, where the canonicalizer and postcondition validators are frozen,
-and in the fail-safe commit gate, where a render that cannot satisfy its
-obligations commits nothing rather than acting. It is not a separate runtime
-policy dial.
+precedence. The numbered order decides *which tenet wins*. The operational stack
+**correctness > safety > cost > interrupt-minimization** is how that order
+projects onto the decisions actually made. Correctness is non-negotiable and
+flows from Tenets 1, 2, and 5 (authored intent, bounded determinism, verifiable
+evidence); by design it is realized where decisions are frozen — at compile,
+where the canonicalizer and postcondition validators are fixed, and at the
+commit gate, whose admissibility check keeps an inadmissible render from
+corrupting the truth (correctness) and whose fail-closed default makes a render
+that cannot satisfy its obligations commit nothing rather than act (safety,
+Tenet 4). Below that floor the stack is the resolution rule for the
+safety → cost → silence trade-offs — Tenet 4's "safety outranks cost; cost
+outranks silence": safety is Tenet 4, cost is the resource budget the gates are
+constrained by, and interrupt-minimization is a downstream goal rather than an
+authority the other tenets bend around. The stack is not a separate runtime
+policy dial and does not override the numbered precedence — it projects that
+precedence onto the operational decisions; the numbered precedence governs
+everything else.
 
 ---
 
@@ -24,7 +34,7 @@ The `*.prose.md` is the single authored source of meaning. Everything else —
 compiled artifacts, projections, operational policy — is *derived* and
 reconcilable; when a derived artifact disagrees with the contract, the contract
 is right. There is no second authored surface for intent: not a prompt, a
-config, or a tuned judge.
+config, or a separate scoring artifact.
 
 ## 2. Intelligence is the model's; determinism only bounds it.
 
@@ -62,7 +72,8 @@ Portability is the discipline that keeps every host honest.
 
 ## 7. One bounded run, one session; the DAG composes.
 
-An activation is one bounded session in one runtime. What looks like
+An activation is one bounded run in one runtime — one render that commits one
+world-model, even when it spawns isolated sub-sessions to get there. What looks like
 orchestration inside it — wiring, delegation, sub-task isolation, choreography
 — is the agent honoring the contract with the runtime's own primitives. The
 only seam where multiple runs meet is the world-model DAG, where activations

--- a/spec/01-Language.md
+++ b/spec/01-Language.md
@@ -4,16 +4,16 @@
 
 This document is the specification of **the OpenProse Language & Framework** —
 the durable `*.prose.md` contract format, the skill semantics that interpret
-it, the model-run compiler that lowers it, the standard library that packages
-reusable behavior, and the CLI surface that drives it. It is the spec for what
-ships **bundled as the SKILL**.
+it, the model-run compiler that lowers it, and the standard library that
+packages reusable behavior. It is the spec for what ships **bundled as the
+SKILL**.
 
 The OpenProse corpus divides labor exactly, and each document maps to what
 ships:
 
 - [01-Language.md](./01-Language.md) — **this document, the Language &
   Framework**, bundled as the **SKILL**: syntax, kinds, sections, compile
-  model, std/co, CLI surface.
+  model, std/co.
 - [02-ReactorHarness.md](./02-ReactorHarness.md) — **the Reactor
   Harness**, bundled as the **CLI/Server**: the runtime control architecture
   (loop, invariants, the reconciler, memoization, forecast, receipts, composition)
@@ -39,12 +39,12 @@ This file has three parts, mirroring its companions:
 
 ## Part I — The Ideal OpenProse Language & Framework
 
-OpenProse is a contract format, runtime doctrine, skill package, standard
-library, and CLI wrapper for making agent work readable, reviewable, versioned,
-reusable, and inspectable. A user writes one `*.prose.md` file of durable
-intent. A Prose Complete agent host reads it, wires the responsibility DAG, spawns
-isolated bounded sessions, and
-leaves a durable receipt under an OpenProse root.
+OpenProse is a contract format, runtime doctrine, skill package, and standard
+library for making agent work readable, reviewable, versioned, reusable, and
+inspectable. A user writes one `*.prose.md` file of durable intent. The
+compile phase (Forme) wires the responsibility DAG from the contract set; a
+Prose Complete agent host then serves that DAG — spawning isolated bounded
+sessions and leaving a durable receipt under an OpenProse root.
 
 The central idea:
 
@@ -79,17 +79,21 @@ Part II is honest about how far the current skill has climbed toward them.
 - **Intelligence lives in the model, not in deterministic code (Tenet 2).**
   Compilation is itself model work — intelligent sessions lower a contract into
   its IR (the Forme topology, the per-node canonicalizer, and the postcondition
-  validators); deterministic code only validates that IR, wires connectors,
+  validators — deterministic where the obligation is expressible, render-attested
+  where it is semantic); deterministic code only validates that IR, wires connectors,
   enforces boundaries, schedules, and signs. The language never grows a config
   format to encode what the model should decide.
 - **The authored surface is small, stable, and complete.** Five kinds
   (`responsibility`, `function`, `gateway`, `pattern`, `test`), the canonical
-  `###` section set (`### Goal`, `### Requires`, `### Maintains`,
-  `### Continuity`, `### Invariants`, `### Execution`, plus
-  `### Parameters`/`### Returns` for a `function`, and the carried
-  `### Shape`/`### Environment`/`### Tools`/`### Runtime`), and the header
-  hierarchy are the
-  entire language. Persistence is conferred by *mounting* a responsibility — the
+  `###` section set (`### Description`, `### Goal`, `### Requires`,
+  `### Maintains`, `### Continuity`, `### Invariants`, `### Errors`,
+  `### Strategies`, `### Execution`, plus `### Parameters`/`### Returns` for a
+  `function`, the gateway ingress sections
+  (`### Schedule`/`### Receives`/`### Emits`/`### Payload`), the test and pattern
+  sections (`### Fixtures`/`### Expects` for a `test`,
+  `### Slots`/`### Config`/`### Delegation` for a `pattern`), and the carried
+  `### Shape`/`### Environment`/`### Skills`/`### Tools`/`### Runtime`), and the
+  header hierarchy are the entire language. Persistence is conferred by *mounting* a responsibility — the
   harness gives a mounted node its single durable world-model — not by a config
   flag. New capability is new *semantics* in skill docs, never new syntax or a
   YAML overlay.
@@ -100,7 +104,11 @@ Part II is honest about how far the current skill has climbed toward them.
   into a deterministic **canonicalizer**, and the run phase fingerprints each
   render's output through it. An unmoved fingerprint means the world did not
   materially change, so the dumb reconciler skips the render at zero cost —
-  there is no judge re-deciding "did this change." Absent a material/immaterial
+  there is no judge re-deciding "did this change." The fingerprint is one term
+  of the node's three-part memo key `(contract_fingerprint, input_fingerprints,
+  freshness_epoch)`; a declared freshness window (`valid_until`) is the third
+  term, so silent staleness still forces a re-render even when nothing observable
+  moved (see `### Requires`). Absent a material/immaterial
   split, maintenance cost scales with the clock, not with surprise. The
   *normalization convention* is the author's prose inside `### Maintains`; the
   compiled mechanics are the harness's
@@ -133,7 +141,10 @@ before it may commit. There is no separate judge and no `### Criteria`:
 satisfaction folds into `### Maintains`, checked deterministically where it can
 be expressed as a validator and self-attested by the render where it is
 semantic. A render that cannot satisfy its postconditions commits nothing — the
-prior truth stands and a `failed` receipt records why.
+prior truth stands and a `failed` receipt records why: a reason addressed to the
+contract author, naming exactly what the render could not satisfy. (The shipped
+v0 receipt does not yet carry that reason field — see
+[02-ReactorHarness.md](./02-ReactorHarness.md) Part II.)
 
 **Facets make subscription structural.** A `####` sub-heading inside
 `### Maintains` declares a facet — a named part of the truth. Its name is, at
@@ -142,15 +153,23 @@ an always-on atomic token over the whole truth), its *subscription symbol* (a
 consumer names it in `### Requires`, and the reconciler wakes that consumer only
 when *that* facet's token moves — `Requires.<facet>` ↔ `Maintains.<facet>`), and
 its region of the world-model. Declaring no parts is the atomic default — one
-truth, one token — and costs nothing. This adds no new grammar; it reuses the
-heading hierarchy and the Requires↔Maintains join. *Structure is subscription.*
+truth, one token — and costs nothing. Symmetrically, a consumer whose
+`### Requires` names the producer *without* a facet binds to that always-on atomic
+token and so wakes on *any* material change (the OR of every facet); naming a
+facet is how a consumer narrows that to one region. This adds no new grammar; it
+reuses the heading hierarchy and the Requires↔Maintains join. *Structure is
+subscription.*
 
 **`### Requires` declares what the node subscribes to.** It names the upstream
 facets this node consumes; Forme matches each `### Requires` entry to a
 producer's `### Maintains` facet and draws the subscription edge. `### Requires`
 is the input side of the memo key: the run phase fingerprints the node's
-contract together with its subscribed inputs, and re-renders only when one of
-them moves.
+contract together with its subscribed inputs and its freshness epoch, and
+re-renders only when one of them moves. (Shipped v1 realizes the freshness term
+as a forecast-driven self-receipt over a two-part `(contract_fingerprint,
+input_fingerprints)` key rather than a literal third element; the decision
+semantics are identical — see [02-ReactorHarness.md](./02-ReactorHarness.md)
+Part II.)
 
 **`### Continuity` declares the wake source — when, beyond an input change, a
 node should re-render.** It is not a schedule. A node is *input-driven* by
@@ -170,9 +189,12 @@ identity, projection-only shapes — is the Reactor authoring pattern's
 ([03-ReactorPattern.md](./03-ReactorPattern.md)); the runtime mechanics are the
 harness's ([02-ReactorHarness.md](./02-ReactorHarness.md)).
 
-The full mechanics of the runtime that *serves* these contracts — the two-phase
-compile/run split, memoization, the deterministic continuity clock, receipts,
-composition — are **not** specified here. They are the Reactor harness's concern
+The full *mechanics* of the runtime that *serves* these contracts — the
+two-phase compile/run split, the memo engine, the deterministic continuity
+clock, the receipt ledger, composition — are **not** specified here. This
+document states their *language-level semantics* — what the author declares (a
+freshness window, a postcondition, the receipt as the commit object) and what it
+means — and leaves the mechanics that realize them to the Reactor harness
 ([02-ReactorHarness.md](./02-ReactorHarness.md)). This document's ideal is the
 *language*: the contract a human or agent writes, and the semantics by which it
 is understood.
@@ -182,18 +204,22 @@ is understood.
 ## Part II — What Exists Today
 
 > This part is a synthesis of the current `openprose/prose` repository, treated
-> as the source of truth, measured honestly against Part I. The skill is **mid-migration**:
-> its `runtime_contract` advanced from `1` to `2` in the `v0.15.0` "Intelligent
-> React" overhaul, which retired the judge / verdict / pressure / fulfillment
-> loop and re-cleaved the kind taxonomy around a single render atom. The
-> *teaching docs* (`SKILL.md`, `contract-markdown.md`, `concepts/`, `changelog.md`)
-> are on the new model; the *library examples* under `skills/open-prose/examples/`
-> are migrated; the bundled `packages/std/` and `packages/co/` contracts are
-> **not yet migrated** (they still carry the retired vocabulary). This part says
-> so plainly rather than projecting completion. Older framing around hosted cloud
-> products, social execution networks, company financing, `kind: program`,
-> standalone `.prose` source files, and the old registry model is not part of
-> this synthesis unless the current repo still contains a live implementation.
+> as the source of truth, measured honestly against Part I. The `v0.15.0`
+> "Intelligent React" overhaul advanced the skill's `runtime_contract` from `1`
+> to `2`, retiring the judge / verdict / pressure / fulfillment loop and
+> re-cleaving the kind taxonomy around a single render atom. That migration is now
+> **essentially complete across the corpus**: the teaching docs (`SKILL.md`,
+> `contract-markdown.md`, `concepts/`, `changelog.md`), the library examples under
+> `skills/open-prose/examples/`, and the bundled `packages/std/` and `packages/co/`
+> contracts all carry the current vocabulary — **zero** `kind: service`,
+> `kind: system`, or `### Ensures` remain. The legacy `@openprose/prose-cli`
+> binary has been **removed**: the language is embodied by the SKILL in-session,
+> and the Reactor (the SDK + `reactor` CLI,
+> [02-ReactorHarness.md](./02-ReactorHarness.md)) is the deterministic harness
+> that compiles and runs served responsibilities. Older framing around hosted
+> cloud products, social execution networks, company financing, `kind: program`,
+> standalone `.prose` source files, and the old registry model is not part of this
+> synthesis unless the current repo still contains a live implementation.
 
 ### Current Shape
 
@@ -213,19 +239,21 @@ The shippable repository also contains:
 
 | Area | Location | Role |
 | --- | --- | --- |
-| OpenProse skill | `skills/open-prose/` | Agent-facing runtime/spec bundle |
-| CLI | `tools/cli/` (`@openprose/prose-cli`) | Shell entrypoint and deterministic host for compile/serve/status/doctor |
-| Standard library | `packages/std/` | Reusable roles, patterns, ops, delivery, memory, and evals (**not yet migrated** to the v0.15.0 vocabulary) |
-| Company-as-Prose package | `packages/co/` | Generic company-operations starter contracts (**not yet migrated**) |
-| Reactor packages | `packages/reactor/` (`0.2.0`), `packages/reactor-cli/` (`0.1.0`), `packages/reactor-devtools/` | The Reactor harness runtime and its `reactor` CLI/replay viewer; specified in [02-ReactorHarness.md](./02-ReactorHarness.md), **not** language material |
+| OpenProse skill | `skills/open-prose/` | Agent-facing runtime/spec bundle — the language's execution surface (the agent embodies the VM in-session) |
+| Standard library | `packages/std/` | Reusable roles, patterns, ops, delivery, memory, and evals (migrated to the current vocabulary) |
+| Company-as-Prose package | `packages/co/` | Generic company-operations starter contracts (migrated to the current vocabulary) |
+| Reactor packages | `packages/reactor/` (`0.3.1`), `packages/reactor-cli/` (`0.2.2`), `packages/reactor-devtools/` (`0.2.0`) | The Reactor harness runtime and its `reactor` CLI/replay viewer; specified in [02-ReactorHarness.md](./02-ReactorHarness.md), **not** language material |
 | Examples | `skills/open-prose/examples/` | Native OpenProse repositories; migrated to responsibility/function/gateway |
-| Tests and fixtures | `tools/cli/tests/`, package test suites | Command-model, harness, compile-validation, and IR/runtime tests |
+| Tests and fixtures | repo-root skill tests (`tests/open-prose/`) + package test suites | Skill/spec conformance, compile-validation, and reactor runtime/IR tests |
 | Plugin envelopes | `.codex-plugin/`, `.claude-plugin/`, `.agents/plugins/` | Marketplace/install metadata |
 
-OpenProse is distributed as an MIT-licensed beta and collects no telemetry. Note
-that this document's CLI is the **`prose` CLI** (`@openprose/prose-cli`); the
-separate **`reactor` CLI** (`packages/reactor-cli/`) drives the Reactor harness
-and is the Harness doc's concern, not this one.
+OpenProse is distributed as an MIT-licensed beta. The SKILL and the language
+collect no telemetry; the `reactor` CLI ships anonymous, opt-out usage analytics
+(disabled by `DO_NOT_TRACK`, `CI`, a non-TTY, or offline mode) — a harness
+concern documented in [02-ReactorHarness.md](./02-ReactorHarness.md). There is no
+longer a `prose` binary: the language is embodied by the SKILL in-session, and
+the **`reactor` CLI** (`packages/reactor-cli/`) is the deterministic harness that
+compiles and runs served responsibilities.
 
 ### What OpenProse Is Not
 
@@ -281,22 +309,25 @@ the abstract VM primitives onto real capabilities:
 | `spawn_session` | Run a render (a responsibility or a called function) in an isolated agent/session with a prompt, optional model, and access to declared input/output paths |
 | `ask_user` | Pause for missing required caller input and resume with the answer |
 | `read_state` / `write_state` | Read and write run state through the selected backend (`<openprose-root>/runs/{id}/` artifacts and durable records) |
-| `copy_binding` | Publish a declared output through the active backend (filesystem copies `workspace/` → `bindings/`; never publishes undeclared scratch) |
+| `copy_binding` | Publish a declared output through the active backend (filesystem writes the canonical artifact to `world-model/` and signs a receipt; never publishes undeclared scratch) |
 | `check_env` | Confirm an environment variable exists without exposing its value |
 
-Codex-style and Claude Code-style environments are the primary documented
-targets. The `prose` CLI can forward runs to `codex-sdk`, `claude-sdk`, or a
-local `mock` harness (the three harnesses under `tools/cli/src/harnesses/`);
-`codex-sdk` is the default. OpenProse commands are therefore first an
-agent-session command language. A shell command such as:
+Codex-style and Claude Code-style coding agents are the primary documented hosts.
+There is no `prose` binary that forwards to a separate harness: the SKILL-loaded
+coding-agent session **is** the host and embodies the VM directly. OpenProse
+commands are therefore first an agent-session command language. An in-session
+instruction such as:
 
 ```bash
 prose run src/hello.prose.md
 ```
 
-means "ask the selected agent harness to embody the OpenProse VM and execute
-this contract." The CLI is not a replacement VM; it never parses `.prose`
-semantics — the SKILL-loaded session embodies the VM.
+means "embody the OpenProse VM and execute this contract here, in-session" — the
+agent maps the primitives onto its own host tools (spawning sub-sessions, reading
+and writing run state, checking env). It never parses `.prose` semantics
+mechanically; the SKILL-loaded session embodies the VM. Continuous, *served*
+responsibilities are run by the Reactor harness (the `reactor` CLI), which the
+skill hands off to via `prose react` ([02-ReactorHarness.md](./02-ReactorHarness.md)).
 
 ### OpenProse Root
 
@@ -317,7 +348,7 @@ The root layout is:
 | `runs/` | Activation receipts for bounded VM runs |
 | `state/` | Durable cross-run state |
 | `state/agents/` | Durable agent memory |
-| `state/responsibilities/{id}/` | Each responsibility's persisted world-model and its signed, append-only receipt ledger (no separate status/pressure store — the judge loop is retired) |
+| `state/world-model/{node}/` | Each responsibility's persisted canonical world-model, with its signed, append-only `receipts.jsonl` ledger (no separate status/pressure store — the judge loop is retired) |
 | `deps/` | Installed git-native dependencies |
 | `prose.lock` | Dependency lockfile |
 | `.env` | Local runtime environment |
@@ -369,7 +400,7 @@ A `kind: responsibility` file carries a required `id:` frontmatter field: a
 tooling-generated, UUIDv7-compatible identifier (rendered as uppercase Crockford
 base32) minted once by `prose` and preserved across `name:` and filename
 renames. `name:` is the human-facing slug; `id:` is the durable identity used to
-key world-model and receipt-ledger state under `state/responsibilities/{id}/`.
+key world-model and receipt-ledger state under `state/world-model/{node}/`.
 Authors do not hand-write `id:`; tooling manages it.
 
 The five current authored kinds are:
@@ -458,9 +489,9 @@ Forme:
    the dumb reconciler reads to schedule and propagate.
 
 The repository keeps the Forme doctrine in `skills/open-prose/forme.md`. The
-older `packages/std/ops/wire.prose.md` contract still exists but, like the rest
-of `std/`, predates the v0.15.0 vocabulary and is pending migration. Forme
-running standalone (no harness) is still well-defined: a single responsibility
+`packages/std/ops/wire.prose.md` contract is a migrated `kind: function` (invoked
+in-session as `prose run std/ops/wire`). Forme running standalone (no harness) is
+still well-defined: a single responsibility
 applies its compiled canonicalizer locally to fingerprint its own receipt.
 
 ### Prose VM
@@ -483,8 +514,8 @@ For a called function:
 For a responsibility render:
 
 1. The reconciler computes the memo key `(contract_fingerprint,
-   input_fingerprints)`; if neither half moved since the last receipt, it writes
-   a `skipped` receipt and spawns nothing.
+   input_fingerprints)`; if neither half moved and no `valid_until` has lapsed
+   since the last receipt, it writes a `skipped` receipt and spawns nothing.
 2. Otherwise spawn one bounded session — the render — which reads the evidence
    the wake delivered and queries the prior world-model **by reference** (never
    pre-stuffed into context).
@@ -502,7 +533,8 @@ runs/{run-id}/
   root.prose.md
   sources/
   workspace/
-  bindings/
+  world-model/
+  receipts/
   vm.log.md
   agents/
 ```
@@ -512,8 +544,9 @@ The separation matters:
 | Directory | Meaning |
 | --- | --- |
 | `sources/` | Immutable source snapshots for the run |
-| `workspace/` | Private scratch and outputs per render |
-| `bindings/` | Public declared outputs visible downstream |
+| `workspace/` | Private, never-fingerprinted render scratch |
+| `world-model/` | The published, canonically-serialized + fingerprinted truth visible downstream |
+| `receipts/` | The signed, append-only receipt ledger for the run |
 
 OpenProse also specifies in-context, SQLite, and PostgreSQL state backends.
 Filesystem is the default and normative reference. In-context is for small
@@ -584,7 +617,8 @@ The reconcile loop is **dumb on purpose** (the full semantics are in
    `self` (the continuity clock's synthetic self-receipt), or `external` (a
    gateway turning a trigger into an edge receipt).
 2. Compute the memo key `(contract_fingerprint, input_fingerprints)`. If neither
-   half moved, write a `skipped` receipt and spawn nothing.
+   half moved and no `valid_until` has lapsed, write a `skipped` receipt and spawn
+   nothing.
 3. Otherwise spawn one render. It computes the new truth, leaves its
    `### Maintains` postconditions satisfied, writes the world-model, and signs a
    receipt with `status` `rendered` or `failed`.
@@ -632,7 +666,7 @@ The canonical output files are:
 | File | Meaning |
 | --- | --- |
 | `dist/manifest.next.json` | Fresh compile output |
-| `dist/manifest.active.json` | Manifest consumed by `prose serve` |
+| `dist/manifest.active.json` | The promoted manifest the served runtime consumes |
 
 Promotion from next to active is explicit.
 
@@ -640,7 +674,7 @@ IR records include:
 
 | Record | Meaning |
 | --- | --- |
-| `sources[]` | Discovered contract set (allowed kinds: responsibility, gateway; functions appear only when discovered, never as topology nodes) |
+| `sources[]` | Discovered contract set (allowed kinds: `responsibility`, `function`, `gateway`, `pattern`, `test`, `unknown`); only responsibilities and gateways become topology nodes — functions appear when discovered but never as nodes |
 | `topology` | Forme's resolved DAG: nodes (each with `contract_fingerprint` and `wake_source`), `edges`, and the `acyclic` postcondition |
 | `canonicalizers[]` | One per node: the deterministic lowering of `### Maintains` — `canonicalizer(world-model) → fingerprints` |
 | `postconditions[]` | One set per node: validators lowered from `### Maintains` postconditions (deterministic where expressible, render-attested otherwise) |
@@ -650,12 +684,11 @@ IR records include:
 The canonical compiler is a pinned ProseScript program at
 `skills/open-prose/compiler/index.prose.md` whose agents are **compile-step
 renders** — Forme (wiring), the canonicalizer compiler, and the postcondition
-compiler — so the compile output is itself auditable (Tenet 2). The `prose` CLI
-also ships a deterministic TypeScript source-compiler
-(`tools/cli/src/prose/repository-source-compiler.ts`) used as a validating
-fallback when the harness produces no manifest. Whether that fallback should be
-reframed as a *structural validator only* or acknowledged as a permitted,
-semantics-free mechanical lowering remains open roadmap work (Part III §3).
+compiler — so the compile output is itself auditable (Tenet 2). The Reactor
+harness realizes the same compile phase through its `agent-compile` adapter
+(content-addressed IR cache; [02-ReactorHarness.md](./02-ReactorHarness.md)).
+There is no separate deterministic source-compiler binary — the deprecated `prose`
+CLI that once shipped one has been removed.
 
 Important compiler doctrine:
 
@@ -666,61 +699,46 @@ Important compiler doctrine:
 - Do not invent provider auth, queue names, routes, payload schemas, or
   subscription setup the source does not supply.
 - Write `manifest.next.json` only after the IR shape is valid.
-- Stop after writing; the CLI performs deterministic validation.
+- Stop after writing; the harness performs deterministic validation.
 
 The compile-phase IR is **source-derived**: it is a function of the `*.prose.md`
 source set and nothing else. The Reactor harness's token-truth receipts,
 forecasts, freshness state, and reconciler decisions are **sibling runtime state**
 owned by `@openprose/reactor` — not IR fields and not new source syntax. See
-Part III §3 and [02-ReactorHarness.md](./02-ReactorHarness.md).
+*Boundary with the Reactor harness* (Part III) and
+[02-ReactorHarness.md](./02-ReactorHarness.md).
 
-### CLI
+### Commands
 
-The CLI package is `@openprose/prose-cli`, version `0.14.0` in the repository
-(`tools/cli/package.json`). It is an Oclif TypeScript package published as the
-`prose` binary. (This is distinct from the `reactor` CLI in
-`packages/reactor-cli/`, which drives the harness and belongs to the Harness doc.)
+There is **no `prose` binary**. `prose …` is a command vocabulary the SKILL
+**embodies in-session**: the user (or an agent) types `prose <verb>` and the
+SKILL-loaded session performs it by mapping to host tools — not a shell-out to an
+installed package. The legacy `@openprose/prose-cli` (an Oclif binary) has been
+removed.
 
-Its two jobs are:
-
-1. Turn user-facing commands into canonical OpenProse prompts for agent
-   harnesses.
-2. Host deterministic local runtime pieces for compile-phase IR, status, and
-   trigger serving.
-
-Current local deterministic commands (the Oclif commands under
-`tools/cli/src/commands/`):
+The served, continuously-reconciled lifecycle for responsibilities — repository-IR
+`compile`, `run`, `serve`, and observability — is delivered by the deterministic
+**`reactor` CLI** (the harness, [02-ReactorHarness.md](./02-ReactorHarness.md)),
+which the skill hands off to via `prose react`. The in-session command vocabulary:
 
 | Command | Role |
 | --- | --- |
-| `prose compile [path] [--out <dir>]` | Forward compile to the harness, then validate the generated IR |
-| `prose serve` | Serve active IR with local cron and HTTP adapters |
-| `prose status` | Read active IR and runtime receipts locally |
-| `prose doctor` | Inspect or install selected provider skill targets |
-
-Current forwarded commands (the agent-prompt model in
-`tools/cli/src/prose/command-model.ts`):
-
-| Command | Role |
-| --- | --- |
-| `prose run <file.prose.md\|package/handle>` | Run a responsibility (served/reconciled) or a called function |
+| `prose run <file.prose.md\|package/handle>` | Run a responsibility or a called function in-session |
+| `prose react "<use case>" [--start]` | Take a standing goal to a running, inspectable Reactor (hands off to the `reactor` CLI) |
 | `prose test <path>` | Execute `kind: test` contracts |
 | `prose lint <file.prose.md>` | Validate source structure and contract consistency |
 | `prose preflight <file.prose.md>` | Check dependencies and `### Environment` without executing |
 | `prose inspect <run-id>` | Inspect a completed run (`std/evals/inspector`) |
-| `prose install [--update]` | Install and pin dependencies |
+| `prose install [--update]` | Install and pin git-native dependencies |
 | `prose examples [name]` | List or run bundled examples |
-| `prose upgrade [--dry-run]` | Migrate legacy source/layout conventions (now including the v0.15.0 kind/section rewrites) |
-| `prose write [request...]` | Generate validated OpenProse source from rough English or pseudo-Prose (backed by `std/ops/prose-author`); non-interactive by default in CLI forwarding |
+| `prose upgrade [--dry-run]` | Migrate legacy source/layout conventions (including the v0.15.0 kind/section rewrites) |
+| `prose write [request...]` | Generate validated OpenProse source from rough English or pseudo-Prose (backed by `std/ops/prose-author`) |
 
-Harness selection uses `--harness` or `PROSE_HARNESS`. The harnesses are
-`codex-sdk`, `claude-sdk`, and `mock` (`tools/cli/src/harnesses/`); `codex-sdk`
-is the default.
-
-`prose serve` loads `dist/manifest.active.json`, validates it, registers local
-cron timers and HTTP routes, exposes a health endpoint, and dispatches accepted
-events into ordinary bounded activations. HTTP triggers return `202 Accepted`
-before long-running agent work completes.
+The host for an in-session `prose run` is the coding agent itself (Codex- or
+Claude-Code-style); there is no harness-selection binary. The served
+`compile → run → serve` lifecycle — its durable continuity loop, HTTP trigger
+surface, and connector ingress — is the Reactor harness's, documented in
+[02-ReactorHarness.md](./02-ReactorHarness.md).
 
 ### Dependencies
 
@@ -766,14 +784,12 @@ make the feedback loop explicit: a run can be inspected, graded against
 contracts, compared across runs, diagnosed, profiled, and used to propose source
 or platform improvements.
 
-**Honest gap:** `packages/std/` and `packages/co/` have **not** been migrated to
-the v0.15.0 vocabulary. Their contracts still declare `kind: service` (≈25 files)
-/ `kind: system` (≈18) and `### Ensures` (across ≈62 files); **no** contract yet
-uses the renamed `kind: function` / `kind: responsibility`. The only non-retired
-kinds present are the unchanged `kind: pattern` (≈19) and `kind: test`. The
-teaching docs and the bundled `examples/` are on the new model, but `std`/`co`
-source still carries the retired vocabulary and is the largest pending migration
-task (Part III §1).
+**Migration status:** `packages/std/` and `packages/co/` are now **migrated** to
+the current vocabulary — **zero** `kind: service`, `kind: system`, or
+`### Ensures` remain. Their contracts use `kind: function` (≈35 files),
+`kind: responsibility`, the unchanged `kind: pattern` (19), and `kind: test`. (`co`
+keeps its on-disk directory names `services/` and `systems/` for path stability,
+even though the contracts inside are migrated.)
 
 ### Company-As-Prose Package
 
@@ -790,15 +806,14 @@ company as an OpenProse-native repository. Current public contracts include:
 | `co/evals/*` | Evaluations for the package contracts |
 
 The package explicitly avoids OpenProse, Inc. private business logic. It is
-generic company-operations scaffolding. Like `std/`, its on-disk paths
-(`services/`, `systems/`) and contracts still use the pre-v0.15.0 vocabulary and
-are pending migration to `function` / `responsibility`.
+generic company-operations scaffolding. Its on-disk directory names (`services/`,
+`systems/`) are kept for path stability, but the contracts inside are migrated to
+the current `function` / `responsibility` vocabulary.
 
 ### Examples
 
 The examples under `skills/open-prose/examples/` are OpenProse Native
-Repositories, and — unlike `std/` and `co/` — they **are migrated** to the
-v0.15.0 vocabulary (their `src/` carries only `kind: function`,
+Repositories on the current vocabulary (their `src/` carries only `kind: function`,
 `kind: responsibility`, and `kind: gateway`; no `service`, no `system`). Each
 uses:
 
@@ -814,9 +829,10 @@ prose.lock
 The shared lifecycle is:
 
 ```bash
-prose compile
-cp dist/manifest.next.json dist/manifest.active.json
-prose serve
+# Embody and run the repository in-session:
+prose run
+# Or hand its standing goal to a durable, served Reactor (the harness):
+prose react "<the repository's standing goal>" --start
 ```
 
 Current standing-goal example repositories include `stargazer-outreach`,
@@ -835,27 +851,27 @@ language feature:
 | --- | --- |
 | `declared-skills` | `### Skills` resolution and the `skill_unresolved` diagnostic |
 | `declared-tools` | `### Tools` resolution and the `tool_unresolved` diagnostic |
-| `auto-pocock` | A non-interactive multi-step responsibility adapting an external skill workflow |
+| `auto-pocock` | A non-interactive multi-step `function` pipeline adapting an external skill workflow |
 | `session-to-prose` | Turning a working session into authored `*.prose.md` source |
-| `flat-tokens` | A Reactor-runtime token-accounting demo (Reactor-harness material, not language material) |
 
 ### Tests And Release
 
-The current repository validates the language surface at several layers
-(`tools/cli/tests/` and the package test suites):
+The current repository validates the language surface at several layers (the
+repo-root `tests/open-prose/` skill suite and the package test suites):
 
 | Layer | Coverage |
 | --- | --- |
-| Command-model tests | Argument validation and the canonical agent-prompt forwarding for each `prose` command |
-| Harness tests | `codex-sdk` / `claude-sdk` / `mock` selection and dispatch |
-| Compile-validation tests | Compile-phase IR shape (topology, canonicalizers, postconditions, contract fingerprints), root resolution, status, serve dispatch |
-| Reactor-runtime tests | Fingerprint comparison, skip/render/propagate, receipt `status` (`rendered`/`skipped`/`failed`), freshness — in `packages/reactor/` (harness material) |
-| CI workflows | CLI release checks, real harness smoke, skill install smoke, OpenProse smoke, plugin manifest validation, release publishing |
+| Skill/spec conformance | `tests/open-prose/` asserts the SKILL docs (contract-markdown, concepts, state, compiler) embody the current model — kinds, sections, the no-judge reconciler, and the world-model state shape |
+| Compile-validation tests | Compile-phase IR shape (topology, canonicalizers, postconditions, contract fingerprints) and root resolution |
+| Reactor-runtime tests | Fingerprint comparison, skip/render/propagate, receipt `status` (`rendered`/`skipped`/`failed`), freshness — in `packages/reactor*/` (harness material) |
+| CI workflows | Skill install smoke, OpenProse smoke, plugin manifest validation, and the reactor package (`reactor-v*`) publish train |
 
-The release process uses one release train: skill metadata, plugin metadata, the
-CLI npm package, package lock, and tarball installer share the same `X.Y.Z`
-version. The protected release workflow verifies CLI/package/plugin surfaces,
-publishes `@openprose/prose-cli`, and creates a GitHub Release.
+The release process uses **independent tracks** (`.version-bump.json`): the
+`skill` track moves the SKILL and both plugin manifests together — `SKILL.md`,
+`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` — because the Claude
+Code marketplace deduplicates by manifest version. The Reactor packages publish on
+their own `reactor-v*` OIDC train. There is **no `prose-cli` release train** (the
+binary was removed).
 
 ### Mental Model
 
@@ -883,8 +899,8 @@ receipt)`:
 
 | Term | Meaning |
 | --- | --- |
-| Activation | One bounded VM render, launched by `prose run` or `prose serve` |
-| Binding | A public declared output artifact |
+| Activation | One bounded VM render, launched in-session by `prose run` or by the Reactor harness (`reactor run` / `serve`) |
+| Binding | A published declared output: the canonical world-model artifact a downstream subscribes to |
 | Canonicalizer | The deterministic lowering of `### Maintains` that maps a world-model to its fingerprints |
 | Contract Markdown | The canonical `*.prose.md` source format |
 | Facet | A `####` part under `### Maintains`: a named, independently-subscribable unit of truth (fingerprint unit + subscription symbol) |
@@ -901,107 +917,101 @@ receipt)`:
 | Receipt | The signed commit object; `status` ∈ {`rendered`, `skipped`, `failed`}; the unit of the append-only ledger |
 | Repository IR | The compile-phase IR (topology + canonicalizers + postconditions + contract fingerprints) consumed by deterministic infrastructure |
 | Responsibility | The headline kind: a standing truth kept current over time, mounted as a DAG node |
-| World-model | A node's maintained truth (the DOM analogue), persisted under `state/responsibilities/{id}/` |
+| World-model | A node's maintained truth (the DOM analogue), persisted under `state/world-model/{node}/` |
 
 ---
 
 ## Part III — What Is Next
 
-The gap between Part I and Part II is now **mostly migration, not invention.**
-The `v0.15.0` "Intelligent React" overhaul already reshaped the taught taxonomy
-to the Ideal (five kinds; the load-bearing `### Requires` / `### Maintains` /
-`### Continuity` sections; facets; the dumb reconciler; receipts with
-`status` ∈ {`rendered`, `skipped`, `failed`}). What remains is **finishing the
-migration across the corpus that the teaching docs already lead**, closing a few
-in-flight SKILL inconsistencies, and shipping the genuine runtime affordances the
-Ideal assumes (which are mostly harness work, surfaced through the language).
-No new `*.prose.md` syntax is owed.
+Part I is now substantially real at the **language layer**. The `v0.15.0`
+"Intelligent React" overhaul reshaped the taught taxonomy to the Ideal (five
+kinds; the load-bearing `### Requires` / `### Maintains` / `### Continuity`
+sections; facets; the dumb reconciler; receipts with `status` ∈ {`rendered`,
+`skipped`, `failed`}), and the corpus migration that once dominated this roadmap
+is **done**: `packages/std/` and `packages/co/` carry **zero** `kind: service`,
+`kind: system`, or `### Ensures`, and the teaching docs (`SKILL.md`,
+`contract-markdown.md`, `concepts/`, `changelog.md`) are on the current model.
+The legacy `prose` CLI binary is gone; the language is embodied by the SKILL
+in-session, and the deterministic-source-compiler fallback it once carried is
+resolved by removal (compilation is model-run, Tenet 2). **No new `*.prose.md`
+syntax is owed.**
 
-### 1. Complete the kind/section migration across the corpus (the central item)
+What remains is not language work but **harness affordances the language already
+describes** — promised by the contract an author writes, delivered by the Reactor
+harness ([02-ReactorHarness.md](./02-ReactorHarness.md)) — plus the one
+language-level recursion the Ideal keeps as its closing item. Each item below is
+scoped to the *residual* gap and cross-linked to the Reactor harness gap cluster
+it closes; the engineering detail lives in 02 Part III.
 
-The teaching docs (`SKILL.md`, `contract-markdown.md`, `concepts/`,
-`changelog.md`) and the bundled `examples/` are on the new model; the largest
-remaining work is everything they reference but that still carries the retired
-vocabulary:
+### 1. Data-driven freshness (the default `valid_until` projector)
 
-- **Migrate `packages/std/` and `packages/co/`.** Their contracts still
-  declare `kind: service` (≈25) / `kind: system` (≈18) and `### Ensures`; **no**
-  contract yet uses `kind: function` / `kind: responsibility` (the only
-  non-retired kinds present are the unchanged `kind: pattern` and `kind: test`).
-  Run the `prose upgrade`
-  kind/section rewrites (the `runtime_contract: 1 → 2` migration map in
-  `changelog.md`) across both packages: `service` → `function`
-  (`### Requires`/`### Ensures` → `### Parameters`/`### Returns`); flatten or
-  split each `system` (a manual-review diagnostic, never auto-guessed);
-  re-home directory names (`co/services/`, `co/systems/`).
-- **Drive the count to zero.** Until `std`/`co` are migrated, an author who
-  composes from them sees both vocabularies side by side. This is the single
-  most visible Part-I/Part-II divergence and the clearest definition-of-done.
+Part I's self-driven continuity — a lapsed `valid_until` mechanically moves a
+facet fingerprint via the self-tick — needs a default projector in the served
+continuity loop. Today that loop (the Reactor's, which `prose react` hands off to)
+runs on a flat poll cadence and arms no per-facet `valid_until` by default, so
+`### Continuity: self-driven` runs at a fixed interval rather than the Ideal's
+"wake exactly when the soonest `valid_until` lapses." The author already writes
+the `valid_until`; the cadence tightens harness-side without a source change.
+(Reactor gap cluster 3 — [02-ReactorHarness.md](./02-ReactorHarness.md) Part III §4.)
 
-### 2. Close the in-flight SKILL inconsistencies
+### 2. The deterministic commit gate, wired
 
-The SKILL is mid-migration and still carries a few stale fragments that should be
-swept to match its own new model:
+`### Maintains` postconditions lower to deterministic validators today
+(`compilePostconditions` runs on the compile path), but the gate that evaluates
+them at commit, `gateCommit`, is built and **unwired** — the live commit rides the
+render's own `### Maintains` self-attestation. The language promises "a render
+that cannot satisfy its postconditions commits nothing"; making that
+deterministic rather than self-attested is harness wiring, not a syntax change.
+(Reactor gap cluster 1 — [02-ReactorHarness.md](./02-ReactorHarness.md) Part III §1.)
 
-- The **"Contract Markdown Sections" example block in `SKILL.md`** still shows
-  `### Ensures` (and a `### Runtime: persist` hint from the retired `### Memory`
-  era). Replace with a `### Requires` / `### Maintains` responsibility or a
-  `### Parameters` / `### Returns` function example, matching `contract-markdown.md`.
-- A few SKILL routing lines still say "service or system" or "inline service";
-  align them to "responsibility or function" and the no-`system` rule already
-  stated in the Format Detection section.
-- The `### Tools` "required even when `(none)`" rule and the `id:` Crockford
-  base32 format should be stated once, consistently, across `SKILL.md`,
-  `contract-markdown.md`, and `changelog.md`.
+### 3. The failed-receipt reason (durable receipt shape)
 
-### 3. Ship the runtime affordances the Ideal assumes
+The language promises a `failed` receipt "addressed to the author, naming exactly
+what it needs." The shipped v0 receipt is too thin to carry that — no `as_of`, no
+failure `reason`, no author-addressing field — so the naming is honored only
+in-render and dropped at commit. Widening the durable receipt is harness work the
+language's failed-receipt promise depends on. (Reactor gap cluster 2 —
+[02-ReactorHarness.md](./02-ReactorHarness.md) Part III §2.)
 
-These are real deferrals — the language describes them, but they are not yet
-fully shipped. Most are harness work surfaced through the language:
+### 4. The actuation boundary, enforced
 
-- **Default `valid_until` freshness projector for `serve`.** Part I's
-  data-driven freshness (a lapsed `valid_until` mechanically moves a facet
-  fingerprint via the self-tick) needs a default projector in the continuity loop;
-  today that loop (which `prose serve` delegates to `@openprose/reactor`) runs on a
-  fixed poll cadence and does not yet read per-facet `valid_until`. Until it lands,
-  `### Continuity: self-driven` runs on a flat cadence, not the Ideal's "wake
-  exactly when the soonest `valid_until` lapses."
-- **Adaptive serve cadence.** With the freshness projector, `serve` should sleep
-  until the soonest armed recheck instead of a fixed poll cadence (the flat
-  `--poll-interval` is the `reactor serve` flag, not a `prose serve` flag), so a
-  quiet system is genuinely idle.
-- **Facet inference.** Facets are declared today (`####` under `### Maintains`).
-  Inferring a reasonable facet split from an undivided `### Maintains` (so authors
-  get subscription granularity without hand-faceting) is future compiler work;
-  the atomic default is correct but coarse until then.
-- **Cryptographic byte-hash signer.** The receipt's `sig` is a v1 meaning-layer
-  attestation and the `signer` is an explicit null state (chain-consistency, not
-  a cryptographic byte-hash). A real signing identity and byte-hash chain are
-  deferred.
-- **Ledger compaction.** The per-node receipt ledger is append-only and grows
-  without bound; compaction / snapshotting of `state/responsibilities/{id}/` is
-  not yet specified.
-- **Live serve adapters beyond cron + HTTP.** Queues, file watches, provider
-  subscription setup, and webhook auth remain later phases (per
-  `responsibility-runtime.md`).
+`### Invariants` declares the rate/scope/prohibited-action bounds on a render's
+world-mutation. Today that boundary is authored prose the render may ignore —
+never lowered or harness-enforced. Lowering it into the render (with an actuation
+sink) makes "the only writable surface is the published truth" a guarantee rather
+than a request. (Reactor gap cluster 3 —
+[02-ReactorHarness.md](./02-ReactorHarness.md) Part III §3.)
 
-### 4. The fixpoint (topology-as-responsibility)
+### 5. Facet inference
+
+Facets are author-declared today (`####` parts under `### Maintains`). Inferring a
+reasonable facet split from an undivided `### Maintains` — so authors get
+subscription granularity without hand-faceting — is deferred compile-phase work;
+the atomic default is correct but coarse until then.
+
+### 6. Richer served ingress
+
+A served responsibility's wake sources beyond local cron-poll and HTTP — queues,
+file watches, provider subscription setup, and webhook authentication — are later
+harness phases. Until they land, a file-watch-shaped contract is authored as a
+poll `### Continuity` with the intended ingress noted, so it migrates cleanly.
+
+### 7. Cross-trust composition (the cryptographic signer)
+
+`### Requires` can pin a consumed revision today, but the acceptable-signer-set
+half of cross-trust composition waits on a real signing identity: the receipt's
+`sig` is a meaning-layer attestation over a null signer, not a cryptographic
+byte-hash chain. A signing adapter and byte-hash chain are deferred. (Reactor gap
+cluster 3 — [02-ReactorHarness.md](./02-ReactorHarness.md) Part III §5.)
+
+### 8. The fixpoint (topology-as-responsibility)
 
 Part I keeps, as its closing recursion, the **fixpoint**: wiring the graph is
 itself a maintained truth, so Forme is a `kind: responsibility` whose world-model
 is the resolved DAG and whose render is the wiring step — memoized like any node,
 bootstrapped by a tiny deterministic seed. Today Forme is a compile-phase render
-that produces the topology, but it is not yet *mounted as a node in the graph it
-draws*. Closing the loop (topology-as-responsibility) is explicitly **post-v1**.
-
-### 5. The deterministic compiler fallback
-
-The `prose` CLI carries a deterministic TypeScript source-compiler
-(`tools/cli/src/prose/repository-source-compiler.ts`) used as a validating
-fallback when the harness produces no manifest. The Ideal commits compilation to
-be model-run (Tenet 2). Resolving whether this fallback is reframed as a
-*structural validator only* or acknowledged as a permitted, semantics-free
-mechanical lowering is open roadmap work.
+that produces the topology but is not yet *mounted as a node in the graph it
+draws*. Closing the loop is explicitly **post-v1**.
 
 ### Boundary with the Reactor harness
 
@@ -1009,21 +1019,27 @@ The language has one source-derived compile: `prose compile` (source →
 compile-phase IR). The IR is a function of the `*.prose.md` source set and
 nothing else. The harness's token-truth receipts, forecasts, freshness state, and
 reconciler decisions are **sibling runtime state owned by `@openprose/reactor`** —
-not IR fields and not new `*.prose.md` syntax. The `--harness`
-(`codex-sdk`/`claude-sdk`/`mock`) surface is a bounded-activation SDK adapter and
-carries no reconciler control logic. The full runtime mechanics live in
+not IR fields and not new `*.prose.md` syntax. The render seam (a
+bounded-activation agent SDK adapter over a model gateway) carries no reconciler
+control logic. The full runtime mechanics live in
 [02-ReactorHarness.md](./02-ReactorHarness.md); this disclaimer is the language
 side of that seam.
 
 ### Definition of done for the language layer
 
-- `packages/std/` and `packages/co/` are migrated to `function` /
-  `responsibility` / `### Maintains`; no retired-vocabulary contract remains in
-  the bundled corpus.
-- The remaining stale SKILL fragments (the `### Ensures` example block, the
-  "service or system" routing lines) are swept to the new model.
-- The default `valid_until` freshness projector and adaptive `serve` cadence
-  ship, so self-driven continuity is data-driven rather than fixed-interval.
-- The deterministic-compiler-fallback question is resolved one way or the other.
+The corpus migration and the SKILL sweep that headlined earlier roadmaps are
+**done** (std/co and the teaching docs carry zero retired vocabulary). What
+remains is the harness delivering the language's standing promises:
+
+- The default `valid_until` freshness projector and adaptive serve cadence ship,
+  so self-driven continuity is data-driven rather than fixed-interval.
+- `gateCommit`'s deterministic validators are wired onto the live commit step, so
+  "a render that cannot satisfy its postconditions commits nothing" is enforced,
+  not only self-attested.
+- The durable receipt carries `as_of`, a failure `reason`, and an
+  author-addressing field, so the failed-receipt-that-names-the-gap survives
+  commit.
+- The `### Invariants` actuation boundary is lowered and enforced at the
+  render/commit split.
 - No new `*.prose.md` syntax is introduced; the fixpoint remains the explicitly
   labeled post-v1 recursion.

--- a/spec/02-ReactorHarness.md
+++ b/spec/02-ReactorHarness.md
@@ -6,7 +6,7 @@ The OpenProse corpus divides labor exactly, and each document maps to what
 ships:
 
 - [01-Language.md](./01-Language.md) — **the Language & Framework**, bundled as
-  the **SKILL**: syntax, kinds, sections, compile model, std/co, CLI surface.
+  the **SKILL**: syntax, kinds, sections, compile model, std/co.
 - [02-ReactorHarness.md](./02-ReactorHarness.md) — **this
   document, the Reactor Harness**, bundled as the **CLI/Server**: the runtime
   control architecture — the loop, invariants, the reconciler, memoization, forecast,
@@ -42,14 +42,16 @@ Start from the lived loop, not the machinery. The architecture is the
 consequence of this promise, not the thing itself.
 
 > You write one sentence of durable intent and what makes it true. Then you
-> walk away — there is no session to babysit. The system interrupts you on
+> walk away — there is no session to babysit. The system needs you back on
 > exactly two conditions: it needs a judgment only a human can make, or an
-> input or permission only you can grant. Otherwise it is silent. Everything it
+> input or permission only you can grant. On either it stops and files a
+> `failed` receipt — addressed to you, naming exactly what it needs — for you to
+> pull; otherwise it is silent. Everything it
 > did, you can verify afterward from a trail you never had to ask for — and you
 > can take that trail and that sentence and run them somewhere else.
 
-Four beats: **author**, **walk away**, **interrupted only when genuinely
-needed**, **verifiable and exitable trail**.
+Four beats: **author**, **walk away**, **back only when genuinely needed**,
+**verifiable and exitable trail**.
 
 One honesty note belongs in the promise itself: interruptions **front-load
 during authoring and asymptote toward silence**. "Walk away" is the steady
@@ -85,9 +87,10 @@ an upstream node's new receipt, or a freshness lapse.
 
 ```text
 event (a receipt arrives)
-  -> the reconciler compares (contract_fingerprint, input_fingerprints)
+  -> the reconciler compares (contract_fingerprint, input_fingerprints, freshness_epoch)
   -> unmoved: write a cheap `skipped` receipt, render nothing
-  -> moved: spawn one bounded render session -> gateCommit -> sign a receipt
+  -> moved (an input changed, the contract changed, or a freshness window lapsed):
+       spawn one bounded render session -> gateCommit -> sign a receipt
   -> propagate: a moved fingerprint wakes the downstream subscribers
 ```
 
@@ -122,7 +125,7 @@ transition.
 The loop above is the **base case**. The full architecture is one mechanism
 applied recursively:
 
-> **A render is a pure step `(contract, evidence, prior world-model) → (new
+> **A render is a single step `(contract, evidence, prior world-model) → (new
 > world-model, signed receipt)`. Everything else — composition, freshness, even
 > the topology itself — is that same render, applied again.**
 
@@ -177,7 +180,7 @@ auditable and replayable like any other run. The output is a static IR consumed
 and validated by deterministic code: **the language is never on the execution or
 safety path** — a model authors the IR, code validates it, and the dumb
 reconciler executes it. This is the same safe pattern throughout: a model
-authors, the CLI validates, the reconciler runs.
+authors, deterministic code validates, the reconciler runs.
 
 Compile re-fires only when the **contract-set fingerprint** moves — an author
 changed intent. A quiet contract set compiles zero times for as long as it stays
@@ -200,7 +203,7 @@ ordered by how much they save:
 
 1. **Don't act.** Nothing the node subscribes to moved, so it writes a cheap
    `skipped` receipt and renders nothing. The trivial case.
-2. **Don't check now.** each self-driven facet carries a `valid_until`;
+2. **Don't check now.** Each self-driven facet carries a `valid_until`;
    until the soonest one lapses, the node sleeps. Provable quiescence is genuinely
    zero tokens on a static world. (= don't re-render until a dependency changes or freshness
    lapses.)
@@ -209,21 +212,31 @@ ordered by how much they save:
    changed region, not the tree.)
 
 The rigorous core is **memoization**: a render is keyed by
-`(contract_fingerprint, input_fingerprints)` — the node's own contract plus the
-fingerprints of every facet it subscribes to. Unchanged key → the render is
-skipped at zero token cost, `React.memo` semantics applied to a bounded LLM
-session. The key contains **nothing else**: no judge verdict, no policy artifact,
-no confidence score. What "counts as a change" was decided once, at compile, by
-the canonicalizer; the run phase only compares.
+`(contract_fingerprint, input_fingerprints, freshness_epoch)` — the node's own
+contract, the fingerprints of every facet it subscribes to, and the freshness
+epoch that advances when a declared `valid_until` lapses (see *The missing-webhook
+problem*). A node that declares no facets exposes one always-on whole-truth
+token, and a consumer whose `### Requires` names that producer *without* a facet
+binds to that token — waking on the OR of every facet. Unchanged key → the
+render is skipped at zero token cost, `React.memo`
+semantics applied to a bounded LLM session. The key contains **nothing judged**:
+no judge verdict, no policy artifact, no confidence score — its three parts are
+the contract, the subscribed inputs, and time, nothing more. What "counts as a
+change" was decided once, at compile, by the canonicalizer; the run phase only
+compares. (The shipped v1 SDK realizes the freshness term as a forecast-driven
+self-receipt over a two-part `(contract_fp, input_fps)` key rather than a literal
+third element — Part II; the decision semantics are identical.)
 
 **Completeness is a compile-time property, not a runtime audit.** A memo key is
 only safe if it captures every input that could change the truth — the classic
 cache-invalidation trap, whose failure is silent (confident staleness). OpenProse
-makes the key complete *by construction*: the canonicalizer fixes, at compile
-time, exactly which fields are material and which facets a node subscribes to. A
-render never improvises a new dependency mid-run, so the key cannot drift out of
-completeness between compiles; discovering a genuinely new dependency is an
-authoring change that re-compiles the contract. There is no roaming judge and no
+makes the key complete *relative to the declared material set*: the canonicalizer
+fixes, at compile time, exactly which fields are material and which facets a node
+subscribes to. A render never improvises a new dependency mid-run, so the key
+cannot drift out of completeness *between compiles* — an under-declared dependency
+stays silently stale until an author notices and re-compiles, but the key never
+degrades on its own. Discovering a genuinely new dependency is an authoring change
+that re-compiles the contract. There is no roaming judge and no
 second "plan-age" clock to police — the completeness guarantee is the
 canonicalizer's, frozen ahead of time.
 
@@ -232,10 +245,11 @@ Memoizing on an input fingerprint means the system could quiesce confidently
 while the world changed silently because no event fired. The defense is freshness:
 a node declares, in `### Continuity`, that a facet stays valid only until some
 `valid_until`. When that instant passes, the harness does not call a model to ask
-whether time elapsed — it **mechanically moves that facet's fingerprint** and
-wakes the node through the ordinary reconcile path, emitting a zero-token
-self-receipt. The lapse *is* a fingerprint move, so "the world will not announce
-it changed" becomes an ordinary wake. Forecast's job is exactly this: manufacture
+whether time elapsed — it **mechanically advances the node's freshness epoch**
+(and, for a *consumed* upstream facet whose window lapsed, moves that facet's
+input fingerprint) and wakes the node through the ordinary reconcile path,
+emitting a zero-token self-receipt. The lapse *is* a memo-key move, so "the world
+will not announce it changed" becomes an ordinary wake. Forecast's job is exactly this: manufacture
 the minimum necessary re-render when no external event will. That is what makes
 silence *safe* rather than *negligent*.
 
@@ -266,9 +280,9 @@ are design defaults and live in **Architecture**, not here.
      "I don't know when"; freshness is "I computed when." Where a source cannot
      push, polling is pushed to a gateway adapter and is itself freshness-paced,
      never a heartbeat.
-   - **Memoization is real.** Unchanged input fingerprint → the render body
-     provably never runs, recoverable from the `tokens.fresh` vs `tokens.reused`
-     split in the receipt.
+   - **Memoization is real.** Unchanged memo key → the render body provably
+     never runs, recoverable from the `tokens.fresh` vs `tokens.reused` split in
+     the receipt.
    - **Every token traces to a named surprise** ∈ {a subscribed input moved, a
      declared freshness window lapsed, the contract itself changed}. A `skipped`
      receipt carries zero cost and copies its fingerprints forward, so the proof
@@ -279,8 +293,13 @@ are design defaults and live in **Architecture**, not here.
    `### Maintains` obligations where it is semantic. A render that fails commits
    nothing: the prior truth stands, no downstream wakes, and a `failed` receipt
    records why. There is no judge and no confidence score in the commit decision.
-   Negate it and an inadmissible render can corrupt the maintained truth — the
-   class's safety claim is void.
+   The hard guarantee — an inadmissible render cannot corrupt the truth — is the
+   **deterministic** validators'; where an obligation is only semantic, the
+   render's self-attestation is a *soft* gate (the render attesting its own
+   `### Maintains` obligations), and how honestly a
+   model attests is a model-choice property measured offline, not a runtime
+   guarantee. Negate the deterministic gate and an inadmissible render can corrupt
+   the maintained truth — the class's correctness guarantee is void.
 7. **Receipts are content-addressed.** Consumers verify evidence instead of
    trusting the producer's claim. The receipt is simultaneously the audit unit, the
    composition unit, and the exit unit. Negate it and Tenets 5 and 6 break at
@@ -299,15 +318,20 @@ not as a class-defining invariant.
 
 ### Precedence stack
 
-When invariants tension, this ordering decides:
+Correctness is the non-negotiable floor (Tenets 1, 2, and 5, realized at compile
+and the commit gate). Below it, when invariants tension over the
+safety → cost → silence trade-offs, this ordering decides:
 
 ```text
 correctness  >  safety  >  cost  >  interrupt-minimization
 ```
 
+It is the operational projection of the numbered tenet precedence
+([00-Tenets.md](./00-Tenets.md)), not a separate runtime policy dial that
+resolves every invariant collision on its own.
 Interrupt-minimization is a downstream ergonomic property, not a pillar. If
 minimizing interrupts ever conflicts with failing safe, safety wins — the
-system interrupts even though it would rather be silent. "Rare interruption" is
+system surfaces the need even though it would rather be silent. "Rare interruption" is
 a target, not a constraint other invariants bend around.
 
 ### Architecture
@@ -342,15 +366,17 @@ Renders interpret and act inside bounded activations.
 The reconciler skips or renders; gateCommit attests; receipts record.
 ```
 
-**Two adapter seams, never merged.** The bounded-activation **agent SDK**
-(`codex-sdk`, `claude-sdk`, …) is an adapter and nothing more: no reconciler
-logic ever lives inside it — memoization, the commit gate, and the continuity
-clock are the package's, not the activation runtime's. Distinct from it is the
+**Two adapter seams, never merged.** The bounded-activation **agent SDK** (the
+host-supplied agent runner, e.g. `@openai/agents`) is an adapter and nothing more:
+no reconciler logic ever lives inside it — memoization, the commit gate, and the
+continuity clock are the package's, not the activation runtime's. Distinct from it is the
 **model-gateway socket** (OpenRouter as the batteries-included default; direct
 Anthropic/OpenAI first-class), which serves raw multi-provider inference — the
 *inference substrate* that compile sessions and renders draw on. Keeping the two
 seams separate is invariant 3 doing load-bearing work: a clone and a long-lived
-deployment differ only by which adapters they bind.
+deployment differ only by which adapters they bind. These two seams are how a host
+realizes the abstract `spawn_session` / inference primitives the Language doc's
+*Prose Complete* table names ([01-Language.md](./01-Language.md)).
 
 **Failure surfaces as a receipt, not a status enum.** There is no
 `up`/`drifting`/`down`/`blocked` status and no pressure projection. A render that
@@ -360,9 +386,12 @@ not yet decidable — there is nothing observable to maintain against" surfaces 
 same way: a `failed` render whose receipt names the gap, routed to the contract
 author (Tenet 2). This is the flagship instance of "surface what only a human can
 decide," realized as an honest receipt rather than a typed runtime interrupt
-class. Richer human-facing interrupts — a typed `needs-input` for a missing
-credential, or `contract-declared` paging the author asked for — are a future
-affordance layered on the same receipt, not a v1 runtime decision class.
+class. Even the human-facing signal stays a *pull*: a `needs-input` for a missing
+credential or a `contract-declared` flag the author asked for is a **reason on
+the same receipt**, surfaced in the trail for the author to pull — never a fourth
+runtime decision class, and never a push the harness owns. Active out-of-band
+delivery (paging, email) is a notification layer someone may build *over* the
+trail, outside this promise.
 
 ### Failure model
 
@@ -424,7 +453,7 @@ the _rigorous_ model, with literal mappings:
 | the render function | a bounded LLM session that computes the next world-model |
 | props | subscriptions (`### Requires` ↔ `### Maintains`) |
 | setState | a new signed receipt (the world-model moved) |
-| React.memo / dependency array | skip the render when `(contract_fp, input_fps)` is unmoved |
+| React.memo / dependency array | skip the render when `(contract_fp, input_fps, freshness_epoch)` is unmoved |
 | the commit phase | sign the receipt, persist the world-model, notify subscribers |
 | partial reconciliation | quiescence; only the changed subtree re-renders |
 | composition / lifting state up | responsibilities consuming each other's receipts |
@@ -450,10 +479,16 @@ dimension. Three seams are where they meet, stated as resolution rules:
    but the reconciler's *decision* stays pure: it reads only fingerprints.
    World-mutation is quarantined inside the bounded render, and only the
    canonicalized published truth re-enters the memo key — so the dumb compare
-   never depends on a side effect.
+   never depends on a side effect. The author bounds that actuation in
+   `### Invariants` — the rate, scope, and prohibited actions the render may not
+   exceed — which the harness lowers and enforces as the render's actuation
+   quarantine. (Today that boundary is authored but not yet lowered — see Part II
+   gap cluster 3.)
 3. **Synchronous tree vs. asynchronous world.** A render's output is always
    `as_of` a timestamp, never "now." Every receipt carries `as_of`; that is where
-   control-systems time-awareness patches React's frozen-tree assumption.
+   control-systems time-awareness patches React's frozen-tree assumption. (The
+   shipped v0 receipt does not yet carry an `as_of` field — Part II gap
+   cluster 2.)
 
 ### Composition
 
@@ -499,40 +534,44 @@ Three genuine collisions, with their resolutions:
 Deferred by design — named here so they are tracked, not invented or silently
 dropped:
 
-1. **Receipt schema — the as-built `v0` shape.** Every decision writes a
+1. **Receipt schema.** Every decision writes a
    content-addressed receipt: the `node`, its `contract_fingerprint`, the `wake`
    (`source ∈ {input, self, external}` plus the upstream `refs` that caused it),
+   an `as_of` timestamp (the instant the truth is asserted as-of, never "now"),
    the `input_fingerprints` it depended on, the per-facet `fingerprints` it
-   produced, a `status ∈ {rendered, skipped, failed}`, the `prev` link that makes
+   produced, a `status ∈ {rendered, skipped, failed}` carrying — on a `failed`
+   receipt — a `reason` that names exactly what the render could not satisfy and
+   the author it is addressed to, the `prev` link that makes
    the per-node chain verifiable, and a `cost` block (`provider`, `model`,
    `tokens.fresh` vs `tokens.reused`, `surprise_cause`) that makes the
    cost-scales-with-surprise and memoization proofs recoverable from a single
    receipt. A `sig` block where `scheme: "none"` carries a `null_reason` is a
    first-class, non-deceptive state. There is **no** `verdict`, no confidence or
    calibration grade, no `role` enum, and no `judge`/`policy-compile` cause —
-   those were retired with the judge. The ledger is an append-only, flat
-   `<state-dir>/receipts.json`.
-2. **The cryptographic signer.** v1 "signed" means tamper-evident at the meaning
-   layer and chain-consistent — *not* yet a cryptographic byte hash. The null
-   signer is the only honest v1 state; a real signing adapter (and the byte hash
-   that makes cross-boundary trust non-repudiable) is a named, deferred
-   milestone. The composition pinning surface (contract revision + acceptable
-   signer set) is specified ahead of it.
+   those were retired with the judge. The ledger is append-only and
+   chain-verifiable. (The shipped v0 receipt is thinner — it carries no `as_of`,
+   no failure `reason`, and no author-addressing field, and persists to a flat
+   `<state-dir>/receipts.json`; that delta is Part II gap cluster 2.)
+2. **The cryptographic signer.** A cryptographic byte-hash signer — binding the
+   published world-model to its receipt so cross-boundary trust is
+   non-repudiable — and the composition pinning surface it backs (contract
+   revision + acceptable signer set) are specified here and deferred. (Part II is
+   honest about the shipped state: v1 "signed" is meaning-layer chain-consistency
+   over a null signer, not yet a byte hash.)
 3. **Ledger compaction.** The receipt ledger grows without bound; an external
    compaction/indexing plan for long-running responsibilities is named roadmap,
    not shipped.
-4. **Facet inference.** Authors declare facets explicitly today (`####` parts
-   under `### Maintains`). Inferring a good facet split from a contract —
-   proposing the material/immaterial boundary — is a v-next compile-phase
-   enhancement, not v1.
+4. **Facet inference.** Facets are author-declared (`####` parts under
+   `### Maintains`). Inferring a good facet split from a contract — proposing the
+   material/immaterial boundary — is a deferred compile-phase enhancement.
 5. **The fixpoint.** The topology-as-responsibility recursion (*The unification
    thesis*) — the system maintaining its own wiring as just another memoized
    render, with epoch rollover when the contract set changes — is specified and
    deferred past v1.
-6. **Default freshness derivation.** A `serve` default that reconstructs each
+6. **Default freshness derivation.** A serve default that reconstructs each
    node's freshness schedule from a `valid_until` convention in published truth —
-   so the common case self-paces with zero per-project wiring — is specified; v1
-   ships a fixed `--poll-interval` cadence and the default projector is deferred.
+   so the common case self-paces with zero per-project wiring — is specified and
+   deferred. (Part II carries the shipped fixed-interval cadence shortfall.)
 
 ### Where it excels
 
@@ -592,11 +631,45 @@ actually changed. Additional worked examples are catalogued in Part II.
 
 ## II. What Exists Today
 
-This section is the conformance ledger: what `@openprose/reactor` (the SDK,
-v0.2.0) and `@openprose/reactor-cli` (the `reactor` binary, v0.1.0) physically
-ship today, measured against Part I and honest about what is partial or not yet
-wired. The companion keyless replay viewer `@openprose/reactor-devtools`
-(v0.1.0) ships alongside.
+This section measures the shipped harness against Part I as a **delta from a
+substantially-realized architecture** — not a gap inventory against vaporware.
+The load-bearing core is real and exact: `@openprose/reactor` (the SDK, v0.3.1)
+and `@openprose/reactor-cli` (the `reactor` binary, v0.2.2) ship the judge-free
+decision spine end to end — the 2-tuple memo reconcile, real memoization with
+zero-token `skipped` receipts, the model-free content-addressed canonicalizer
+with its mandatory always-on `@atomic` facet, bounded one-render-one-world-model
+activations, the facet-bound acyclic Forme DAG, no-new-primitive composition with
+diamond coalescing, the published/private world-model split, content-addressed
+independently-verifiable v0 receipts, and the surprise-attributed cost ledger.
+The companion keyless replay viewer `@openprose/reactor-devtools` (v0.2.0) ships
+alongside, and all three packages are published on npm.
+
+Where reality falls short of Part I it clusters on **three seams**, and the rest
+of this section is honest about each:
+
+1. **The deterministic enforcement layer is built but unwired.**
+   `compilePostconditions(...)` runs on the compile path and emits each node's
+   validator set into the IR — but the gate that would *evaluate* it,
+   `gateCommit(...)`, has **zero non-test callers**: the live run path does not
+   consult postconditions on commit (`packages/reactor/src/sdk/run-project.ts`),
+   so the commit decision rides the render's own coarse done/failed
+   self-attestation of `### Maintains`. The "an inadmissible render cannot corrupt
+   the truth" guarantee (Invariant 6) is aspirational until the compiled
+   validators are threaded onto the commit step.
+2. **The durable receipt is too thin to carry the promises pinned to it.** The
+   exact-keyed v0 `Receipt` shape (`packages/reactor/src/shapes/index.ts`) has no
+   `as_of`, no failure `reason`, and no author-addressing field — so the
+   failed-receipt-that-names-the-gap (Part I's "files a `failed` receipt …
+   naming exactly what it needs"), per-receipt `as_of` (the seam-3 fix), and
+   ask-a-human routing are honored only ephemerally in-render and dropped at
+   commit.
+3. **The world-mutating / freshness / cross-trust halves are deferred.**
+   `### Invariants` is never lowered into the render (the authored
+   rate/scope/prohibited-action quarantine survives only as prose the model may
+   ignore); the serve daemon's freshness clock arms nothing by default (so it
+   does the fixed-interval work Part I forbids); cost is observed, not budgeted;
+   and the topology edge pins a revision but no acceptable-signer-set — all gated
+   behind the honestly-deferred null signer.
 
 **The retired judge/policy spine is gone, not current.** The earlier
 `@openprose/responsibility` package — with its judge, verdict/status enum,
@@ -615,9 +688,9 @@ recovery) — never as a policy core being extended.
 
 | Surface           | What Exists                                                                                                                                                                          |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SDK core          | `@openprose/reactor` v0.2.0 — the headless, zero-runtime-dependency reconciler, world-model store, canonicalizer, postcondition `gateCommit`, receipt ledger, forecast/freshness bridge |
-| CLI               | `@openprose/reactor-cli` v0.1.0 — the `reactor` binary: `init`, `doctor`, `compile`, `run`, `serve`, `trigger`, `status`, `topology`, `inspect`, `logs`, `trace`, `receipts`            |
-| Replay viewer     | `@openprose/reactor-devtools` v0.1.0 — keyless offline receipt-ledger replay (`--describe` headless summary + browser graph)                                                            |
+| SDK core          | `@openprose/reactor` v0.3.1 — the headless, zero-runtime-dependency reconciler, world-model store, canonicalizer, postcondition `gateCommit`, receipt ledger, forecast/freshness bridge |
+| CLI               | `@openprose/reactor-cli` v0.2.2 — the `reactor` binary: thirteen commands — `init`, `doctor`, `compile`, `run`, `serve`, `trigger`, `status`, `topology`, `inspect`, `logs`, `trace`, `receipts`, `telemetry` |
+| Replay viewer     | `@openprose/reactor-devtools` v0.2.0 — keyless offline receipt-ledger replay (`--describe` headless summary + browser graph)                                                            |
 | Contract kinds    | `responsibility`, `function`, `gateway`, `pattern`, `test` (authored in `*.prose.md`); compiled by intelligent sessions, never a `.prose` parser                                        |
 | State layout      | a `<state-dir>` (default `./.reactor`): flat `receipts.json`, `world-models/<node>/published.json`, and a content-addressed `compile/` IR cache                                         |
 | Render seam       | the bounded-activation agent SDK adapter (host-supplied `@openai/agents`) over a model gateway (OpenRouter default); the live render needs a key, every observability command is keyless         |
@@ -631,10 +704,11 @@ replay offline.
 ### Responsibility Catalog
 
 These worked examples were moved out of Part I (one example is enough to teach
-the thesis) but remain a useful catalog. The two scaffolded contracts ship today
-as runnable CLI examples (`examples/quickstart`, `examples/gateway-connector`);
-the rest are authoring targets phrased in the current section vocabulary
-(`### Goal` / `### Requires` / `### Maintains` / `### Continuity`).
+the thesis) but remain a useful catalog. The three scaffolded contracts ship
+today as runnable CLI examples (`examples/agent-observatory`,
+`examples/gateway-connector`, `examples/quickstart`); the rest are authoring
+targets phrased in the current section vocabulary (`### Goal` / `### Requires` /
+`### Maintains` / `### Continuity`).
 
 - **Release readiness** — `### Goal:` the release candidate is ready to ship;
   `### Continuity` wakes before every planned release and when release evidence
@@ -653,57 +727,68 @@ the rest are authoring targets phrased in the current section vocabulary
 
 ### The SDK: `@openprose/reactor`
 
-`@openprose/reactor` v0.2.0 is the **headless, zero-runtime-dependency SDK core**
+`@openprose/reactor` v0.3.1 is the **headless, zero-runtime-dependency SDK core**
 — the reconciler, the receipt ledger, the world-model store, and the
 compile/render seams. It installs no provider, no key, and no UI; the live render
 needs two host-supplied deps (`@openai/agents`, `zod`), while the
-inspection/replay surface needs neither. It exposes deterministic, content-addressed building blocks
-through typed subpaths (verified against `package.json` exports):
+inspection/replay surface needs neither. The published `exports` map is **seven**
+entries: `.` (the root barrel re-exporting the building blocks), `./agents` (the
+compile + render agent adapters), `./adapters` (storage + connector seams),
+`./run` and `./run/types` (the reconcile loop and its types), `./internals` (the
+lower-level building blocks), and `./package.json`. The deterministic,
+content-addressed pieces those entrypoints expose live as internal `src/` modules
+— located below by path, reachable through the root barrel and `./internals`, and
+**not** each a separately-published subpath:
 
-| Subpath                          | Ships                                                                                                                     |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `@openprose/reactor/reactor` *   | the **dumb reconciler** — memo/skip → schedule (single-flight + dirty-coalescing) → commit → propagate; no judge step      |
-| `@openprose/reactor/canonicalizer` | the per-node compiled fingerprint function over `### Maintains`; re-lowered keylessly from a serializable spec at mount    |
-| `@openprose/reactor/forme`       | the topology render — `### Requires` ↔ `### Maintains` wiring with diagnostics and an acyclicity postcondition             |
-| `@openprose/reactor/postcondition` * | `compilePostconditions(...)` + `gateCommit(...)` — deterministic validators + the render's `### Maintains` self-attestation |
-| `@openprose/reactor/receipt`     | receipt v0 build/verify/inspect; status `{rendered, skipped, failed}`; `verifyReceipt` + `verifyReceiptChain` check a receipt and the ledger chain |
-| `@openprose/reactor/world-model` | the content-addressed store with the published-truth / private-workspace split (`fs-store`, `store`, `canonical`)          |
-| `@openprose/reactor/memo`        | the `(contract_fingerprint, input_fingerprints)` memo key — and nothing else                                              |
-| `@openprose/reactor/forecast`    | self-driven `### Continuity`: a lapsed `valid_until` mechanically moves a facet fingerprint and wakes the node (zero-token) |
-| `@openprose/reactor/composition` | the read-isolation pin — a content-addressed snapshot of each consumed upstream facet (the dependency = evidence graph)    |
-| `@openprose/reactor/cost`        | token-truth: `tokens.fresh` vs `tokens.reused` + `surprise_cause`                                                          |
-| `@openprose/reactor/projection`  | tiered receipt-proof projection (owner / subscriber / public) that keeps private payload fields out of lower-trust views   |
-| `@openprose/reactor/sdk`         | `createReactor` + `run-project` — mount a DAG, drive wakes, read dispositions                                              |
-| `@openprose/reactor/adapters/*`  | the two seams: `agent-compile` (compile sessions → IR), `agent-render` (bounded render); plus fs/memory storage, connectors |
+| Module (`src/…`)       | Ships                                                                                                                     |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `reactor/`             | the **dumb reconciler** — memo/skip → schedule (single-flight + dirty-coalescing) → commit → propagate; no judge step      |
+| `canonicalizer/`       | the per-node compiled fingerprint function over `### Maintains`; re-lowered keylessly from a serializable spec at mount    |
+| `forme/`               | the topology render — `### Requires` ↔ `### Maintains` wiring with diagnostics and an acyclicity postcondition             |
+| `postcondition/`       | `compilePostconditions(...)` + `gateCommit(...)` — deterministic validators + the render's `### Maintains` self-attestation (built and tested; **not yet called on the live commit path** — see below) |
+| `receipt/`             | receipt v0 build/verify/inspect; status `{rendered, skipped, failed}`; `verifyReceipt` + `verifyReceiptChain` check a receipt and the ledger chain |
+| `world-model/`         | the content-addressed store with the published-truth / private-workspace split (`fs-store`, `store`, `canonical`)          |
+| `memo/`                | the `(contract_fingerprint, input_fingerprints)` memo key — and nothing else                                              |
+| `forecast/`            | self-driven `### Continuity`: a lapsed `valid_until` mechanically moves a facet fingerprint and wakes the node (zero-token) |
+| `composition/`         | the read-isolation pin — a content-addressed snapshot of each consumed upstream facet (the dependency = evidence graph)    |
+| `cost/`                | token-truth: `tokens.fresh` vs `tokens.reused` + `surprise_cause`                                                          |
+| `projection/`          | tiered receipt-proof projection (owner / subscriber / public) that keeps private payload fields out of lower-trust views   |
+| `sdk/`, `run/`         | `createReactor` + `run-project` — mount a DAG, drive wakes, read dispositions                                              |
+| `adapters/`            | the two seams: `agent-compile` (compile sessions → IR), `agent-render` (bounded render); plus fs/memory storage, connectors |
 
-\* The `reactor` and `postcondition` modules are internal-by-subpath today
-(barrels under `src/`, not in the published `exports` map); the table names them
-to locate the shipped behavior. The `exports` map itself publishes **fifteen**
-subpaths: the non-starred rows above (with `adapters/*` covering both
-`agent-compile` and `agent-render`), plus the root `.`, `./run-project`, and
-`./evidence-plan` (not separately tabled). `reactor` and `postcondition` are
-**not** among them.
+The `exports` map deliberately keeps the published surface small while the
+building blocks above stay reachable through the root barrel and `./internals`.
+(Earlier drafts of this section over-counted the published surface as fifteen
+named subpaths; the shipped map is the seven entries above.)
 
 The reconciler's surprise property is an enforced, tested invariant: when an
 input fingerprint does not move, the render body provably never runs, recoverable
 from the `tokens.fresh` vs `tokens.reused` split in the receipt. The commit gate
 is offline — no model call is on the commit path.
 
-**gateCommit run-phase wiring is partial — state it plainly.** The deterministic
-commit gate `gateCommit(...)` and `compilePostconditions(...)` are built and
-unit-tested, and the `agent-compile` adapter emits each node's validator set into
-the compiled IR. But the live `agent-render` adapter today gates a commit on the
-render's **own structured done/failed self-attestation** of its `### Maintains`
-obligations — it returns `rendered` or `failed`, and the reconciler trusts that
-outcome — rather than re-running the compiled `gateCommit(...)` validators over
-the render's output in the run phase. The two halves exist; threading the
-compiled deterministic validators into the render adapter's commit path is the
-named remaining wiring (see Part III). A failed render still commits nothing: the
-prior world-model stands and nothing downstream wakes.
+**The deterministic commit gate is built but unwired — state it plainly.**
+`compilePostconditions(...)` is built, unit-tested, and **runs on the compile
+path**: the `agent-compile` adapter lowers and emits each node's validator set
+into the compiled IR. But the gate that would evaluate that set at commit,
+`gateCommit(...)`, has **zero non-test callers**: the live run path does not
+consult postconditions on commit (`packages/reactor/src/sdk/run-project.ts`).
+The commit decision today rides the render's **own structured done/failed
+self-attestation** of its `### Maintains` obligations — the render returns
+`rendered` or `failed` and the reconciler trusts that outcome — rather than
+re-running the compiled `gateCommit(...)` validators over the render's output.
+Both halves exist; threading the compiled deterministic validators onto the live
+commit step is the named remaining wiring (see Part III), and until it lands the
+Invariant 6 "an inadmissible render cannot corrupt the truth" guarantee is
+carried by the render's self-attestation, not by the deterministic gate. (Even
+once wired, the deterministic predicate DSL covers `=`/`≠`/`≥`/`<` plus
+`and`/`or`/`not` over flat scalar facts; quantified obligations like "every claim
+cites a source" stay render-attested, not deterministically checkable.) A failed
+render still commits nothing: the prior world-model stands and nothing downstream
+wakes.
 
 ### The CLI: `@openprose/reactor-cli`
 
-`@openprose/reactor-cli` v0.1.0 ships the `reactor` binary as the deterministic
+`@openprose/reactor-cli` v0.2.2 ships the `reactor` binary as the deterministic
 **reference client** that configures the SDK — it never re-implements the
 reconciler and never parses `.prose`. The three-phase lifecycle is
 `compile → run → serve`:
@@ -718,26 +803,32 @@ reconciler and never parses `.prose`. The three-phase lifecycle is
 - **`run`** ensures the IR is fresh, boots the reactor, drains to quiescence,
   prints per-node dispositions + cost, and exits (one-shot).
 - **`serve`** boots the durable host (flat `receipts.json` + filesystem
-  world-models), runs the continuity driver loop, and exposes a small HTTP
-  surface (`GET /health`, `GET /status`, `GET /cost`, `POST /<node>/trigger`).
-  It binds `127.0.0.1` by default and ships **no auth in v1** (the trigger route
-  can cause model spend; front it with a proxy before exposing). It drains
-  in-flight work on `SIGINT`/`SIGTERM`.
+  world-models), runs the continuity driver loop, and exposes a small,
+  reactor-namespaced HTTP surface — `GET /health`, `GET /<reactor>/status`,
+  `GET /<reactor>/cost`, `GET /<reactor>/topology`, `GET /<reactor>/receipts`,
+  `GET /<reactor>/nodes/<node>`, and `POST /<reactor>/trigger/<node>`. It binds
+  `127.0.0.1` by default and ships **no auth in v1** (the trigger route can cause
+  model spend; front it with a proxy before exposing). It drains in-flight work
+  on `SIGINT`/`SIGTERM`.
 
-The full command surface (verified against the README + `src/commands/`):
-`init`, `doctor` (`--live` runs one smoke render), `compile`, `run`, `serve`,
-`trigger`, `status`, `topology`, `inspect`, `logs`, `trace`, and
-`receipts [list|verify|cost]`. Documented stable exit codes: `0` success, `1` a
-reported failure with an actionable message (stale cache, broken chain, no
-contracts, bad config, unhealthy env, missing live key/dep), `2` a usage error.
+The full command surface is **thirteen** commands: `init`, `doctor` (`--live`
+runs one smoke render), `compile`, `run`, `serve`, `trigger`, `status`,
+`topology`, `inspect`, `logs`, `trace`, `receipts [list|verify|cost]`, and
+`telemetry` (the anonymous-analytics control). The six observability commands
+(`status`, `topology`, `inspect`, `logs`, `trace`, `receipts`) are deterministic
+**projections** implemented together in `src/commands/observe.ts`, not one file
+per command. Documented stable exit codes: `0` success, `1` a reported failure
+with an actionable message (stale cache, broken chain, no contracts, bad config,
+unhealthy env, missing live key/dep), `2` a usage error.
 
 **The offline boundary is real and load-bearing.** Requiring the CLI entrypoint
 loads neither `@openai/agents` nor `zod`; only `compile`/`run`/`serve`/`trigger`
-reach the model surface, via dynamic `import()` inside the handler. `init`,
-`doctor`, and the **whole observability suite** (`status`, `topology`, `inspect`,
-`logs`, `trace`, `receipts`) run fully offline with the model deps absent — and
-so does the keyless `reactor-devtools` replay. The per-package
-`pnpm test:offline` (no key, no network) is the contributor commit gate.
+and `doctor --live` reach the model surface, via dynamic `import()` inside the
+handler. `init`, plain `doctor`, and the **whole observability suite** (`status`,
+`topology`, `inspect`, `logs`, `trace`, `receipts`) run fully offline with the
+model deps absent — and so does the keyless `reactor-devtools` replay. The
+offline test gate (`REACTOR_OFFLINE=1`, run with no key and no network, via the
+root `pnpm test:reactor:offline`) is the contributor commit gate.
 
 **Durable substrate.** `serve` persists to a flat `<state-dir>/receipts.json`
 (the chain-verifiable ledger, the same file `reactor-devtools <state-dir>` reads)
@@ -763,7 +854,7 @@ reconstructs the same trail.
 
 Part I states the invariants as an unqualified north star. This ledger is where
 reality is honest, keyed to the eight Part I invariants. The verdict is reported
-against the shipped `@openprose/reactor` v0.2.0 / `@openprose/reactor-cli` v0.1.0
+against the shipped `@openprose/reactor` v0.3.1 / `@openprose/reactor-cli` v0.2.2
 build, not the retired judge package.
 
 | Invariant                              | State   | Evidence / Gap                                                                                                                                                                                                                                |
@@ -773,12 +864,13 @@ build, not the retired judge package.
 | 3. Adapters are the only reason hosts differ | Conformant (surface), unmeasured (live) | The SDK seam injects all adapters with no hidden defaults; the live render seam is the agent SDK over a model gateway. Recorded provider parity is not yet a shipped multi-provider matrix.                                                          |
 | 4. Activations are bounded             | Conformant | Continuity lives in the durable receipt trail + world-model store; no long-running session. Renders are bounded, single-flight-per-node, dirty-coalescing.                                                                                          |
 | 5. Cost scales with surprise           | Conformant as a tested invariant; unmeasured empirically | The memo-skip is an enforced test invariant — an unmoved input fingerprint provably never runs the render body, recoverable from `tokens.fresh` vs `tokens.reused` + `surprise_cause`. **No benchmark/dollar numbers** are claimed; honest long-horizon benchmarks are the named open ask (README "Deliberately not yet here"). |
-| 6. The commit gate is deterministic (`gateCommit`) | **Partial** | `gateCommit(...)` + `compilePostconditions(...)` are built and unit-tested; `agent-compile` emits each node's validator set into the IR. The live `agent-render` adapter commits on the render's **own done/failed self-attestation** of `### Maintains`, not yet on a run-phase `gateCommit(...)` call over the render output. A failed render still commits nothing. Wiring the compiled validators into the render commit path is the named remaining work. |
-| 7. Receipts are content-addressed      | Conformant; meaning-layer signer only | Receipt v0 is content-addressed and chain-verifiable (`verifyReceiptChain`, `receipts verify`), persisted to flat `<state-dir>/receipts.json`. Tiered `projection` keeps private payload fields out of subscriber/public proofs. The signer is an explicit **null state** (`{ scheme: "none", null_reason: "no-signer-adapter-configured" }`) — v1 "signed" = chain-consistency, not a cryptographic byte hash. |
+| 6. The commit gate is deterministic (`gateCommit`) | **Built, not wired** | `compilePostconditions(...)` is built, unit-tested, and runs on the compile path (`agent-compile` emits each node's validator set into the IR) — but the gate that evaluates it, `gateCommit(...)`, has **zero non-test callers**: the live run path does not consult postconditions on commit (`sdk/run-project.ts`), so the commit rides the render's **own done/failed self-attestation** of `### Maintains`. A failed render still commits nothing. Threading the compiled validators onto the live commit step is the named remaining work. |
+| 7. Receipts are content-addressed      | Conformant; thin shape + meaning-layer signer | Receipt v0 is content-addressed and chain-verifiable (`verifyReceiptChain`, `receipts verify`), persisted to flat `<state-dir>/receipts.json`. Tiered `projection` keeps private payload fields out of subscriber/public proofs. Two honest gaps: the exact-keyed v0 shape carries **no `as_of`, no failure `reason`, and no author-addressing**, so per-receipt as-of time and the failed-receipt-that-names-the-gap are dropped at commit (Part I's seam-3 and "names exactly what it needs"); and the signer is an explicit **null state** (`{ scheme: "none", null_reason: "no-signer-adapter-configured" }`) — v1 "signed" = chain-consistency, not a cryptographic byte hash. |
 | 8. State is replayable and exitable    | Conformant (chain), partial (artifacts) | A fresh reactor imports a runtime-produced ledger and produces the same next receipt hash; `reactor-devtools <state-dir>` replays it offline. Caveat: `receipts verify` proves chain consistency, **not** the world-model artifacts on disk — editing a `world-models/*/published.json` while leaving `receipts.json` intact is not caught (the null-signer boundary). |
 
-The same honesty discipline applies to the null signer, the partial gateCommit
-wiring, and the pre-publish package state (see Honest Current Limits).
+The same honesty discipline applies to the null signer, the unwired gateCommit,
+the thin receipt shape, and the deferred actuation / freshness-pacing / trust
+seams (see Honest Current Limits).
 
 ### Tests And Release Gate
 
@@ -793,9 +885,11 @@ The shipped suites (verified against the package `scripts` and `src/` layout):
   suite — including the test asserting the **flat `<state-dir>/receipts.json`**
   at the state-dir root for DevTools interop.
 - The devtools replay suite (keyless).
-- The **offline commit gate** — `pnpm -C packages/<pkg> test:offline`, run with
-  no model key and no network. The published GitHub Actions release gate uses npm
-  trusted publishing/OIDC and rejects tag/package-version mismatches.
+- The **offline gate** — the root `pnpm test:reactor:offline` (`REACTOR_OFFLINE=1`,
+  no model key, no network) covering the SDK + CLI + devtools. The published
+  GitHub Actions release gate uses npm trusted publishing/OIDC and publishes each
+  reactor package at its own version on its `reactor-v*` train (an idempotent
+  skip when that version is already on npm — not a tag/version equality assertion).
 
 What they prove: the SDK builds, packs, imports, and reconciles deterministically;
 the memo-skip invariant holds; receipts are content-addressed and chain-verify;
@@ -811,39 +905,54 @@ hardening. These are the deliberately-pending items the README and Part III name
 
 | Area              | Location                                                              | Role                                                                                       |
 | ----------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| SDK package       | `packages/reactor/` (`@openprose/reactor` v0.2.0)                     | The headless reconciler + canonicalizer + postcondition + receipt + world-model + forecast + composition SDK |
+| SDK package       | `packages/reactor/` (`@openprose/reactor` v0.3.1)                     | The headless reconciler + canonicalizer + postcondition + receipt + world-model + forecast + composition SDK |
 | Reconciler        | `packages/reactor/src/reactor/index.ts`                              | The dumb run phase: memo/skip → schedule → commit → propagate; no judge                     |
 | Canonicalizer     | `packages/reactor/src/canonicalizer/`                               | Per-node compiled fingerprint function over `### Maintains`; facet boundaries               |
-| Postcondition     | `packages/reactor/src/postcondition/index.ts`                       | `compilePostconditions(...)` + `gateCommit(...)` (built/tested; run-phase wiring partial)   |
+| Postcondition     | `packages/reactor/src/postcondition/index.ts`                       | `compilePostconditions(...)` (runs on the compile path) + `gateCommit(...)` (built/tested; **zero live callers** — unwired) |
 | Receipt ledger    | `packages/reactor/src/receipt/index.ts`                             | Receipt v0 build/verify/inspect; status `{rendered, skipped, failed}`; null signature       |
 | World-model store | `packages/reactor/src/world-model/`                                 | Content-addressed store; published-truth / private-workspace split; `fs-store`              |
 | Forecast          | `packages/reactor/src/forecast/index.ts`                            | Self-driven `### Continuity`; `valid_until` → fingerprint freshness bridge (zero-token)      |
 | Composition       | `packages/reactor/src/composition/index.ts`                         | The read-isolation pin over each consumed upstream facet                                     |
 | Render seam       | `packages/reactor/src/adapters/agent-render/`                       | The bounded LLM render; commits on self-attested done/failed                                 |
 | Compile seam      | `packages/reactor/src/adapters/agent-compile/`                      | Compile sessions → topology / canonicalizer / postcondition IR                              |
-| CLI package       | `packages/reactor-cli/` (`@openprose/reactor-cli` v0.1.0)           | The `reactor` binary; `src/commands/` holds the 12 commands + serve HTTP surface             |
-| Replay viewer     | `packages/reactor-devtools/` (`@openprose/reactor-devtools` v0.1.0) | Keyless offline receipt-ledger replay (`--describe` + browser graph)                         |
-| Examples          | `packages/reactor-cli/examples/`                                    | `quickstart` (gateway + responsibility) and `gateway-connector`, runnable from a fresh checkout |
+| CLI package       | `packages/reactor-cli/` (`@openprose/reactor-cli` v0.2.2)           | The `reactor` binary; `src/commands/` holds the 13 commands (observability via `observe.ts`) + serve HTTP surface |
+| Replay viewer     | `packages/reactor-devtools/` (`@openprose/reactor-devtools` v0.2.0) | Keyless offline receipt-ledger replay (`--describe` + browser graph)                         |
+| Examples          | `packages/reactor-cli/examples/`                                    | `agent-observatory`, `gateway-connector`, and `quickstart` (gateway + responsibility) — three, runnable from a fresh checkout |
 
 This is enough to say the Reactor-class harness exists as shipped software. It is
 not yet enough to say the public category claim is empirically proven.
 
 ### Honest Current Limits
 
-- The three packages are staged as pre-publish tarballs; they must hit public npm
-  before a clean `npm i -g` story (the CLI/devtools peer-depend on the SDK).
-- **`gateCommit`'s compiled validators are not yet wired into the live render
-  commit path** — the run phase trusts the render's `### Maintains`
-  self-attestation (invariant 6 is Partial).
+- **`gateCommit`'s compiled validators have zero live callers** — the run phase
+  does not consult postconditions on commit and trusts the render's `### Maintains`
+  self-attestation (invariant 6: built, not wired). This is gap cluster 1.
+- **The durable receipt shape is too thin to carry its promises** — the exact-keyed
+  v0 `Receipt` has no `as_of`, no failure `reason`, and no author-addressing, so
+  per-receipt as-of time and the failed-receipt-that-names-the-gap are honored only
+  in-render and dropped at commit. This is gap cluster 2.
+- **`### Invariants` is never lowered into the render** — the authored
+  rate/scope/prohibited-action actuation boundary is neither compiled, attested,
+  nor harness-enforced; it survives only as prose the render may ignore, bounded
+  in practice by the cwd-rooted workspace sandbox and the turn cap. There is no
+  world-mutation actuation sink (render tools are fs/shell over a private
+  workspace; connectors are read-only ingress). Part of gap cluster 3.
 - The signer is null-only (meaning-layer chain consistency); no cryptographic
   byte hash, so `receipts verify` does not bind the world-model artifacts on disk.
+  The topology edge pins a consumed **revision** but no **acceptable-signer-set**,
+  so cross-trust-domain composition has no pin even ahead of the signer.
 - No benchmark or dollar numbers — the surprise property is a tested invariant,
   not a measured speedup; honest long-horizon benchmarks are the named open ask.
+  Cost is **observed, not budgeted** (no enforced token ceiling per node/run).
 - No Postgres / durable cloud storage adapter (the storage seam is synchronous).
 - Within-reactor node-level parallelism (Change B) is deferred; `--concurrency`
   parallelizes reactors, not nodes.
-- `serve` uses a fixed `--poll-interval` cadence; the default `valid_until`
-  freshness projector (and adaptive idle-to-soonest-recheck) is deferred.
+- **`serve`'s freshness clock arms nothing by default** — the SDK computes
+  `next_self_recheck` from the soonest `valid_until`, but the shipped daemon's
+  freshness reader defaults to none and no node emits `valid_until` by default, so
+  `serve` sleeps a flat `--poll-interval` (default 60s) and does the fixed-interval
+  work Part I forbids. Forecast-paced / adaptive idle is deferred. Part of gap
+  cluster 3.
 - The fixpoint (topology-as-responsibility), facet inference, and ledger
   compaction are specified and deferred.
 - `serve` ships no auth in v1 — the HTTP surface is a single-operator,
@@ -881,16 +990,15 @@ time?
 
 ### Required Engineering Work
 
-#### 1. Publish And Pin The Packages
+The packages are already published (`@openprose/reactor` 0.3.1,
+`@openprose/reactor-cli` 0.2.2, `@openprose/reactor-devtools` 0.2.0) with OIDC
+provenance, so the headline of earlier roadmaps is done. The remaining work is
+**closing the three gap clusters** the Conformance Ledger names (§1–§5 below
+correspond to them), then publish hardening and the deferred enhancements and
+recursions (§6–§9). It is ordered by leverage: the commit-gate and freshness
+items are load-bearing.
 
-The three packages are staged tarballs (`@openprose/reactor` 0.2.0,
-`@openprose/reactor-cli` 0.1.0, `@openprose/reactor-devtools` 0.1.0). Ship them to
-public npm with provenance via the existing OIDC/trusted-publishing GitHub Actions
-gate (it already rejects tag/package-version mismatches), so the CLI and devtools
-can peer-depend on the published SDK cleanly. This is the minimum that turns
-"install all three tarballs, SDK first" into `npm i -g @openprose/reactor-cli`.
-
-#### 2. Wire `gateCommit` Into The Run-Phase Commit
+#### 1. Wire `gateCommit` Into The Run-Phase Commit  *(gap cluster 1)*
 
 The deterministic commit gate is the half-built invariant. `gateCommit(...)` and
 `compilePostconditions(...)` exist and are tested, and `agent-compile` already
@@ -901,26 +1009,59 @@ into the render adapter's commit path so a commit must pass deterministic
 postconditions **and** the render's self-attestation, closing invariant 6. A
 failure on either path still commits nothing and writes a `failed` receipt.
 
-#### 3. The Cryptographic Signer
+#### 2. Widen The Durable Receipt  *(gap cluster 2)*
+
+The exact-keyed v0 `Receipt` (`src/shapes/index.ts`) is too thin to carry the
+promises pinned to it: it has no `as_of`, no failure `reason`, and no
+author-addressing field, so per-receipt as-of time (seam 3) and the
+failed-receipt-that-names-the-gap ("addressed to you, naming exactly what it
+needs") are honored only in-render and dropped at commit. Add `as_of`, a failure
+`reason`, and an author-addressing field to the durable shape — and persist them
+through the ledger and tiered projections — so the Ideal receipt schema is what
+actually survives a commit.
+
+#### 3. Lower And Enforce The Actuation Boundary  *(gap cluster 3)*
+
+`### Invariants` declares a render's world-mutation bounds (rate, scope,
+prohibited actions), but the section is never lowered into the render — it
+constrains the model only as prose, bounded in practice by the cwd-rooted
+workspace sandbox and the turn cap. Lower it into the render and add a
+world-mutation actuation sink, so the published/workspace split and "the only
+writable surface is the published truth" become harness-enforced rather than
+author-trusted.
+
+#### 4. The Default Freshness Projector + Adaptive Serve Cadence  *(gap cluster 3)*
+
+`serve` runs a fixed poll cadence because `readFreshness` arms no instants today
+(no node emits `valid_until` by default), so it does the fixed-interval work Part
+I forbids. Build the default `valid_until` freshness projector that reconstructs
+each node's recheck schedule from a `valid_until` convention in published truth,
+honor a gateway's declared `### Schedule` as a freshness-paced cadence rather than
+dropping it, then let `serve` sleep to the soonest armed `next_self_recheck`
+instead of a flat heartbeat — so the common case self-paces with zero per-project
+wiring and a quiet system trends to genuinely zero tokens.
+
+#### 5. The Cryptographic Signer  *(gap cluster 3)*
 
 Today's signer is the honest null state (`scheme: "none"`); `receipts verify`
-proves chain consistency but not the world-model artifacts on disk. Add a real
+proves chain consistency but not the world-model artifacts on disk, and the
+topology edge pins a consumed revision but no acceptable-signer-set. Add a real
 signing adapter that produces a cryptographic byte hash binding the published
 world-model to its receipt, so `verify` catches an edited
 `world-models/*/published.json`, and so cross-boundary composition (the
 contract-revision + acceptable-signer pin) becomes non-repudiable. The pinning
 surface (the read-isolation pin in `composition`) is already specified ahead of it.
 
-#### 4. The Default Freshness Projector + Adaptive Serve Cadence
+#### 6. Pin And Harden The Publish Train
 
-`serve` runs a fixed `--poll-interval` cadence because `readFreshness` arms no
-instants today. Build the default `valid_until` freshness projector that
-reconstructs each node's recheck schedule from a `valid_until` convention in
-published truth, then let `serve` sleep to the soonest armed `next_self_recheck`
-instead of a flat heartbeat — so the common case self-paces with zero per-project
-wiring and a quiet system trends to genuinely zero tokens.
+The three packages publish with provenance via the OIDC/trusted-publishing
+GitHub Actions gate on the `reactor-v*` train (each package publishes at its own
+version — an idempotent skip when that version is already on npm), so the CLI and
+devtools peer-depend on the published SDK and `npm i -g @openprose/reactor-cli`
+works. The package work itself is done; the residual is pinning/policy hardening
+of the publish train only.
 
-#### 5. Ledger Compaction And Facet Inference
+#### 7. Ledger Compaction And Facet Inference
 
 The flat `receipts.json` grows without bound; a compaction/indexing plan for
 long-running responsibilities is named, not shipped. And authors declare facets
@@ -928,17 +1069,17 @@ explicitly (`####` parts under `### Maintains`) — inferring a good
 material/immaterial facet split from a contract is a v-next compile-phase
 enhancement.
 
-#### 6. The Fixpoint (Topology-As-Responsibility)
+#### 8. The Fixpoint (Topology-As-Responsibility)
 
 The closing recursion: mount Forme + the compile sessions as ordinary reactor
 nodes so the reactor maintains its **own** topology, memoized on the contract-set
 fingerprint, with an epoch rollover when the contract set changes (and a
-cold-miss sweep). The CLI surface stays the same — `compile` shifts from an
+cold-miss sweep). The `reactor` command surface stays the same — `compile` shifts from an
 external batch to forcing/inspecting the compile nodes, `serve` stops
 special-casing re-compile, and `status`/`topology` gain an epoch view. Specified
 and deferred past v1.
 
-#### 7. Within-Reactor Parallelism (Change B)
+#### 9. Within-Reactor Parallelism (Change B)
 
 `--concurrency` parallelizes reactors, not nodes; the SDK has no `maxConcurrency`
 and within a reactor drains stay serial behind a per-reactor queue. Adding a
@@ -1065,7 +1206,12 @@ Sober. Make a strong claim, then show the evidence and the limits.
   `@openprose/reactor-devtools` are public, version-consistent, and provenance-
   verified through the OIDC gate.
 - `gateCommit`'s compiled validators are wired into the run-phase commit (invariant
-  6 closed), not only the render's self-attestation.
+  6 / gap cluster 1 closed), not only the render's self-attestation.
+- The durable receipt carries `as_of`, a failure `reason`, and an author-addressing
+  field (gap cluster 2 closed), so per-receipt as-of time and the
+  failed-receipt-that-names-the-gap survive commit.
+- The `### Invariants` actuation boundary is lowered and harness-enforced at the
+  render/commit split (gap cluster 3), not author-trusted prose.
 - A fresh clone runs the `quickstart` and `gateway-connector` examples end to end;
   the keyless `reactor-devtools` replay shows dispositions + cost-by-surprise.
 - The eval suite includes the offline invariant tests **plus** the empirical

--- a/spec/03-ReactorPattern.md
+++ b/spec/03-ReactorPattern.md
@@ -6,7 +6,7 @@ The OpenProse corpus divides labor exactly, and each document maps to what
 ships:
 
 - [01-Language.md](./01-Language.md) — **the Language & Framework**, bundled as
-  the **SKILL**: syntax, kinds, sections, compile model, std/co, CLI surface.
+  the **SKILL**: syntax, kinds, sections, compile model, std/co.
 - [02-ReactorHarness.md](./02-ReactorHarness.md) — **the Reactor
   Harness**, bundled as the **CLI/Server**: the runtime control architecture
   (loop, invariants, the reconciler, memoization, forecast, receipts, composition). It
@@ -78,7 +78,7 @@ It grows only as the work demands:
 
 | File | `kind:` | What the author is really writing |
 | --- | --- | --- |
-| The standing goal | `responsibility` | One `### Goal` sentence + the `### Maintains` world-model that makes it true (facets, canonicalization, postconditions) |
+| The standing goal | `responsibility` | One `### Goal` sentence + the `### Maintains` world-model that makes it true (type, facets, canonicalization, postconditions) |
 | Event ingress | `gateway` | How and when the world is allowed to wake the loop |
 | A helper | `function` | A called, ephemeral computation a render invokes — `### Parameters` → `### Returns` |
 
@@ -101,7 +101,7 @@ table is the spine of the pattern; the prose after it only elaborates.
 | 2. Materiality is compiled and shared | Declare *what counts as a material change* as natural language inside `### Maintains` — which fields matter, how they normalize, where the facets fall. The compile phase lowers that into a deterministic canonicalizer; you state the materiality, not the hash. |
 | 3. Adapters are the only reason homes differ | Author no host-specific logic in contracts. Declare needs in `### Tools` / `### Environment` by name only. The same contract must run local and cloud. |
 | 4. Activations are bounded | Never write a render that assumes it keeps running. No "while true," no in-session waiting for the next event. Continuity lives in the receipt ledger, not a session. |
-| 5. Cost scales with surprise | Write `### Maintains` so "did anything material change?" is **cheaply decidable** — give the truth a stable content identity and facet it so an unrelated change wakes nobody. Declare freshness (`valid_until`) in `### Continuity` so silent staleness still wakes the node. This is the rule authors most often violate. |
+| 5. Cost scales with surprise | Write `### Maintains` so "did anything material change?" is **cheaply decidable** — give the truth a stable content identity and facet it so an unrelated change wakes nobody. Declare freshness (`valid_until`) in `### Continuity` so silent staleness still wakes the node. This is a rule authors often violate. |
 | 6. The commit gate is deterministic | State satisfaction as **postconditions inside `### Maintains`** — deterministic where you can express a validator, self-attested by the render where it is semantic. There is no separate judge and no `### Criteria`. |
 | 7. Receipts are content-addressed | Trust the harness's signed receipt ledger as the audit / composition / exit unit. Do not hand-roll a scratch log. |
 | 8. State is replayable and exitable | Keep all durable truth in the responsibility's `### Maintains` world-model, in plain structured records. A reader must be able to take the contract and its trail to another harness. |
@@ -122,8 +122,8 @@ silent.
 
 ### Rule 2 — `### Continuity` declares the wake source; `### Maintains` carries the materiality
 
-These were once one rule; they are two jobs, and conflating them is the most
-common authoring mistake.
+These were once one rule; they are two jobs, and conflating them is a common
+authoring mistake.
 
 `### Continuity` answers **when, beyond an input change, this node should
 re-render**:
@@ -157,7 +157,9 @@ There is no `### Criteria` and no judge. State what "satisfied" means as
   validator the harness runs at commit. If it fails, the render commits nothing.
 - **Self-attested where it is semantic.** Where the obligation cannot be reduced
   to a validator, the render must attest it satisfied its own `### Maintains`
-  before it signs. `gateCommit` fails closed: no attestation, no commit.
+  before it signs. `gateCommit` fails closed: no attestation, no commit. (Part II:
+  the deterministic gate is built but currently unwired, so the live commit rides
+  the render's self-attestation until the compiled validators are threaded on.)
 
 When the truth genuinely has *nothing observable to maintain against*, the render
 cannot satisfy its postcondition and writes a `failed` receipt naming the gap —
@@ -171,7 +173,9 @@ the `failed` receipt and its reason carry it.
 `### Invariants` (the section that absorbs the old `### Constraints`) is where the
 author quarantines world-mutation — the authoring-time expression of the
 render/commit split: a render may act, but only the canonicalized published truth
-re-enters the memo, and `### Invariants` bounds what the render may touch.
+re-enters the memo, and `### Invariants` is where the author bounds what the
+render may touch — the actuation boundary the harness is to enforce at the
+render/commit split. (Part II: authored but not yet lowered into the render.)
 
 Two boundary shapes recur:
 
@@ -192,7 +196,11 @@ deliberately, not by backing into it.
 
 Authors most often write the anti-pattern: a render that re-derives everything
 every time. The fix is not a service decomposition — it is shaping `### Maintains`
-so the dumb reconciler can skip:
+so the dumb reconciler can skip. The reconciler keys each render on the 3-tuple
+`(contract_fingerprint, input_fingerprints, freshness_epoch)`; your leverage is
+to make the input fingerprints move only on real change. (Shipped v1 realizes the
+freshness term as a forecast self-receipt over a 2-tuple key — identical decision
+semantics; see [02-ReactorHarness.md](./02-ReactorHarness.md) Part II.)
 
 1. **Give the truth a stable content identity.** The canonicalizer fingerprints
    the published truth; make sure an unchanged world yields an unchanged
@@ -222,9 +230,9 @@ obligations make it safe:
   facet as a declared subscription, not a copied value.
 - **Pin revision and trust.** For cross-trust-domain composition, pin which
   revision of A you accept and an acceptable signer set; unpinned composition is
-  a supply-chain attack the author closes, not the runtime. (In v1 "signed" is
-  meaning-layer chain-consistency; the cryptographic signer is a deferred
-  milestone.)
+  a supply-chain attack the author closes, not the runtime. (Part II: v1 "signed"
+  is meaning-layer chain-consistency over a null signer; the cryptographic
+  byte-hash signer is deferred.)
 
 Freshness needs no special authoring: each facet carries its own `valid_until`,
 so a stale upstream facet's fingerprint lapses and wakes B through the ordinary
@@ -247,9 +255,8 @@ Reactor-native contracts and should be the author's default vocabulary:
 | `oversight` | The actor / observer / arbiter split — the canonical projection-only shape |
 
 These coordinate `call`s to `function`s *inside a render*; none is a separate
-node, a judge tier, or an autowired graph. Depth — running a critic only on the
-uncertain branch — is ordinary `### Execution` control flow, not a
-confidence-gated judge ensemble.
+node or an autowired graph. Depth — running a critic only on the uncertain
+branch — is ordinary `### Execution` control flow.
 
 ### A worked example: the competitor-activity monitor
 
@@ -274,6 +281,9 @@ launches — is current.
 ### Requires
 
 - `competitors`: the watchlist (names + domains) this monitor tracks.
+- `pages` from `competitor-sources-gateway`: the latest fetched source content,
+  staged with a cheap content identity so unchanged sources don't wake the
+  extraction.
 
 ### Maintains
 
@@ -295,9 +305,11 @@ no observable source is not committed (the render attests this).
 
 ### Continuity
 
-- Input-driven: wake when the `competitors` watchlist changes.
-- Self-driven: each part carries a `valid_until` of +1 business day; when it
-  lapses, that part is re-checked against the world.
+- Input-driven: wake when `pages` (new staged source content) or the
+  `competitors` watchlist changes. Unchanged sources leave the `pages`
+  fingerprint still, so the expensive extraction memo-skips at zero render tokens.
+- Self-driven: each part carries a `valid_until` of +1 business day as a safety
+  net, so a silently stale part is re-checked even if the gateway missed a change.
 
 ### Invariants
 
@@ -306,9 +318,48 @@ no observable source is not committed (the render attests this).
 
 ### Tools
 
-- cli:web-fetch
-- cli:fs-read
+- cli:fs-read   # reads staged source content; the gateway owns web-fetch
 ```
+
+**The gateway** that feeds it — cheap, deterministic ingress with a stable
+content identity, so the monitor's render only fires on real change:
+
+```markdown
+---
+name: competitor-sources-gateway
+kind: gateway
+id: 067NC4KG01RG50R40M30E2091A
+---
+
+### Goal
+
+The latest fetched source content for each tracked competitor is staged for
+extraction — fetched and staged only, never interpreted here (extraction is the
+monitor's render).
+
+### Continuity
+
+external-driven: the competitor sources cannot push, so the gateway re-checks
+them on a *freshness-paced* cadence — a `valid_until` of +6h on the staged
+`pages`, not a blind heartbeat (invariant 5).
+
+### Maintains
+
+#### pages
+The fetched source content per competitor, normalized to its stable main text.
+Material: the content hash of a competitor's normalized text changed. Immaterial:
+fetch timestamp, request ids, response headers, ads, and boilerplate.
+
+### Schedule
+
+- Re-fetch each competitor's funding, careers, and product pages when the staged
+  `pages` freshness window (+6h) lapses — the freshness-paced recheck for sources
+  that cannot push, not a fixed-interval poll.
+```
+
+The gateway does the cheap, deterministic half (fetch + normalize + hash); the
+monitor does the expensive, semantic half (extract funding / hiring / launches),
+and only when the gateway's `pages` fingerprint actually moves.
 
 **A downstream consumer** subscribes to one facet, and wakes only on that facet:
 
@@ -333,19 +384,28 @@ A short brief summarizing the latest funding activity for the watchlist.
   if funding stays quiet.
 ```
 
-What the harness does with this, for free:
+What an ideal Reactor harness does with this:
 
-- A re-poll that finds **no material funding change** produces an unchanged
-  `funding` fingerprint, so the monitor writes a `skipped` receipt and the brief
-  never wakes — *cost scales with surprise.*
+- A gateway poll that finds **no changed source content** leaves the `pages`
+  fingerprint unmoved, so the monitor's extraction **memo-skips at zero render
+  tokens** (the gateway pays only a cheap, non-LLM fetch + hash) and the brief
+  never wakes — *cost scales with surprise.* When sources change but the funding
+  *facet* does not, the monitor renders, re-derives an unchanged `funding`
+  fingerprint, and still leaves the brief asleep.
 - A new **hiring** signal moves only the `hiring` fingerprint; the brief
   subscribes to `funding`, so it stays asleep — *facets make subscription
   selective.*
-- When `funding`'s `valid_until` lapses, the continuity clock moves its
-  fingerprint and wakes the monitor with a zero-token self-receipt; if the
-  re-check finds real news, *that* propagates to the brief.
+- When `funding`'s `valid_until` safety net lapses, the continuity clock advances
+  the monitor's freshness epoch and wakes it with a zero-token self-receipt; the
+  monitor re-extracts from the latest staged `pages`, and only real news
+  propagates to the brief.
 - A render that cannot cite a source for an entry fails its postcondition,
   commits nothing, and leaves a `failed` receipt — the prior truth stands.
+
+Two of these are ideal harness behavior the contract is authored to, not yet
+delivered: forecast-paced freshness arming (today `serve` polls a flat interval)
+and the gateway's `### Schedule` cadence (today dropped by the compiler) are Part
+II deferrals — the contract above is correct; the harness climbs to it.
 
 No `kind: system`, no `### Services`, no judge, no ledger service: the render
 maintains the world-model, the canonicalizer senses change, `gateCommit` gates
@@ -378,7 +438,8 @@ Each is the natural non-Reactor instinct and why it breaks an invariant:
   id, a re-ordered list — so the fingerprint moves on noise (breaks invariant 5).
 - **Consuming another responsibility's value by copying it into the contract.**
   Not a verifiable, revision-pinned subscription; a supply-chain hole (breaks
-  invariants 6/7). Name the facet in `### Requires` instead.
+  Rule 6 composition and invariant 7's content-addressed receipts). Name the
+  facet in `### Requires` instead.
 - **"Swarm of subagents that continuously watches."** The cron-plus-prompt shape
   the Reactor replaces. The Reactor-native form is: a subscribed input or a
   lapsed `valid_until` wakes one bounded render; nothing watches in between.
@@ -408,12 +469,13 @@ authors against. This section is the conformance ledger: what the skill routes
 today, measured honestly against that pattern.
 
 The reference harness backing the skill is the three packages that ship
-together — `@openprose/reactor` (the engine SDK, `0.2.0`), `@openprose/reactor-cli`
-(command `reactor`, `0.1.0`, twelve commands), and `@openprose/reactor-devtools`
-(the replay viewer, `0.1.0`). The skill's `responsibility-runtime.md` and
+together — `@openprose/reactor` (the engine SDK, `0.3.1`), `@openprose/reactor-cli`
+(command `reactor`, `0.2.2`, thirteen commands), and `@openprose/reactor-devtools`
+(the replay viewer, `0.2.0`). The skill's `responsibility-runtime.md` and
 `concepts/{responsibility,reactor}.md` are already written to this model; the
 retired judge/verdict/status/pressure/fulfillment vocabulary is gone from the
-authoring surface, not merely deprecated.
+authoring surface, not merely deprecated, and the legacy `prose` CLI binary has
+been removed (the language is embodied by the SKILL in-session).
 
 ### The authoring surface that already exists
 
@@ -428,20 +490,24 @@ kinds and sections Part I names, and only those.
 | `kind: gateway` — sugar for an external-driven responsibility; Forme's entry-point set | Present; `reactor serve` registers it and stages ingress (fetch → extract → stage + a durable idempotency cursor) |
 | `kind: pattern` / `kind: test` | Present; patterns expand at compile time, tests route to `prose test` / `reactor` test semantics |
 | Facets: `####` parts under `### Maintains` — name = fingerprint unit + subscription symbol; atomic default | Present and **facet-granular propagation is live in production** (the v2 named-parts model); a downstream subscribed to one facet does not wake when another moves |
-| `### Maintains` as the world-model schema doing four jobs (type, canonicalization spec, facets, postconditions) | Present; the postconditions are the folded-in `### Criteria`, compiled to validators |
+| `### Maintains` as the world-model schema doing four jobs (type, canonicalization spec, facets, postconditions) | Present; the postconditions live **inside `### Maintains`**, compiled to validators (there is no separate `### Criteria` section — it was removed) |
 | `### Continuity` as the structural wake-source declaration (input / self / external) | Present; self-driven recheck and the gateway entry point are both wired (Phase 4) |
 | `### Execution` ProseScript for variable-depth work inside one render | Present — an `if`-gated `call` to a `function` is the depth mechanism, not a judge tier |
 | Compile as SKILL-loaded sessions (Forme / canonicalizer / postcondition) → deterministic lowering → content-addressed IR cache | Present; a `.prose` set mounts without hand-authoring via a true semantic `Requires ↔ Maintains` match |
 | Run: dumb reconciler — memo-skip on unmoved `(contract_fp, input_fp)`, single-flight + coalescing, failure = no-commit, propagate only on a `rendered` moved fingerprint | Present (`@openprose/reactor`); restart-survival proven (truth + ledger survive a fresh process) |
-| `gateCommit`: deterministic postcondition validators + render self-attestation of `### Maintains`; receipt status in `{rendered, skipped, failed}` | Present; no judge, no verdict, no status enum |
+| `gateCommit`: deterministic postcondition validators + render self-attestation of `### Maintains`; receipt status in `{rendered, skipped, failed}` | Partial; no judge, no verdict, no status enum — but the commit rides the render's **self-attestation** today: the deterministic `gateCommit(...)` validators are built and tested yet have **zero live callers** (02-ReactorHarness gap cluster 1) |
 | Content-addressed, chain-verifiable receipt ledger; cost = `tokens.fresh` vs `tokens.reused` + `surprise_cause` | Present (`reactor receipts` chain-verifies and tamper-detects; the devtools meter renders "cost scales with surprise") |
 | Composition: a downstream responsibility names an upstream facet in `### Requires`; Forme draws the subscription edge | Present; the reconciler reads the topology `edges` to resolve propagation |
 
 The skill can already express a Reactor-native program end to end *in the current
 model*: one responsibility with a faceted `### Maintains`, a gateway for ingress,
-a `function` helper for an expensive sub-step, a projection-only or full
-actuation boundary in `### Invariants`, postcondition-gated commit, and a
-composition edge that is a real subscription rather than a copied value.
+a `function` helper for an expensive sub-step, an actuation boundary in
+`### Invariants`, postcondition-gated commit, and a composition edge that is a
+real subscription rather than a copied value. Two honest caveats the author must
+hold (see limits): the `### Invariants` actuation boundary is **authored but not
+yet harness-enforced** — it is never lowered into the render, so it constrains the
+model only as prose; and the postcondition gate currently rides the render's
+self-attestation, not the deterministic `gateCommit(...)` validators.
 
 ### Current authoring limits
 
@@ -461,23 +527,39 @@ reality is honest, rule by rule.
 
 ### Honest current limits for authors
 
-- **`### Continuity` self-driven recheck is wired, but the cadence is flat.**
-  The continuity scheduler drives the freshness-lapse → synthetic self-receipt
-  bridge (a lapsed `valid_until` flips a fact's status, moves the facet
-  fingerprint, and wakes the node — a **zero-token** fingerprint move, not a
-  model re-render). `reactor serve` polls it on a flat `--poll-interval`
-  (default 60s); **forecast-paced / adaptive idle** off each node's soonest
-  `next_self_recheck` is deferred. Declare `valid_until` now; the cadence
-  tightens later without a source change.
+- **`### Continuity` self-driven recheck exists, but `serve`'s freshness clock
+  arms nothing by default.** The bridge is real (a lapsed `valid_until` flips a
+  fact's status, moves the facet fingerprint, and wakes the node — a **zero-token**
+  fingerprint move, not a model re-render), and the SDK computes each node's
+  soonest `next_self_recheck`. But the shipped `serve` daemon's freshness reader
+  defaults to none and no node emits `valid_until` by default, so it sleeps a flat
+  `--poll-interval` (default 60s) and does the fixed-interval work the ideal
+  forbids. Forecast-paced / adaptive idle is the deferred next step. Declare
+  `valid_until` now; the cadence tightens later without a source change.
+- **The `### Invariants` actuation boundary is authored, not enforced.** The
+  authored rate/scope/prohibited-action quarantine is never lowered into the
+  render — neither compiled, attested, nor harness-checked — so it constrains the
+  model only as prose, bounded in practice by the cwd-rooted workspace sandbox and
+  the turn cap. There is also no world-mutation actuation sink yet (render tools
+  are fs/shell over a private workspace; connectors are read-only ingress).
+- **A gateway's `### Schedule` cadence is not yet honored.** Gateways poll
+  external sources, but a per-gateway `### Schedule` (e.g. "every 6h") is dropped
+  by the compiler today; cadence is the serve loop's flat poll interval. Declare
+  the intended schedule now; it binds once the compiler carries it.
+- **The deterministic commit gate is unwired.** `compilePostconditions(...)`
+  runs on the compile path, but the gate that evaluates it, `gateCommit(...)`, has
+  zero live callers; the commit rides the render's `### Maintains` self-attestation
+  (02-ReactorHarness gap cluster 1).
 - **Serve ingress is local cron-poll + HTTP only.** Gateway poll connectors and
   an HTTP trigger surface ship; **queues, file watches, and provider
   subscriptions** do not. A worktree/planning-dir watcher must use a poll
   `### Continuity` today and note the intended file-watch form.
-- **The cryptographic signer is a null-state.** Composition pins a revision and
-  is chain-verifiable at the meaning layer, but pinning an *acceptable signer
-  set* for cross-trust-domain composition is not enforceable until the
-  byte-hash signer lands. Functionally adequate within one trust domain;
-  cryptographically weaker than the ideal across domains.
+- **The cryptographic signer is a null-state, and the dependency edge pins no
+  signer set.** Composition pins a content-addressed *revision* and is
+  chain-verifiable at the meaning layer, but the topology edge carries no
+  *acceptable-signer-set* pin, and the byte-hash signer that would enforce one is
+  deferred. Functionally adequate within one trust domain; cryptographically
+  weaker than the ideal across domains.
 - **Materiality is authored, not yet inferred.** The author writes the
   material/immaterial split in `### Maintains` prose and the compile session
   lowers it. The skill does **not** infer facets or materiality from the truth's
@@ -531,6 +613,10 @@ should mirror the load they bear:
   referents; when the truth has *nothing observable to maintain against*, that
   is an expected, high-value `failed` receipt routed to the author — **never** a
   `blocked`/`drifting` status enum (those are retired).
+- The failed receipt that *names the gap and routes it to the author* depends on
+  the harness widening the durable receipt with a `reason` + author-addressing
+  field (02 gap cluster 2); until that lands, the doctrine is authorable but the
+  routed reason is dropped at commit. Author to it now.
 
 ### 3. Land the materiality lowering's prose→spec half
 
@@ -542,7 +628,30 @@ the spec reliably — so that "state the materiality, not the hash" is trustwort
 across more contract shapes. This is a compile-session quality effort, not a new
 grammar; there is no `.prose` parser to build.
 
-### 4. Forecast-paced continuity cadence
+### 4. Wire the deterministic commit gate
+
+The author states satisfaction as postconditions inside `### Maintains`, and the
+compile phase lowers them to deterministic validators (`compilePostconditions`
+runs on the compile path). But the gate that would evaluate them at commit,
+`gateCommit(...)`, has zero live callers — the commit rides the render's own
+`### Maintains` self-attestation. So the author's postconditions are *compiled*
+but not yet the *enforced* commit gate. Threading the compiled validators onto
+the live commit step (02 gap cluster 1) makes Rule 3's "no attestation, no
+commit" a deterministic guarantee rather than a render self-report. The author
+writes postconditions to it now; the enforcement tightens harness-side.
+
+### 5. Lower and enforce the `### Invariants` actuation boundary
+
+Rule 4's actuation quarantine is authored prose today: `### Invariants` declares
+the rate/scope/prohibited-action bounds, but the section is never lowered into
+the render — it constrains the model only as prose, bounded in practice by the
+cwd-rooted workspace sandbox and the turn cap, with no world-mutation actuation
+sink. Lowering it into the render (02 gap cluster 3) makes a projection-only
+contract's "the only writable surface is the published truth" a harness-enforced
+guarantee rather than an author's request. Author the boundary now; it binds once
+the harness lowers it.
+
+### 6. Forecast-paced continuity cadence
 
 The self-driven recheck path is wired (freshness-lapse → synthetic self-receipt,
 a zero-token fingerprint move), but `reactor serve` polls it on a flat
@@ -552,7 +661,7 @@ expiry instead of waking every interval — the *forecast-paced quiescence* Part
 implies. The author already writes the `valid_until` that feeds it; the cadence
 tightens harness-side, without a source change.
 
-### 5. Richer serve ingress adapters
+### 7. Richer serve ingress adapters
 
 `reactor serve` supports local cron-poll and HTTP, plus gateway poll connectors
 with a durable idempotency cursor. Queues, file watches, provider subscriptions,
@@ -560,7 +669,7 @@ and webhook authentication remain later runtime phases. Until they land, a
 file-watch-shaped responsibility is authored as a poll `### Continuity`; the
 intended ingress form should be noted in the contract so it migrates cleanly.
 
-### 6. The cryptographic signer (cross-trust-domain composition)
+### 8. The cryptographic signer (cross-trust-domain composition)
 
 The receipt ledger is content-addressed and chain-verifiable, and the `signer`
 is an explicit null-state (`kind: "null" | "signed"`, only `null` shipped). v1
@@ -578,6 +687,12 @@ runtime's guarantee.
 - A facet under-faceting lint exists; doctrine never promises an on-disk
   `published/<facet>/…` subtree.
 - The prose→spec materiality lowering is hardened across the example corpus.
+- The compiled postconditions are wired onto the live commit (`gateCommit`), so
+  the author's `### Maintains` postconditions are the enforced commit gate, not
+  only the render's self-attestation.
+- The `### Invariants` actuation boundary is lowered and harness-enforced, so a
+  projection-only contract's "only the published truth is writable" is a
+  guarantee, and the failed receipt carries the routed `reason`.
 - `reactor serve` arms `next_self_recheck` (forecast-paced cadence) so an idle
   reactor sleeps to the next real expiry.
 - The cryptographic signer lands and a pinned signer set is enforceable for


### PR DESCRIPTION
Brings the OpenProse spec (00-Tenets, 01-Language, 02-ReactorHarness, 03-ReactorPattern) into honest three-part parity:

- **Part I = the ideal** — implementation-agnostic, internally + cross-file consistent.
- **Part II = actual** — measured against shipped `@openprose/reactor*` + SKILL.
- **Part III = path** — a real actual→ideal roadmap, every item still genuinely remaining.

### Highlights
- Memo key stated as the 3-tuple `(contract_fingerprint, input_fingerprints, freshness_epoch)`; shipped 2-tuple confined to bridge notes.
- Ideal receipt schema reframed (drops the as-built v0 label) and gains `as_of` + failure `reason` + author-addressing, matching seam 3 and the Failure model.
- Precedence-stack scope and the commit-gate pillar (admissibility=correctness, fail-closed=safety) reconciled across 00/02/03.
- Deleted `prose` CLI binary and `### Criteria` residue removed from the ideal.
- Part III re-baselined off shipped reality: the corpus migration (std/co) retired as **done**; the receipt-shape (gap cluster 2) and actuation (gap cluster 3) forward items added so every Part II limit has a Part III item; section cross-references made consistent.

Docs-only (no code touched); test baselines unchanged. A background verification+repair workflow is still running and may surface follow-ups in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)