### PR TITLE
fix(reactor): height-ordered, dirty-count-gated reconciler drain (MK-1)

### DIFF
--- a/packages/reactor/src/reactor/__tests__/reconciler-async.test.ts
+++ b/packages/reactor/src/reactor/__tests__/reconciler-async.test.ts
@@ -23,6 +23,7 @@ import {
   type FingerprintMap,
   type InputFingerprints,
   type Receipt,
+  type TopologyEdge,
   type TopologyWorldModel,
   type Wake,
   type WorldModelCommit,
@@ -93,6 +94,7 @@ function fakeWorldModelRef(node: string): WorldModelRef {
 }
 
 const inputWake: Wake = { source: "input", refs: [] };
+const externalWake: Wake = { source: "external", refs: [] };
 
 const singleNodeTopology: TopologyWorldModel = {
   nodes: [],
@@ -433,4 +435,198 @@ test("coalescing-under-await: MANY wakes during one render collapse to a single 
     ["i4"],
     "the single follow-up renders against the freshest inputs (i4, last-writer-wins)",
   );
+});
+
+// ==========================================================================
+// MK-1 (async twin) — the height-ordered drain over `drainAsync`, with an
+// OBSERVABLY-SLOW long path. The await-frontier gap: the height frontier must
+// not advance until the awaited render commits. If `drainAsync` advanced before
+// a producer settled, the staggered glitch returns ON THE ASYNC PATH ONLY (the
+// path `serve` uses) — the slow long path makes a premature E fire detectable.
+// ==========================================================================
+
+const STAGGERED_DIAMOND = [
+  { producer: "A", subscriber: "B" },
+  { producer: "B", subscriber: "C" },
+  { producer: "A", subscriber: "E" }, // short edge (1 hop)
+  { producer: "C", subscriber: "E" }, // long path tail (3 hops)
+];
+
+const SYMMETRIC_DIAMOND = [
+  { producer: "A", subscriber: "B" },
+  { producer: "A", subscriber: "C" },
+  { producer: "B", subscriber: "E" },
+  { producer: "C", subscriber: "E" },
+];
+
+interface AsyncChainRender {
+  node: string;
+  inputs: { producer: string; fp: string }[];
+}
+
+/**
+ * Async chain harness (the async twin of reconciler.test.ts's `chainHarness`):
+ * table-sourced, drives the REAL `reconciler.drainAsync`. `delays[node]` makes a
+ * node's awaited render observably slow (the long path), so a frontier that
+ * advanced before settling would fire E against a stale C.
+ */
+function asyncChainHarness(
+  edges: readonly { producer: string; subscriber: string }[],
+  delays: Record<string, number> = {},
+): {
+  reconciler: ReturnType<typeof createReconciler>;
+  renderCounts: Record<string, number>;
+  renderLog: AsyncChainRender[];
+  resetBookkeeping: () => void;
+  bumpInput: () => void;
+} {
+  const nodeIds = [...new Set(edges.flatMap((e) => [e.producer, e.subscriber]))];
+  const ledger = new FakeLedger();
+  const published: Record<string, string> = {};
+  for (const n of nodeIds) published[n] = "seed:" + n;
+  let extInput = "ext:0";
+  const lastRenderedInputs: Record<string, string> = {};
+  const renderCounts: Record<string, number> = {};
+  for (const n of nodeIds) renderCounts[n] = 0;
+  const renderLog: AsyncChainRender[] = [];
+  let renderSeq = 0;
+
+  const topology: TopologyWorldModel = {
+    nodes: nodeIds.map((n) => ({
+      node: asNodeId(n),
+      contract_fingerprint: asFingerprint(CONTRACT_A),
+      wake_source: "input",
+    })),
+    edges: edges.map((e) => ({
+      subscriber: asNodeId(e.subscriber),
+      producer: asNodeId(e.producer),
+      facet: ATOMIC_FACET,
+    })),
+    entry_points: [asNodeId("A")],
+    acyclic: true,
+  };
+
+  const renderOnce = (req: RenderRequest): RenderOutcome => {
+    const node = req.node;
+    renderCounts[node] = (renderCounts[node] ?? 0) + 1;
+    renderSeq += 1;
+    const seenInputs = req.input_fingerprints.map(String);
+    const inbound = req.inbound_edges.map((e) => String(e.producer));
+    renderLog.push({
+      node,
+      inputs: inbound.map((p, i) => ({ producer: p, fp: seenInputs[i] ?? "" })),
+    });
+    const nowKey = JSON.stringify(seenInputs);
+    const moved =
+      lastRenderedInputs[node] === undefined || lastRenderedInputs[node] !== nowKey;
+    lastRenderedInputs[node] = nowKey;
+    if (moved) published[node] = "v" + renderSeq + ":" + node;
+    const commit: WorldModelCommit = {
+      node: asNodeId(node),
+      version: ("sha256:" +
+        ("c".repeat(63) + String(renderSeq % 10))) as ContentAddress,
+      fingerprints: atomic(published[node] ?? "seed:" + node),
+    };
+    return { status: "rendered", commit, semantic_diff: {}, cost: RENDER_COST };
+  };
+
+  const ports: ReconcilerPorts = {
+    ledger,
+    worldModel: { publishedRef: (node) => fakeWorldModelRef(node) },
+    resolveInputFingerprints: (node: string, inEdges: readonly TopologyEdge[]) =>
+      node === "A"
+        ? [asFingerprint(extInput)]
+        : inEdges.map((e) =>
+            asFingerprint(published[String(e.producer)] ?? "seed:" + String(e.producer)),
+          ),
+    spawnRender: () => {
+      throw new Error("sync spawnRender must not be used on the async path");
+    },
+    spawnRenderAsync: async (req: RenderRequest) => {
+      const d = delays[req.node] ?? 0;
+      // A real suspension on the slow long path — exercises the await-frontier.
+      await new Promise<void>((r) => setTimeout(r, d));
+      return renderOnce(req);
+    },
+  };
+
+  const reconciler = createReconciler(ports, {
+    topology,
+    contract_fingerprints: Object.fromEntries(
+      nodeIds.map((n) => [n, asFingerprint(CONTRACT_A)]),
+    ),
+  });
+  return {
+    reconciler,
+    renderCounts,
+    renderLog,
+    resetBookkeeping: () => {
+      for (const n of nodeIds) renderCounts[n] = 0;
+      renderLog.length = 0;
+    },
+    bumpInput: () => {
+      extInput = "ext:1";
+    },
+  };
+}
+
+/** Cold-start a chain in dependency order, returning the pre-wake published map. */
+async function coldStartAsync(
+  reconciler: ReturnType<typeof createReconciler>,
+  order: readonly string[],
+): Promise<void> {
+  for (const n of order) {
+    await reconciler.drainAsync([{ node: n, wake: inputWake }]);
+  }
+}
+
+test("drainAsync (MK-1): staggered diamond with a SLOW long path — the join renders ONCE against settled inputs (await-frontier closed)", async () => {
+  const h = asyncChainHarness(STAGGERED_DIAMOND, { B: 15, C: 25 });
+  // Cold-start A,B,C,E in dependency order so the next wake is an incremental wave.
+  await coldStartAsync(h.reconciler, ["A", "B", "C", "E"]);
+  h.resetBookkeeping();
+  h.bumpInput();
+  await h.reconciler.drainAsync([{ node: "A", wake: externalWake }]);
+
+  equal(h.renderCounts["E"], 1, "E renders exactly once on the async path (no premature fire)");
+  // No E render saw A-moved-but-C-still-seed (the async glitch).
+  const glitched = h.renderLog
+    .filter((x) => x.node === "E")
+    .some((er) => {
+      const a = er.inputs.find((i) => i.producer === "A");
+      const c = er.inputs.find((i) => i.producer === "C");
+      return !!a && !!c && a.fp !== "seed:A" && c.fp.startsWith("seed:");
+    });
+  equal(glitched, false, "no async glitch — E never fired against a stale (seed) C");
+  equal(h.renderCounts["A"], 1);
+  equal(h.renderCounts["B"], 1);
+  equal(h.renderCounts["C"], 1);
+});
+
+test("drainAsync (MK-1 control): symmetric equal-path diamond renders the join once", async () => {
+  const h = asyncChainHarness(SYMMETRIC_DIAMOND, { B: 10, C: 20 });
+  await coldStartAsync(h.reconciler, ["A", "B", "C", "E"]);
+  h.resetBookkeeping();
+  h.bumpInput();
+  await h.reconciler.drainAsync([{ node: "A", wake: externalWake }]);
+  equal(h.renderCounts["E"], 1);
+  equal(h.renderCounts["A"], 1);
+  equal(h.renderCounts["B"], 1);
+  equal(h.renderCounts["C"], 1);
+});
+
+test("drainAsync (MK-1): a no-change re-drain renders zero (prune holds on the async path)", async () => {
+  const h = asyncChainHarness(STAGGERED_DIAMOND, { B: 10, C: 15 });
+  await coldStartAsync(h.reconciler, ["A", "B", "C", "E"]);
+  h.bumpInput();
+  await h.reconciler.drainAsync([{ node: "A", wake: externalWake }]); // a real wave
+  h.resetBookkeeping();
+  const results = await h.reconciler.drainAsync([{ node: "A", wake: externalWake }]);
+  equal(
+    Object.values(h.renderCounts).reduce((a, b) => a + b, 0),
+    0,
+    "a no-change async re-drain renders nothing",
+  );
+  equal(results.length, 1, "only the seed produced a receipt; the closure pruned");
+  equal(results[0]?.disposition, "skipped");
 });

--- a/packages/reactor/src/reactor/__tests__/reconciler.test.ts
+++ b/packages/reactor/src/reactor/__tests__/reconciler.test.ts
@@ -33,6 +33,7 @@ import {
   type RenderRequest,
   type WakeEvent,
   COLD_START_ATOMIC_FINGERPRINT,
+  computeHeights,
   createReconciler,
   inboundEdges,
   memoKeyMoved,
@@ -879,6 +880,323 @@ test("facet eval (diamond): a subscriber reachable by two moved facets of one pr
   equal(xWakes.length, 1, "the diamond reconverges to ONE wake, not one per edge");
   equal(xWakes[0]?.disposition, "rendered");
   equal(h.renderCount(), before + 2, "one vendor render + one single x_sub render");
+});
+
+// ==========================================================================
+// MK-1 — the height-ordered, dirty-count-gated drain + the staggered
+// (unequal-path) diamond regression.
+//
+// The stock FIFO drain renders a recombinant join with UNEQUAL path lengths
+// TWICE: once prematurely against a half-propagated input set (a GLITCH — the
+// short edge moved, the long path is still stale), then again once the long
+// path settles (a REDUNDANT render). "Cost scales with surprise" (Invariant 5)
+// visibly fails for that topology. The height-ordered drain fires each node
+// once, in ascending height, only after all its dirty producers have settled —
+// so the join renders EXACTLY ONCE against fully-settled inputs.
+//
+// These tests drive the REAL `reconciler.drain` over an independent A→B→C→E
+// chain (the existing `harness` hand-feeds tuples; `facetHarness` is
+// single-producer — neither models a multi-hop chain), porting the C1 live-repro
+// mechanism: each node reads its upstreams' CURRENT published fingerprints from a
+// mutable table and moves its own fingerprint iff its inputs moved.
+// ==========================================================================
+
+/** Cheap dependency-respecting (Kahn) order for cold-starting a chain. */
+function topoOrder(
+  nodeIds: readonly string[],
+  edges: readonly { producer: string; subscriber: string }[],
+): string[] {
+  const indeg: Record<string, number> = {};
+  const out: Record<string, string[]> = {};
+  for (const n of nodeIds) {
+    indeg[n] = 0;
+    out[n] = [];
+  }
+  for (const e of edges) {
+    indeg[e.subscriber] = (indeg[e.subscriber] ?? 0) + 1;
+    (out[e.producer] ??= []).push(e.subscriber);
+  }
+  const q = nodeIds.filter((n) => (indeg[n] ?? 0) === 0);
+  const order: string[] = [];
+  while (q.length > 0) {
+    const n = q.shift() as string;
+    order.push(n);
+    for (const m of out[n] ?? []) {
+      indeg[m] = (indeg[m] ?? 0) - 1;
+      if (indeg[m] === 0) q.push(m);
+    }
+  }
+  return order;
+}
+
+interface ChainRender {
+  node: string;
+  inputs: { producer: string; fp: string }[];
+  moved: boolean;
+}
+
+/**
+ * A chain-capable, table-sourced harness (port of `c1-diamond-glitch`): each
+ * node reads its inbound producers' CURRENT published fingerprints and, on
+ * render, moves its own published fingerprint iff its input tuple moved since it
+ * last rendered. Drives the REAL `reconciler.drain`/`drainAsync`. `stableNodes`
+ * render but never move their published truth (so they settle their downstreams
+ * WITHOUT propagating — the prune path).
+ */
+function chainHarness(
+  edges: readonly { producer: string; subscriber: string }[],
+  opts?: { stableNodes?: readonly string[] },
+): {
+  reconciler: ReturnType<typeof createReconciler>;
+  nodeIds: string[];
+  renderCounts: Record<string, number>;
+  renderLog: ChainRender[];
+  ledger: FakeLedger;
+  preWake: Record<string, string>;
+  resetBookkeeping: () => void;
+  bumpInput: () => void;
+} {
+  const stable = new Set(opts?.stableNodes ?? []);
+  const nodeIds = [...new Set(edges.flatMap((e) => [e.producer, e.subscriber]))];
+  const ledger = new FakeLedger();
+  const published: Record<string, string> = {};
+  for (const n of nodeIds) published[n] = "seed:" + n;
+  let extInput = "ext:0";
+  const lastRenderedInputs: Record<string, string> = {};
+  const renderCounts: Record<string, number> = {};
+  for (const n of nodeIds) renderCounts[n] = 0;
+  const renderLog: ChainRender[] = [];
+  let renderSeq = 0;
+
+  const topology: TopologyWorldModel = {
+    nodes: nodeIds.map((n) => ({
+      node: asNodeId(n),
+      contract_fingerprint: asFingerprint(CONTRACT_A),
+      wake_source: "input",
+    })),
+    edges: edges.map((e) => ({
+      subscriber: asNodeId(e.subscriber),
+      producer: asNodeId(e.producer),
+      facet: ATOMIC_FACET,
+    })),
+    entry_points: [asNodeId("A")],
+    acyclic: true,
+  };
+
+  const ports: ReconcilerPorts = {
+    ledger,
+    worldModel: { publishedRef: (node) => fakeWorldModelRef(node) },
+    resolveInputFingerprints: (node, inEdges) =>
+      node === "A"
+        ? [asFingerprint(extInput)]
+        : inEdges.map((e) =>
+            asFingerprint(published[String(e.producer)] ?? "seed:" + String(e.producer)),
+          ),
+    spawnRender: (req) => {
+      const node = req.node;
+      renderCounts[node] = (renderCounts[node] ?? 0) + 1;
+      renderSeq += 1;
+      const seenInputs = req.input_fingerprints.map(String);
+      const inbound = req.inbound_edges.map((e) => String(e.producer));
+      const seen = inbound.map((p, i) => ({ producer: p, fp: seenInputs[i] ?? "" }));
+      const prevKey = lastRenderedInputs[node];
+      const nowKey = JSON.stringify(seenInputs);
+      const moved = prevKey === undefined || prevKey !== nowKey;
+      lastRenderedInputs[node] = nowKey;
+      renderLog.push({ node, inputs: seen, moved });
+      if (moved && !stable.has(node)) {
+        published[node] = "v" + renderSeq + ":" + node;
+      }
+      const commit: WorldModelCommit = {
+        node: asNodeId(node),
+        version: ("sha256:" +
+          ("c".repeat(63) + String(renderSeq % 10))) as ContentAddress,
+        fingerprints: atomic(published[node] ?? "seed:" + node),
+      };
+      return { status: "rendered", commit, semantic_diff: {}, cost: RENDER_COST };
+    },
+  };
+
+  const reconciler = createReconciler(ports, {
+    topology,
+    contract_fingerprints: Object.fromEntries(
+      nodeIds.map((n) => [n, asFingerprint(CONTRACT_A)]),
+    ),
+  });
+
+  // Cold-start every node to a committed baseline in dependency order.
+  for (const n of topoOrder(nodeIds, edges)) {
+    reconciler.reconcile({ node: n, wake: inputWake });
+  }
+  const preWake: Record<string, string> = { ...published };
+
+  return {
+    reconciler,
+    nodeIds,
+    renderCounts,
+    renderLog,
+    ledger,
+    preWake,
+    resetBookkeeping: () => {
+      for (const n of nodeIds) renderCounts[n] = 0;
+      renderLog.length = 0;
+    },
+    bumpInput: () => {
+      extInput = "ext:1";
+    },
+  };
+}
+
+const STAGGERED_DIAMOND = [
+  { producer: "A", subscriber: "B" },
+  { producer: "B", subscriber: "C" },
+  { producer: "A", subscriber: "E" }, // short edge (1 hop)
+  { producer: "C", subscriber: "E" }, // long path tail (3 hops)
+];
+
+const SYMMETRIC_DIAMOND = [
+  { producer: "A", subscriber: "B" },
+  { producer: "A", subscriber: "C" },
+  { producer: "B", subscriber: "E" },
+  { producer: "C", subscriber: "E" },
+];
+
+/** Did any E render fire against A-moved-but-C-still-pre-wake (the glitch)? */
+function eGlitched(log: ChainRender[], cPreWake: string): boolean {
+  for (const er of log.filter((x) => x.node === "E")) {
+    const aIn = er.inputs.find((i) => i.producer === "A");
+    const cIn = er.inputs.find((i) => i.producer === "C");
+    if (!aIn || !cIn) continue;
+    if (aIn.fp !== "seed:A" && cIn.fp === cPreWake) return true;
+  }
+  return false;
+}
+
+// --- U1: computeHeights ----------------------------------------------------
+
+test("computeHeights: staggered diamond → A:0,B:1,C:2,E:3 (unequal path lengths)", () => {
+  deepEqual(computeHeights(["A", "B", "C", "E"], STAGGERED_DIAMOND), {
+    A: 0,
+    B: 1,
+    C: 2,
+    E: 3,
+  });
+});
+
+test("computeHeights: symmetric diamond → A:0,B:1,C:1,E:2 (equal path lengths)", () => {
+  deepEqual(computeHeights(["A", "B", "C", "E"], SYMMETRIC_DIAMOND), {
+    A: 0,
+    B: 1,
+    C: 1,
+    E: 2,
+  });
+});
+
+test("computeHeights: a forged cyclic topology throws (acyclicity is load-bearing)", () => {
+  let threw = false;
+  try {
+    computeHeights(
+      ["X", "Y"],
+      [
+        { producer: "X", subscriber: "Y" },
+        { producer: "Y", subscriber: "X" },
+      ],
+    );
+  } catch {
+    threw = true;
+  }
+  ok(threw, "a cycle must throw, not loop forever or return a bogus height");
+});
+
+// --- U0 (the primary) + U6 -------------------------------------------------
+
+test("drain (MK-1 PRIMARY): staggered unequal-path diamond — the join renders ONCE against settled inputs", () => {
+  const h = chainHarness(STAGGERED_DIAMOND);
+  const cPreWake = h.preWake["C"] as string;
+  h.resetBookkeeping();
+  h.bumpInput();
+  const results = h.reconciler.drain([{ node: "A", wake: externalWake }]);
+
+  equal(h.renderCounts["E"], 1, "E renders exactly once (stock FIFO renders it twice)");
+  equal(
+    eGlitched(h.renderLog, cPreWake),
+    false,
+    "no E render fired against A-moved-but-C-stale (no glitch)",
+  );
+  // The single E render saw the SETTLED C (moved off its pre-wake fingerprint).
+  const eRender = h.renderLog.find((x) => x.node === "E");
+  const cInput = eRender?.inputs.find((i) => i.producer === "C");
+  ok(cInput && cInput.fp !== cPreWake, "E saw the settled (post-wave) C fingerprint");
+  equal(h.renderCounts["A"], 1);
+  equal(h.renderCounts["B"], 1);
+  equal(h.renderCounts["C"], 1);
+  // Every node fired and the drain returned one result per fired node.
+  equal(results.filter((r) => r.disposition === "rendered").length, 4);
+});
+
+test("drain (MK-1 control): symmetric equal-path diamond — the join also renders once (the trigger is UNEQUAL length, not the shape)", () => {
+  const h = chainHarness(SYMMETRIC_DIAMOND);
+  h.resetBookkeeping();
+  h.bumpInput();
+  h.reconciler.drain([{ node: "A", wake: externalWake }]);
+  equal(h.renderCounts["E"], 1, "the symmetric control never glitched and still renders E once");
+  equal(h.renderCounts["A"], 1);
+  equal(h.renderCounts["B"], 1);
+  equal(h.renderCounts["C"], 1);
+});
+
+test("drain (MK-1): a no-change re-drain renders ZERO nodes and mints exactly one (seed) skip — the move-aware prune", () => {
+  const h = chainHarness(STAGGERED_DIAMOND);
+  // First, a real wave to settle everything.
+  h.bumpInput();
+  h.reconciler.drain([{ node: "A", wake: externalWake }]);
+  // Re-drain with NO input change: A skips, its whole downstream closure prunes.
+  h.resetBookkeeping();
+  const results = h.reconciler.drain([{ node: "A", wake: externalWake }]);
+  equal(
+    Object.values(h.renderCounts).reduce((a, b) => a + b, 0),
+    0,
+    "a no-change re-drain renders nothing (cost scales with surprise)",
+  );
+  equal(results.length, 1, "only the seed produced a receipt; the closure was pruned");
+  equal(results[0]?.node, "A");
+  equal(results[0]?.disposition, "skipped");
+});
+
+test("drain (MK-1): two seeds on one chain — the interior seed waits for its dirty upstream (no glitch)", () => {
+  // A→B→C; wake BOTH A and C. C is a directly-woken seed AND downstream of A→B.
+  // Without the interior-seed gate, C fires on its own wake against a pre-wake B,
+  // then again once B settles. The gate makes C wait until B settles ⇒ C renders
+  // once, against the moved B.
+  const h = chainHarness([
+    { producer: "A", subscriber: "B" },
+    { producer: "B", subscriber: "C" },
+  ]);
+  const bPreWake = h.preWake["B"] as string;
+  h.resetBookkeeping();
+  h.bumpInput();
+  h.reconciler.drain([
+    { node: "A", wake: externalWake },
+    { node: "C", wake: externalWake },
+  ]);
+  equal(h.renderCounts["C"], 1, "the interior seed fired exactly once (gate held)");
+  const cRender = h.renderLog.find((x) => x.node === "C");
+  const bInput = cRender?.inputs.find((i) => i.producer === "B");
+  ok(bInput && bInput.fp !== bPreWake, "C saw the settled (moved) B, not the pre-wake B");
+});
+
+test("drain (MK-1): a pruned interior node still settles a deeper join — no prune-deadlock", () => {
+  // Staggered diamond with B STABLE: A moves and wakes both E (short) and B
+  // (long). B renders but does NOT move its truth ⇒ C is settled-without-moved
+  // ⇒ C is PRUNED (no render). C must STILL settle E, or the depth-3 join
+  // deadlocks. E fires once (woken by A's short edge) against the unchanged C.
+  const h = chainHarness(STAGGERED_DIAMOND, { stableNodes: ["B"] });
+  h.resetBookkeeping();
+  h.bumpInput();
+  h.reconciler.drain([{ node: "A", wake: externalWake }]); // must not throw (no deadlock)
+  equal(h.renderCounts["C"], 0, "C was pruned (its only producer B settled without moving)");
+  equal(h.renderCounts["E"], 1, "the depth-3 join still fired exactly once — C settled it");
+  equal(h.renderCounts["A"], 1);
 });
 
 test("no judge: a skip never invokes the render (the harness never asks an LLM 'did this change')", () => {

--- a/packages/reactor/src/reactor/index.ts
+++ b/packages/reactor/src/reactor/index.ts
@@ -332,6 +332,51 @@ export interface ReconcilerHandle {
   ) => Promise<readonly ReconcileResult[]>;
 }
 
+/** A plain `input` wake — the fallback delivered to a downstream the drain
+ * fires before any producer propagated a wake-carrying receipt to it. */
+const INPUT_WAKE: Wake = { source: "input", refs: [] };
+
+/**
+ * The compile-time height of every node — Minsky's cheap partial order over the
+ * static topology (MK-1). `height(n) = 0` if `n` has no inbound edge (an entry
+ * node), else `1 + max(height(producer))`. Memoized DFS with a cycle guard
+ * (acyclicity is a compile-time postcondition — architecture.md §2 — but the
+ * run-phase throw is O(nodes), runs once per epoch, and is Tenet-5 evidence).
+ *
+ * The node set MUST be supplied by the caller from `edges ∪ entry_points` (NOT
+ * `topology.nodes`, which is `[]` in the compiled IR / tests) so a producer-only
+ * or entry-only node still gets a height.
+ */
+export function computeHeights(
+  nodeIds: readonly string[],
+  edges: readonly { readonly producer: string; readonly subscriber: string }[],
+): Readonly<Record<string, number>> {
+  const producersOf: Record<string, string[]> = {};
+  for (const n of nodeIds) producersOf[n] = [];
+  for (const e of edges) (producersOf[e.subscriber] ??= []).push(e.producer);
+
+  const height: Record<string, number> = {};
+  const visiting = new Set<string>();
+  const visit = (n: string): number => {
+    const cached = height[n];
+    if (cached !== undefined) return cached;
+    if (visiting.has(n)) {
+      throw new Error(
+        `reactor: cycle detected at "${n}" — the reconciler topology must be ` +
+          "acyclic (architecture.md §2: compile-time acyclicity postcondition).",
+      );
+    }
+    visiting.add(n);
+    let h = 0;
+    for (const p of producersOf[n] ?? []) h = Math.max(h, visit(p) + 1);
+    visiting.delete(n);
+    height[n] = h;
+    return h;
+  };
+  for (const n of nodeIds) visit(n);
+  return height;
+}
+
 /**
  * Construct the dumb reconciler over injected ports + a fixed compiled
  * topology. No judge, no policy, no backstop — the entire decision is
@@ -350,6 +395,162 @@ export function createReconciler(
       flight.set(node, state);
     }
     return state;
+  };
+
+  // --- MK-1: compile-time height table + producer/subscriber adjacency, the
+  // ordering substrate for the height-ordered, dirty-count-gated drain. Derived
+  // once here from the FROZEN topology edges ∪ entry_points.
+  //
+  // static-topology assumption: heights are compile-time constants per scheduling
+  // epoch; the fixpoint (C3, architecture.md §11) makes height dynamic — recompute
+  // on epoch rollover (createReconciler is already per-epoch), never cache across a
+  // rewire. Add NO dynamic-height / pseudo-height / GC-of-orphaned-nodes machinery
+  // here (it re-pays the Minsky costs this fix exists to avoid).
+  const drainEdges = topology.topology.edges.map((e) => ({
+    producer: String(e.producer),
+    subscriber: String(e.subscriber),
+  }));
+  const drainNodeIds = [
+    ...new Set<string>([
+      ...drainEdges.flatMap((e) => [e.producer, e.subscriber]),
+      ...topology.topology.entry_points.map(String),
+    ]),
+  ];
+  const heightOf = computeHeights(drainNodeIds, drainEdges);
+  const subscribersOf: Record<string, string[]> = {};
+  const producersOf: Record<string, string[]> = {};
+  for (const n of drainNodeIds) {
+    subscribersOf[n] = [];
+    producersOf[n] = [];
+  }
+  for (const e of drainEdges) {
+    (subscribersOf[e.producer] ??= []).push(e.subscriber);
+    (producersOf[e.subscriber] ??= []).push(e.producer);
+  }
+
+  // PASS 1 of a drain (shared by the sync + async paths): from the seed wakes,
+  // mark the transitive-closure DIRTY set and, for each dirty node, count its
+  // DISTINCT dirty producers — the number of upstream settle events it must
+  // observe before it may fire. Seeds with no dirty producer are ready at once
+  // (count 0); an INTERIOR seed (downstream of another seed) keeps a non-zero
+  // count and waits on its dirty upstreams — the interior-seed gate that stops
+  // the staggered glitch from re-appearing. Pure; only PASS 2's render call
+  // differs across sync/async, so the two loops stay split by function color.
+  const planDrain = (
+    initial: readonly WakeEvent[],
+  ): { seedNodes: Set<string>; dirty: Set<string>; remaining: Map<string, number> } => {
+    const seedNodes = new Set(initial.map((e) => String(e.node)));
+    const dirty = new Set<string>();
+    const stack = [...seedNodes];
+    while (stack.length > 0) {
+      const n = stack.pop() as string;
+      if (dirty.has(n)) continue;
+      dirty.add(n);
+      for (const s of subscribersOf[n] ?? []) {
+        if (!dirty.has(s)) stack.push(s);
+      }
+    }
+    const remaining = new Map<string, number>();
+    for (const n of dirty) {
+      const dirtyProducers = new Set(
+        (producersOf[n] ?? []).filter((p) => dirty.has(p)),
+      );
+      remaining.set(n, dirtyProducers.size);
+    }
+    return { seedNodes, dirty, remaining };
+  };
+
+  // The drain frontier: the per-drain bookkeeping shared by `drain` and
+  // `drainAsync`. Everything except the single render call (sync `reconcile` vs
+  // `await reconcileAsync`) lives here, so there is ONE implementation of the
+  // height ordering, the dirty-count gate, the settle-based decrement, and the
+  // move-aware prune — no two-copies drift, and the per-node single-flight guard
+  // in `reconcile`/`reconcileAsync` is reused untouched.
+  const startFrontier = (initial: readonly WakeEvent[]) => {
+    const { seedNodes, dirty, remaining } = planDrain(initial);
+    const done = new Set<string>(); // fired OR pruned — removed from the frontier
+    const moved = new Set<string>(); // a fired dirty producer propagated to this node
+    const wakeFor = new Map<string, Wake>();
+    for (const e of initial) wakeFor.set(String(e.node), e.wake);
+    const maxIter = drainNodeIds.length * 4 + 16;
+    let guard = 0;
+
+    return {
+      /**
+       * The next node to fire: the lowest-height ready node (dirty ∧ not done ∧
+       * all dirty producers settled), tie-broken by node id for determinism;
+       * `null` at quiescence. Throws on the iteration guard (deadlock defense).
+       */
+      next(): string | null {
+        const ready = [...dirty].filter(
+          (n) => !done.has(n) && (remaining.get(n) ?? 0) === 0,
+        );
+        if (ready.length === 0) return null;
+        if (++guard > maxIter) {
+          throw new Error(
+            "reactor: drain exceeded its iteration guard (possible topology deadlock).",
+          );
+        }
+        ready.sort(
+          (a, b) => (heightOf[a] ?? 0) - (heightOf[b] ?? 0) || (a < b ? -1 : 1),
+        );
+        return ready[0] as string;
+      },
+      /**
+       * Does this ready node actually render? A directly-woken seed always fires
+       * (its wake IS the move). A downstream fires only if ≥1 dirty producer
+       * propagated to it; one whose producers all settled WITHOUT moving it
+       * cannot itself have moved — it is PRUNED (no render, no skipped receipt).
+       */
+      shouldFire(node: string): boolean {
+        return seedNodes.has(node) || moved.has(node);
+      },
+      wakeOf(node: string): Wake {
+        return wakeFor.get(node) ?? INPUT_WAKE;
+      },
+      /**
+       * Record a processed node: carry a fired node's propagated wakes + mark
+       * the movement it caused, mark the node done, then SETTLE its downstreams
+       * — decrement EVERY dirty, not-yet-done subscriber whether or not this node
+       * moved (a memo-skipping or pruned producer must still settle its
+       * subscriber, else a join deadlocks). `result === null` is the prune path:
+       * suppress only the render, never the settle bookkeeping.
+       */
+      commit(node: string, result: ReconcileResult | null): void {
+        if (result !== null) {
+          for (const p of result.propagated) {
+            const target = String(p.node);
+            if (!dirty.has(target)) {
+              // Under static acyclic topology a propagated wake is always inside
+              // the precomputed dirty closure; a target outside it is a topology
+              // / propagation bug — surface it rather than silently fold it in.
+              throw new Error(
+                `reactor: drain propagation reached a non-dirty node "${target}" — ` +
+                  "the precomputed dirty closure is incomplete (topology/propagation bug).",
+              );
+            }
+            wakeFor.set(target, p.wake);
+            moved.add(target);
+          }
+        }
+        done.add(node);
+        for (const s of new Set(subscribersOf[node] ?? [])) {
+          if (!dirty.has(s) || done.has(s)) continue;
+          const r = remaining.get(s) ?? 0;
+          if (r > 0) remaining.set(s, r - 1);
+        }
+      },
+      /** Post-loop sanity: every dirty node must have been fired or pruned. */
+      finish(): void {
+        const unfinished = [...dirty].filter((n) => !done.has(n));
+        if (unfinished.length > 0) {
+          throw new Error(
+            "reactor: drain left dirty nodes unfired (deadlock): " +
+              unfinished.join(","),
+          );
+        }
+      },
+    };
   };
 
   const reconcile = (event: WakeEvent): ReconcileResult => {
@@ -436,18 +637,23 @@ export function createReconciler(
   const drain = (
     initial: readonly WakeEvent[],
   ): readonly ReconcileResult[] => {
+    // MK-1: height-ordered, dirty-count-gated drain (replaces the arrival-order
+    // FIFO queue). A recombinant (diamond) node with UNEQUAL path lengths fires
+    // exactly ONCE per wave, against FULLY-SETTLED inputs — no glitch render, no
+    // redundant render. `reconcile` (memo/skip, single-flight, commit, propagate)
+    // is reused byte-for-byte; only the SCHEDULING of wakes changes (the seam
+    // MK-1 lives in — the spec pins the per-node decision, never the drain order).
+    const frontier = startFrontier(initial);
     const results: ReconcileResult[] = [];
-    const queue: WakeEvent[] = [...initial];
-    while (queue.length > 0) {
-      const event = queue.shift() as WakeEvent;
-      const result = reconcile(event);
-      results.push(result);
-      // Propagation: only `rendered`-with-a-moved-fingerprint enqueues
-      // downstreams (architecture.md §4.1; world-model.md §8).
-      for (const downstream of result.propagated) {
-        queue.push(downstream);
+    for (let node = frontier.next(); node !== null; node = frontier.next()) {
+      let result: ReconcileResult | null = null;
+      if (frontier.shouldFire(node)) {
+        result = reconcile({ node, wake: frontier.wakeOf(node) });
+        results.push(result);
       }
+      frontier.commit(node, result);
     }
+    frontier.finish();
     return results;
   };
 
@@ -551,20 +757,25 @@ export function createReconciler(
   const drainAsync = async (
     initial: readonly WakeEvent[],
   ): Promise<readonly ReconcileResult[]> => {
+    // MK-1, async twin: the same height-ordered, dirty-count-gated frontier as the
+    // sync `drain`, but each fire is `await`ed FULLY before its settle/propagate
+    // bookkeeping is applied and the frontier re-evaluates `next()` — closing the
+    // await-frontier gap (the height frontier must not advance until the awaited
+    // render commits). Stays a serial pick-lowest-ready loop: NO node-level
+    // parallelism (Change B is deferred). `reconcileAsync` — including its per-node
+    // single-flight/coalesce guard — is reused untouched; the drain serialization
+    // and that guard are independent safety layers.
+    const frontier = startFrontier(initial);
     const results: ReconcileResult[] = [];
-    const queue: WakeEvent[] = [...initial];
-    // Serialized fixpoint loop: await each reconcile fully before shifting the
-    // next event (05 §1.2). Preserves today's FIFO ordering + "one render in
-    // flight per node" exactly; the only difference from the sync drain is the
-    // `await`.
-    while (queue.length > 0) {
-      const event = queue.shift() as WakeEvent;
-      const result = await reconcileAsync(event);
-      results.push(result);
-      for (const downstream of result.propagated) {
-        queue.push(downstream);
+    for (let node = frontier.next(); node !== null; node = frontier.next()) {
+      let result: ReconcileResult | null = null;
+      if (frontier.shouldFire(node)) {
+        result = await reconcileAsync({ node, wake: frontier.wakeOf(node) });
+        results.push(result);
       }
+      frontier.commit(node, result);
     }
+    frontier.finish();
     return results;
   };
 


### PR DESCRIPTION
## What

The arrival-order FIFO reconciler drains (`drain` / `drainAsync`) render a recombinant (diamond) join with **unequal path lengths twice**: once prematurely against a half-propagated input set (a **glitch** — the short edge moved, the long path is still stale), then again once the long path settles (a **redundant render**). "Cost scales with surprise" (Invariant 5) visibly fails for that topology — reproducible **live in the shipped `masked-relay` demo**.

This replaces both drains with a **compile-time height-ordered, dirty-input-count-gated** drain (Minsky / self-adjusting computation): a node fires exactly once, in ascending height, only after **every dirty producer has settled** — so a join renders **once, against fully-settled inputs**.

## How

- **`computeHeights` + adjacency**, derived once per epoch from the frozen topology `edges ∪ entry_points` (not `topology.nodes`, which is `[]` in the IR). Cycle-guard throw kept; a static-topology marker is left for the deferred fixpoint (C3).
- **One shared `startFrontier` core** — PASS-1 dirty closure + dirty-count, the height-ordered ready pick, settle-based decrement, and the move-aware prune — drives **both** the sync and async loops; only the render call differs. `reconcile` / `reconcileAsync` (including the per-node single-flight/coalesce guard) are **reused byte-for-byte**.
- The async path **awaits each fire fully before advancing the frontier** (closes the await-frontier gap) and stays **serial** (no Change-B node-level parallelism).
- **Settle-based** (not move-based) decrement so a memo-skipping producer never starves a join; **move-aware prune** so a no-change re-drain renders zero and mints only the seed's skip; **interior-seed gate** so a directly-woken interior node still waits on its dirty upstreams.

**Public API unchanged.** No caller edits — `drain` now returns fire-order rather than FIFO arrival-order; audited `sdk/mounted-dag`, `sdk/reactor-handle`, `sdk/continuity-scheduler` (interior-target seeds), `scenario/implementation-pipeline`: none asserts arrival order. **No `spec/` edit** — the spec pins the per-node decision, never the drain order (the seam MK-1 lives in).

## Tests (red-first)

The primary test **demonstrably failed on the pre-fix FIFO drain** (`E=2` with a glitch, proven in a scratch build of the unmodified `index.ts`) and passes after the fix:

- staggered unequal-path diamond (**sync + async**, async with an observably-slow long path) → join renders once against settled inputs;
- symmetric equal-path control (the trigger is *unequal length*, not the recombinant shape);
- no-change re-drain → zero renders / one seed skip (prune);
- two-seeds-on-one-chain (interior-seed gate);
- 3-deep prune-no-deadlock;
- `computeHeights` height assertions + forged-cyclic-topology throw.

Full `@openprose/reactor` suite green (the one failing test is a live OpenRouter call — `403 Key limit exceeded` — environmental, unrelated).

## Refs

- Plan: `planning/plans/2026-06-07-mk1-drain-fix/PLAN.md`
- Backlog: MK-1
- Prototype: `planning/ideation/minsky-experiments/c2-topo-drain/`

## Coordination note (not in this PR)

Plan U7 (re-scoping the REPORT "diamond single-wake = tested" sentence) is **owned by the credibility-seam batch** and is deliberately **left out of this PR** to avoid a write-collision; it can land once that batch settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)