### PR TITLE
fix(deps): sync pnpm-lock.yaml with the workspace package specs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         specifier: 0.11.6
         version: 0.11.6(@ai-sdk/provider@3.0.10)(@openai/agents@0.11.6(ws@8.21.0)(zod@4.4.3))(@openai/codex-sdk@0.125.0)(ai@6.0.195(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@openprose/reactor':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../reactor
       ai:
         specifier: 6.0.195
@@ -64,7 +64,7 @@ importers:
   packages/reactor-devtools:
     dependencies:
       '@openprose/reactor':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../reactor
     devDependencies:
       '@types/node':
@@ -76,6 +76,12 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+
+  packages/reactor-evals:
+    dependencies:
+      '@openprose/reactor':
+        specifier: workspace:^
+        version: link:../reactor
 
 packages:
 


### PR DESCRIPTION
### What
CI's `pnpm install --frozen-lockfile` (examples gate and other jobs) fails because
pnpm-lock.yaml drifted from the workspace package.json files:
- reactor-cli pins @openprose/reactor as `workspace:*` in the lockfile but
  `workspace:^` in package.json.
- reactor-evals is a workspace package but was never recorded in the lockfile.

Regenerated with the pinned pnpm 9.15.0 (`pnpm install --lockfile-only`); the diff is
exactly those two fixes and `pnpm install --frozen-lockfile` now passes.

### Note
This fixes the install step. It also unmasks separate example-test failures on main
(reactor reuse/skip behavior changed without regenerating the example fixtures),
which are being addressed separately.