### PR TITLE
docs(spec): parity follow-ups from code-grounded verification

### DIFF
--- a/spec/00-Tenets.md
+++ b/spec/00-Tenets.md
@@ -19,8 +19,9 @@ corrupting the truth (correctness) and whose fail-closed default makes a render
 that cannot satisfy its obligations commit nothing rather than act (safety,
 Tenet 4). Below that floor the stack is the resolution rule for the
 safety → cost → silence trade-offs — Tenet 4's "safety outranks cost; cost
-outranks silence": safety is Tenet 4, cost is the resource budget the gates are
-constrained by, and interrupt-minimization is a downstream goal rather than an
+outranks silence": safety is Tenet 4, cost is the spend weighed against safety
+and silence — observed, never an enforced budget the gates run against — and
+interrupt-minimization is a downstream goal rather than an
 authority the other tenets bend around. The stack is not a separate runtime
 policy dial and does not override the numbered precedence — it projects that
 precedence onto the operational decisions; the numbered precedence governs
@@ -41,11 +42,12 @@ config, or a separate scoring artifact.
 The model acts as a bounded *agent* — with an environment, a filesystem, and
 the ability to read, write, and run code — that dynamically explores rather
 than consuming a one-shot context. Intelligence lives in exactly two layers it
-authors: the compilation (the canonicalizer and the postcondition validators,
-frozen once per contract) and the render (the bounded session that computes the
-next world-model). Deterministic code validates, schedules, records, and
-executes what the agent authored, and constrains it with limits the agent
-cannot override — it never decides meaning itself.
+authors: the compilation (the Forme topology, the per-node canonicalizer, and
+the postcondition validators, frozen once per contract) and the render (the
+bounded session that computes the next world-model). Deterministic code
+validates, schedules, records, and executes what the agent authored, and
+constrains it with limits the agent cannot override — it never decides meaning
+itself.
 
 ## 3. Continuity lives in the trail, not a session.
 

--- a/spec/01-Language.md
+++ b/spec/01-Language.md
@@ -128,9 +128,9 @@ Part II is honest about how far the current skill has climbed toward them.
 ### What the responsibility's load-bearing sections mean
 
 Most `###` sections' meaning is self-evident
-from their name. Three carry the semantic load of a `kind: responsibility` and
+from their name. Four carry the semantic load of a `kind: responsibility` and
 the Ideal must state them rather than defer: `### Requires`, `### Maintains`,
-and `### Continuity`.
+`### Continuity`, and `### Invariants`.
 
 **`### Maintains` is the world-model schema — the truth this node keeps
 current.** It does four jobs at once: it *types* the maintained truth; it
@@ -181,6 +181,19 @@ Freshness *state* lives in the world-model as data; `### Continuity` carries onl
 the *policy* that reads it. When a `valid_until` lapses, the harness mechanically
 moves the affected facet's fingerprint and wakes the node — no model call to
 decide that time has passed.
+
+**`### Invariants` declares the render's actuation boundary — the bound on how it
+may touch the world.** A render may act (send the mail, write the register), but
+`### Invariants` states the rate and scope of that world-mutation and the
+mutations it must not make ("only the published truth is writable; never modify
+the observed system"). It is the authoring-time half of the render/commit split:
+only the canonicalized published truth re-enters the memo, and `### Invariants`
+bounds everything else the render may do. (This is the capability *rate/scope*
+bound; which collaborators a render may call is `### Shape`'s job.) In the ideal
+the harness lowers and enforces this boundary at the render/commit split; today
+it is authored prose the render is asked to honor, not yet harness-enforced —
+see [02-ReactorHarness.md](./02-ReactorHarness.md) Part II gap cluster 3 and
+Part III §3.
 
 The author writes these; the harness owns the fingerprinting, the forecast
 cadence, the receipts, and the subscription wiring. The granular how-to —
@@ -348,7 +361,7 @@ The root layout is:
 | `runs/` | Activation receipts for bounded VM runs |
 | `state/` | Durable cross-run state |
 | `state/agents/` | Durable agent memory |
-| `state/world-model/{node}/` | Each responsibility's persisted canonical world-model, with its signed, append-only `receipts.jsonl` ledger (no separate status/pressure store — the judge loop is retired) |
+| `state/world-model/{node}/` | Each responsibility's persisted canonical world-model, with its signed, append-only `receipts.jsonl` ledger — the language VM root layout (the Reactor harness's own state-dir uses a flat `receipts.json`, [02-ReactorHarness.md](./02-ReactorHarness.md)); no separate status/pressure store — the judge loop is retired |
 | `deps/` | Installed git-native dependencies |
 | `prose.lock` | Dependency lockfile |
 | `.env` | Local runtime environment |
@@ -409,7 +422,7 @@ The five current authored kinds are:
 | --- | --- | --- |
 | `responsibility` | Served (continuously reconciled) | The headline kind: a mounted DAG node maintaining a standing truth over time |
 | `function` | Called (one-shot) | A stateless, ephemeral helper: bind `### Parameters`, run one render, return `### Returns`. No Forme phase, no world-model. (Renamed from `service`.) |
-| `gateway` | Mounted as external-driven | Sugar for an external-driven responsibility; compiled into a trigger registration for `prose serve` |
+| `gateway` | Mounted as external-driven | Sugar for an external-driven responsibility; compiled into a trigger registration the Reactor harness serves (`reactor serve`) |
 | `test` | Via `prose test` | Fixtures plus natural-language assertions against a subject responsibility or function |
 | `pattern` | Instantiated at compile time | Reusable coordination algorithm expanded into nodes; never directly run |
 
@@ -786,8 +799,9 @@ or platform improvements.
 
 **Migration status:** `packages/std/` and `packages/co/` are now **migrated** to
 the current vocabulary — **zero** `kind: service`, `kind: system`, or
-`### Ensures` remain. Their contracts use `kind: function` (≈35 files),
-`kind: responsibility`, the unchanged `kind: pattern` (19), and `kind: test`. (`co`
+`### Ensures` remain. Their contracts use `kind: function` (≈35 files), the
+unchanged `kind: pattern` (19), `kind: test`, and `kind: responsibility` (in
+`std` only — `co` is functions, patterns, and tests). (`co`
 keeps its on-disk directory names `services/` and `systems/` for path stability,
 even though the contracts inside are migrated.)
 

--- a/spec/02-ReactorHarness.md
+++ b/spec/02-ReactorHarness.md
@@ -994,9 +994,9 @@ The packages are already published (`@openprose/reactor` 0.3.1,
 `@openprose/reactor-cli` 0.2.2, `@openprose/reactor-devtools` 0.2.0) with OIDC
 provenance, so the headline of earlier roadmaps is done. The remaining work is
 **closing the three gap clusters** the Conformance Ledger names (§1–§5 below
-correspond to them), then publish hardening and the deferred enhancements and
-recursions (§6–§9). It is ordered by leverage: the commit-gate and freshness
-items are load-bearing.
+correspond to them), then publish hardening, the deferred enhancements and
+recursions, and production hardening (§6–§10). It is ordered by leverage: the
+commit-gate and freshness items are load-bearing.
 
 #### 1. Wire `gateCommit` Into The Run-Phase Commit  *(gap cluster 1)*
 
@@ -1085,6 +1085,20 @@ and deferred past v1.
 and within a reactor drains stay serial behind a per-reactor queue. Adding a
 node-level render worker pool (the pool pulling individual ready node-renders,
 preserving single-flight-per-node) is the deferred Change B.
+
+#### 10. Declared-Capability Resolution + Production Hardening
+
+Three honest deferrals share one theme — the harness does not yet act on what the
+contract or operator declares: (a) **declared capabilities are inert** —
+`### Tools` / `### Environment` / `### Skills` are authored name-only but the
+harness neither resolves nor enforces them (compile reads only
+Requires/Maintains/Continuity/Execution; the render runs a fixed built-in
+toolset), so resolving them fail-closed and passing the declared surface to the
+render is owed; (b) **`serve` ships no auth** — the HTTP surface is
+single-operator / trusted-network until fronted by a proxy, and an auth layer is
+needed before the trigger route is exposed; (c) **no async storage seam** — the
+storage adapter is synchronous, so a Postgres / durable-cloud adapter is out of
+scope until the seam goes async.
 
 ### Required Evaluation Suite
 
@@ -1203,8 +1217,8 @@ Sober. Make a strong claim, then show the evidence and the limits.
 ### Definition Of Done For Launch
 
 - `@openprose/reactor`, `@openprose/reactor-cli`, and
-  `@openprose/reactor-devtools` are public, version-consistent, and provenance-
-  verified through the OIDC gate.
+  `@openprose/reactor-devtools` are public, each published at its own version on
+  the `reactor-v*` train, and provenance-verified through the OIDC gate.
 - `gateCommit`'s compiled validators are wired into the run-phase commit (invariant
   6 / gap cluster 1 closed), not only the render's self-attestation.
 - The durable receipt carries `as_of`, a failure `reason`, and an author-addressing

--- a/spec/03-ReactorPattern.md
+++ b/spec/03-ReactorPattern.md
@@ -488,7 +488,7 @@ kinds and sections Part I names, and only those.
 | `kind: responsibility` with `### Goal` / `### Requires` / `### Maintains` / `### Continuity` / `### Invariants` (+ `### Tools` / `### Shape` / `### Runtime`) | Present and canonical (`concepts/responsibility.md`, `contract-markdown.md`); `id:` is tooling-minted and stable across `name:`/filename renames |
 | `kind: function` with `### Parameters` / `### Returns` — a stateless called helper (the former `service`) | Present; run as a lone render with no Forme phase |
 | `kind: gateway` — sugar for an external-driven responsibility; Forme's entry-point set | Present; `reactor serve` registers it and stages ingress (fetch → extract → stage + a durable idempotency cursor) |
-| `kind: pattern` / `kind: test` | Present; patterns expand at compile time, tests route to `prose test` / `reactor` test semantics |
+| `kind: pattern` / `kind: test` | Present; patterns expand at compile time, tests route to the in-session `prose test` semantic (there is no `reactor test` subcommand) |
 | Facets: `####` parts under `### Maintains` — name = fingerprint unit + subscription symbol; atomic default | Present and **facet-granular propagation is live in production** (the v2 named-parts model); a downstream subscribed to one facet does not wake when another moves |
 | `### Maintains` as the world-model schema doing four jobs (type, canonicalization spec, facets, postconditions) | Present; the postconditions live **inside `### Maintains`**, compiled to validators (there is no separate `### Criteria` section — it was removed) |
 | `### Continuity` as the structural wake-source declaration (input / self / external) | Present; self-driven recheck and the gateway entry point are both wired (Phase 4) |
@@ -518,7 +518,7 @@ reality is honest, rule by rule.
 | --- | --- | --- |
 | 1. Intent lives in the responsibility | Conformant | Fully authorable today |
 | 2. Materiality stated semantically in `### Maintains` | Conformant (authoring) | The author states materiality in prose; it is lowered to a deterministic canonicalizer. The lowering runs **only spec→code** — a compile session reads the `### Maintains` prose and emits the canonicalization spec, which the deterministic producer compiles. There is no `.prose` *parser*; compile is sessions, not a grammar |
-| 3. No host-specific contract logic | Conformant | `### Tools` (`cli:` / `mcp:`) and `### Environment` are name-only; resolution is fail-closed and never installs or contacts at compile |
+| 3. No host-specific contract logic | Conformant (authoring); harness resolution deferred | `### Tools` (`cli:` / `mcp:`), `### Environment`, and `### Skills` are authored name-only and never install or contact at compile — but the Reactor harness does not yet **consume** them: compile reads only `### Requires`/`### Maintains`/`### Continuity`/`### Execution`, and the render runs a fixed built-in toolset, so declared capability names are inert today. Fail-closed resolution/enforcement of the declared surface is a forward item (02 Part III §10) |
 | 4. Bounded activations | Conformant | Idiomatic; the "loop until done" anti-pattern is author error, not a skill gap |
 | 5. Written for memoization / variable depth | Conformant | The reconciler's skip on `(contract_fp, input_fp)` is live (cost scales with surprise, including an immaterial-churn re-poll that still skips); facet selectors are live; depth is an `if`-gated `call` in `### Execution`. The author's leverage is real today |
 | 6. Composition via a subscribed upstream facet | Conformant (meaning-layer) | A downstream names the upstream facet in `### Requires` and Forme wires the edge; receipts are content-addressed and the chain is verifiable. The **cryptographic** signer is a null-state — v1 "signed" is meaning-layer chain-consistency, not a byte-hash — so cross-trust-domain *pinning to a signer set* is not yet enforceable |
@@ -614,9 +614,9 @@ should mirror the load they bear:
   is an expected, high-value `failed` receipt routed to the author — **never** a
   `blocked`/`drifting` status enum (those are retired).
 - The failed receipt that *names the gap and routes it to the author* depends on
-  the harness widening the durable receipt with a `reason` + author-addressing
-  field (02 gap cluster 2); until that lands, the doctrine is authorable but the
-  routed reason is dropped at commit. Author to it now.
+  the harness widening the durable receipt with `as_of`, a `reason`, and an
+  author-addressing field (02 gap cluster 2); until that lands, the doctrine is
+  authorable but the routed reason is dropped at commit. Author to it now.
 
 ### 3. Land the materiality lowering's prose→spec half
 
@@ -658,8 +658,11 @@ a zero-token fingerprint move), but `reactor serve` polls it on a flat
 `--poll-interval`. The deferred work is arming each node's soonest
 `next_self_recheck` off its freshness so an idle reactor sleeps to the next real
 expiry instead of waking every interval — the *forecast-paced quiescence* Part I
-implies. The author already writes the `valid_until` that feeds it; the cadence
-tightens harness-side, without a source change.
+implies. The same step is owed for a gateway's declared `### Schedule`, which the
+compiler drops today (so the gateway runs on the flat serve poll, not its
+authored cadence); honoring it as a freshness-paced cadence rides with this work.
+The author already writes the `valid_until` (and the `### Schedule`) that feeds
+it; the cadence tightens harness-side, without a source change.
 
 ### 7. Richer serve ingress adapters
 
@@ -672,8 +675,9 @@ intended ingress form should be noted in the contract so it migrates cleanly.
 ### 8. The cryptographic signer (cross-trust-domain composition)
 
 The receipt ledger is content-addressed and chain-verifiable, and the `signer`
-is an explicit null-state (`kind: "null" | "signed"`, only `null` shipped). v1
-"signed" means meaning-layer chain-consistency. The deferred milestone is the
+is an explicit null-state (`{ scheme: "none", null_reason: ... }`; the signature
+union ships only the null branch). v1 "signed" means meaning-layer
+chain-consistency. The deferred milestone is the
 cryptographic byte-hash signer, after which a downstream can pin an *acceptable
 signer set* in `### Requires` and have it enforced — closing the cross-trust-domain
 supply-chain edge that is, today, the author's discipline rather than the


### PR DESCRIPTION
Follow-up to #127. Repairs surfaced by an independent code-grounded verification pass (a 58-agent workflow that verified Part I=ideal / Part II=actual-vs-code / Part III=path, with adversarial confirmation). Each fix below was re-checked against the source.

**00-Tenets** — cost is observed, not budgeted (drops the “resource budget the gates are constrained by” gloss); Tenet 2 lists all three model-authored compile artifacts (Forme topology + canonicalizer + postcondition validators).
**01-Language** — states the `### Invariants` actuation-boundary ideal in Part I (the Part III delta now has a Part I to measure against), with a bridge note that it is authored-only today; gateway compiles to a trigger the **reactor** serves (not a non-existent `prose serve`); migration line corrected (`co` has **0** `kind: responsibility`; `std` has 3); distinguishes the language-root `receipts.jsonl` from the harness `receipts.json`.
**02-ReactorHarness** — launch DoD no longer implies version-equality (independent versions on the `reactor-v*` train); new **Part III §10** (declared-capability resolution + `serve` auth + async storage seam) so every Honest-Limit has a forward item.
**03-ReactorPattern** — signer rendered as shipped code (`{ scheme: \"none\", null_reason }`, no invented `kind: \"null\"|\"signed\"`); Part II now honest that `### Tools`/`### Environment`/`### Skills` are authored name-only and **not** consumed by the harness (compile slices only Requires/Maintains/Continuity/Execution; render uses a fixed toolset); `as_of` added to the gap-cluster-2 receipt set; gateway `### Schedule` forward item; corrects the non-existent `reactor test` subcommand.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)