### PR TITLE
chore: point product links at the canonical prose.md

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -25,14 +25,11 @@
     "shortDescription": "Write a Markdown contract (`.prose.md`). Your agent reads it, wires services, runs subagents, and leaves an auditable trace.",
     "longDescription": "OpenProse is a programming language for AI sessions. Write a Markdown contract: an agent reads it, wires the services, runs the subagents, passes artifacts through the filesystem, and leaves a durable trace under the active OpenProse root. Plain prompts are great for one-off work; they get messy when the same process needs roles, handoffs, retries, memory, or a receipt. The plugin activates on `prose ...`, on `.prose.md` files, and on requests for reusable multi-agent orchestration.",
     "category": "Productivity",
-    "capabilities": [
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Read", "Write"],
     "logo": "./assets/plugin/logo.png",
     "composerIcon": "./assets/plugin/composer-icon.png",
     "brandColor": "#8a6b2e",
-    "websiteURL": "https://openprose.ai",
+    "websiteURL": "https://prose.md",
     "privacyPolicyURL": "https://github.com/openprose/prose/blob/main/PRIVACY.md",
     "termsOfServiceURL": "https://github.com/openprose/prose/blob/main/TERMS.md",
     "defaultPrompt": [

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ To take one live, `cd` into its dir and run `reactor doctor → compile → topo
 
 ## The technical report
 
-The full architecture write-up (the React metaphor that _is_ the design, the Forme wiring, the receipt model, an honest RLM accounting, and why nothing on the market is a drop-in replacement) is the **[Reactor technical report](https://docs.openprose.ai/reactor)**.
+The full architecture write-up (the React metaphor that _is_ the design, the Forme wiring, the receipt model, an honest RLM accounting, and why nothing on the market is a drop-in replacement) is the **[Reactor technical report](https://docs.prose.md/reactor)**.
 
 ## Honest status
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -10,11 +10,11 @@ Static assets for the OpenProse language specification repository.
 
 ## Contents
 
-- `readme-header.svg` — Legacy SVG header graphic. The root README now points at the generated `https://openprose.ai/readme-header.png` route from the Run app so the GitHub hero stays aligned with the live brand system.
+- `readme-header.svg` — Legacy SVG header graphic. The root README now points at the generated `https://prose.md/readme-header.png` route from the Run app so the GitHub hero stays aligned with the live brand system.
 
 ## Plugin assets
 
 Wired into `.codex-plugin/plugin.json:interface` for Codex marketplace display.
 
-- `plugin/logo.png` — 512×512 PNG OpenProse wordmark, derived from https://openprose.ai/avatar.png (2048×2048) and resized.
-- `plugin/composer-icon.png` — 64×64 PNG icon, derived from https://openprose.ai/apple-icon (360×360) and resized. Designed to read down to 16px.
+- `plugin/logo.png` — 512×512 PNG OpenProse wordmark, derived from https://prose.md/avatar.png (2048×2048) and resized.
+- `plugin/composer-icon.png` — 64×64 PNG icon, derived from https://prose.md/apple-icon (360×360) and resized. Designed to read down to 16px.

--- a/skills/open-prose/agent-onboarding.md
+++ b/skills/open-prose/agent-onboarding.md
@@ -1,10 +1,10 @@
 <!--
 Canonical agent-onboarding narrative. This file is served at:
 
-  - https://openprose.ai/llms-full.txt
+  - https://prose.md/llms-full.txt
        apps/run/src/app/api/llms-full/route.ts reads it at build time
 
-  - https://openprose.ai/llms-full
+  - https://prose.md/llms-full
        apps/run/src/app/llms-full/page.tsx renders it at build time
 
 - https://curl-me.openprose.ai  (+ aliases: agents, hi, hello, start, readme, hey)
@@ -114,7 +114,7 @@ runs only when something material moves. A `function` is the called helper tier
 prose run research-monitor.prose.md
 ```
 
-The contract says *what*. The runtime figures out *how*. In an agent harness,
+The contract says _what_. The runtime figures out _how_. In an agent harness,
 `prose run ...` is an instruction inside the agent session. From a shell, pass
 that instruction to a Prose Complete runner, for example:
 
@@ -128,13 +128,13 @@ codex exec "prose run research-pipeline.prose.md"
 **For agents:**
 
 - [SKILL.md](https://raw.githubusercontent.com/openprose/prose/main/skills/open-prose/SKILL.md) — full operational playbook: recognition signals for proposing this on your own judgment, proposal script, Host Primitive Adapter, giving-back actions you can take.
-- [Language reference index](https://openprose.ai/llms.txt) — link hub for the specs (VM, Forme, tenets, examples).
+- [Language reference index](https://prose.md/llms.txt) — link hub for the specs (VM, Forme, tenets, examples).
 - [GitHub](https://github.com/openprose/prose) — source, 50+ annotated examples, issues.
 
 **For the human who sent you:**
 
-- [openprose.ai](https://openprose.ai) — product site.
-- [Learn](https://openprose.ai/learn) — language deep-dive.
+- [prose.md](https://prose.md) — product site.
+- [Learn](https://prose.md/learn) — language deep-dive.
 - [Book a demo](https://cal.com/irl-danb/openprose-intro).
 
 ---


### PR DESCRIPTION
prose.md is now the canonical product host; the apex/www openprose.ai and docs.openprose.ai redirect to it. Update the self-referential links in agent onboarding, the Codex plugin websiteURL, the asset docs, and the Reactor technical report so they target prose.md / docs.prose.md directly instead of bouncing through a redirect.