### PR TITLE
fix: omit unset temperature and honor reactor.yml temperature at render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by the skill in-session (there is no `prose` binary): by default the agent
   prints the `reactor` commands for the user to run, and `--start` drives the
   live lifecycle.
+- **`model.reasoning_effort` (`reactor.yml`) / `reasoningEffort` (SDK render and
+  compile options).** Passed verbatim into `modelSettings.reasoning.effort` —
+  values are model-dependent and validated by the provider. OpenAI reasoning
+  models accept a custom temperature only when effort is `none`, so this keeps
+  deterministic setups expressible on those models
+  (`temperature: 0` + `reasoning_effort: none`).
+
+### Changed
+
+- **An unset `temperature` is now omitted from model requests instead of
+  silently becoming 0.** OpenAI reasoning models (gpt-5.5, the o-series) reject
+  any explicit temperature, so "send no temperature" has to be representable:
+  deleting the `temperature:` line from `reactor.yml` — or leaving the SDK's
+  `RenderOptions.temperature` / `CompileSessionConfig.temperature` unset — now
+  sends none, and the provider's default applies. Projects that relied on the
+  implicit 0 should set `temperature: 0` explicitly (the `reactor init`
+  scaffold already writes it). Type surface: `ModelConfig.temperature` is now
+  optional, and `mergeModelSettings` omits the temperature key when none
+  resolves.
 
 ### Removed
 
@@ -28,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SDK + `reactor` CLI are the deterministic harness. The separately-authored
   `### Criteria` section is also removed (postconditions live solely in
   `### Maintains`).
+
+### Fixed
+
+- **`reactor.yml`'s `temperature` now governs run/serve renders, not only
+  compile.** `run`, `serve`, and the multi-reactor host thread
+  `model.temperature` / `model.reasoning_effort` into the render exactly like
+  `render_model`; previously a configured temperature reached compile sessions
+  while renders silently used the SDK default. `reactor doctor --live` no
+  longer pins temperature 0 in its connectivity probe (it 400ed against
+  reasoning render models), and the temperature-rejection 400 from a provider
+  now maps to an actionable hint naming the `reactor.yml` line to fix.
 
 ## [0.15.0] - 2026-06-04 — open-prose skill & plugin
 

--- a/packages/reactor-cli/README.md
+++ b/packages/reactor-cli/README.md
@@ -199,8 +199,10 @@ model:
   provider: openrouter
   render_model: google/gemini-3.5-flash
   compile_model: google/gemini-3.5-flash
-  temperature: 0
+  temperature: 0               # optional — delete the line to send no temperature
   max_turns: 200
+  # reasoning_effort: none     # reasoning models (gpt-5.x, o-series) reject an
+                               # explicit temperature unless effort is none
 
 sandbox:
   mode: none                   # none (default) | docker

--- a/packages/reactor-cli/src/__tests__/init.test.ts
+++ b/packages/reactor-cli/src/__tests__/init.test.ts
@@ -148,6 +148,10 @@ describe('reactor init (offline gate)', () => {
     try {
       await runInitCommand({ dir }, () => {});
       const config = loadConfig({ projectDir: dir });
+      // The scaffold pins an EXPLICIT temperature 0 (reproducible runs for the
+      // default models); deleting that line omits temperature entirely (the
+      // reasoning-model path), so the scaffold must keep writing it.
+      assert.equal(config.model.temperature, 0);
       assert.equal(config.sandbox.mode, 'none');
       assert.equal(config.gateways.length, 1);
       const gw = config.gateways[0]!;

--- a/packages/reactor-cli/src/__tests__/provider-config.test.ts
+++ b/packages/reactor-cli/src/__tests__/provider-config.test.ts
@@ -67,6 +67,51 @@ describe('provider config parsing', () => {
   });
 });
 
+describe('model temperature / reasoning_effort config parsing', () => {
+  function loadFromYml(lines: readonly string[]): ReturnType<typeof loadConfig> {
+    const projectDir = mkdtempSync(join(tmpdir(), 'reactor-cli-temp-cfg-'));
+    try {
+      writeFileSync(join(projectDir, 'reactor.yml'), lines.join('\n'));
+      return loadConfig({ projectDir });
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  }
+
+  it('NO temperature line → temperature stays UNDEFINED (omitted from requests, not 0)', () => {
+    // The reasoning-model unblock: deleting the temperature line must actually
+    // remove the temperature, not silently re-default it to 0.
+    const config = loadFromYml(['model:', '  render_model: openai/gpt-5.5']);
+    assert.equal(config.model.temperature, undefined);
+    assert.equal(config.model.reasoning_effort, undefined);
+  });
+
+  it('no reactor.yml at all → temperature stays UNDEFINED', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'reactor-cli-temp-cfg-'));
+    try {
+      const config = loadConfig({ projectDir });
+      assert.equal(config.model.temperature, undefined);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('explicit temperature: 0 survives (falsy zero is a real value, not "unset")', () => {
+    const config = loadFromYml(['model:', '  temperature: 0']);
+    assert.equal(config.model.temperature, 0);
+  });
+
+  it('a non-zero temperature parses and survives the merge', () => {
+    const config = loadFromYml(['model:', '  temperature: 0.7']);
+    assert.equal(config.model.temperature, 0.7);
+  });
+
+  it('reasoning_effort parses as a verbatim string', () => {
+    const config = loadFromYml(['model:', '  reasoning_effort: none']);
+    assert.equal(config.model.reasoning_effort, 'none');
+  });
+});
+
 describe('reactor compile — custom provider, missing key', () => {
   it('exits NON-ZERO with the exact env var when a custom provider has no key (DEFECT B / stranded user)', async () => {
     // Delete the hermetic key just in case a prior run leaked it into the env.

--- a/packages/reactor-cli/src/__tests__/run-model-config.test.ts
+++ b/packages/reactor-cli/src/__tests__/run-model-config.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Model-config threading on the RUN path — offline, via `callRunProject`'s
+ * injected-impl seam (the same capture pattern the sandbox gate uses).
+ *
+ * `reactor.yml`'s `model.temperature` / `model.reasoning_effort` historically
+ * reached only the COMPILE sessions; run/serve renders silently used the SDK
+ * default. These tests pin the threading into the nested `render: RenderOptions`
+ * the SDK's `createAgentRender` consumes:
+ *   1. `renderTemperature: 0` lands as `render.render.temperature === 0` (the
+ *      falsy value survives — greedy decoding stays expressible).
+ *   2. NO temperature input → NO temperature key in the nested options (the
+ *      render then omits it from the request — the reasoning-model path).
+ *   3. `renderReasoningEffort` rides verbatim, alongside the existing
+ *      `renderModel` threading (pinned here too — it predates these tests).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { callRunProject, type RunRender } from '../run/load-run-project';
+import {
+  createMemoryStorageAdapter,
+  createSystemClockAdapter,
+} from '@openprose/reactor';
+
+/** Run `callRunProject` against a capturing fake impl; return the render it got. */
+async function captureRender(
+  input: Partial<Parameters<typeof callRunProject>[0]>,
+): Promise<RunRender> {
+  let captured: RunRender | undefined;
+  const fakeRunProject: Parameters<typeof callRunProject>[1] = async (call) => {
+    captured = call.render;
+    return { reactor: {} as never, bootResults: [] };
+  };
+  const render: RunRender = {
+    buildRender: (() => async () => ({})) as unknown as RunRender['buildRender'],
+  };
+  await callRunProject(
+    {
+      compiled: {} as never,
+      adapters: {
+        clock: createSystemClockAdapter(),
+        storage: createMemoryStorageAdapter(),
+      },
+      render,
+      ...input,
+    },
+    fakeRunProject,
+  );
+  assert.ok(captured, 'runProject received a render config');
+  return captured!;
+}
+
+describe('run path — model decoding config reaches the nested RenderOptions', () => {
+  it('renderTemperature: 0 lands as render.render.temperature === 0 (falsy survives)', async () => {
+    const captured = await captureRender({
+      renderModel: 'google/gemini-3.5-flash',
+      renderTemperature: 0,
+    });
+    assert.equal(captured.render?.temperature, 0);
+    assert.equal(captured.render?.model, 'google/gemini-3.5-flash');
+  });
+
+  it('NO temperature input → the nested options carry NO temperature key', async () => {
+    // The reasoning-model path: an absent reactor.yml temperature must stay
+    // absent so the render omits the key from the model request entirely.
+    const captured = await captureRender({
+      renderModel: 'openai/gpt-5.5',
+    });
+    assert.equal(captured.render?.model, 'openai/gpt-5.5');
+    assert.ok(
+      captured.render === undefined || !('temperature' in captured.render),
+      'an unset temperature must not be invented on the run path',
+    );
+  });
+
+  it('renderReasoningEffort rides verbatim into render.render.reasoningEffort', async () => {
+    const captured = await captureRender({
+      renderModel: 'openai/gpt-5.5',
+      renderTemperature: 0,
+      renderReasoningEffort: 'none',
+    });
+    assert.equal(captured.render?.temperature, 0);
+    assert.equal(captured.render?.reasoningEffort, 'none');
+  });
+
+  it('a non-zero temperature threads too (the config genuinely governs renders)', async () => {
+    const captured = await captureRender({ renderTemperature: 0.2 });
+    assert.equal(captured.render?.temperature, 0.2);
+  });
+});

--- a/packages/reactor-cli/src/commands/compile.ts
+++ b/packages/reactor-cli/src/commands/compile.ts
@@ -224,7 +224,14 @@ export async function runCompileCommand(
       contractsDir,
       model,
       sdkVersion,
-      temperature: config.model.temperature,
+      // Forward only a CONFIGURED temperature/effort: absent stays absent so
+      // the session omits the key (reasoning models reject explicit values).
+      ...(config.model.temperature !== undefined
+        ? { temperature: config.model.temperature }
+        : {}),
+      ...(config.model.reasoning_effort !== undefined
+        ? { reasoningEffort: config.model.reasoning_effort }
+        : {}),
       maxTurns: config.model.max_turns,
       ...(options.testProviders !== undefined ? { providers: options.testProviders } : {}),
       ...(options.testSkill !== undefined ? { skill: options.testSkill } : {}),
@@ -314,6 +321,14 @@ function providerErrorHint(
   }
   if (matches(429, '429', 'rate limit', 'Too Many Requests')) {
     return `the ${plan.provider} provider returned 429 — rate limited. Retry shortly, or lower --concurrency.`;
+  }
+  if (matches(400, "Unsupported value: 'temperature'", "'temperature' does not support")) {
+    return (
+      `the model rejected the configured temperature — reasoning models only ` +
+      `accept their default unless reasoning_effort is 'none'. Delete the ` +
+      `\`temperature:\` line from reactor.yml (no temperature is sent when it ` +
+      `is absent), or set \`reasoning_effort: none\` to keep a custom value.`
+    );
   }
   return undefined;
 }

--- a/packages/reactor-cli/src/commands/init.ts
+++ b/packages/reactor-cli/src/commands/init.ts
@@ -139,6 +139,10 @@ model:
   provider: openrouter
   render_model: google/gemini-3.5-flash
   compile_model: google/gemini-3.5-flash
+  # Greedy decoding for reproducible runs. OpenAI reasoning models (gpt-5.x,
+  # o-series) reject an explicit temperature: delete this line for those (no
+  # temperature is sent when it is absent), or keep it and set
+  # reasoning_effort: none.
   temperature: 0
   max_turns: 200
   # base_url: https://api.anthropic.com/v1/   # e.g. to use Anthropic directly

--- a/packages/reactor-cli/src/commands/run.ts
+++ b/packages/reactor-cli/src/commands/run.ts
@@ -231,6 +231,14 @@ export async function runRunCommand(
     // Always honor the configured render model (so a non-default model id actually
     // reaches the run-phase render, not just the SDK's gemini default).
     renderModel: config.model.render_model,
+    // Honor the configured decoding knobs at RENDER too, not only compile.
+    // Absent stays absent — the render then omits the keys entirely.
+    ...(config.model.temperature !== undefined
+      ? { renderTemperature: config.model.temperature }
+      : {}),
+    ...(config.model.reasoning_effort !== undefined
+      ? { renderReasoningEffort: config.model.reasoning_effort }
+      : {}),
     ...(liveCustomRender
       ? {
           providerPlan,

--- a/packages/reactor-cli/src/commands/run.ts
+++ b/packages/reactor-cli/src/commands/run.ts
@@ -22,6 +22,7 @@ import {
 } from '../run/run-core';
 import {
   callRunProject,
+  renderDecodingInputs,
   type RunAdapters,
   type RunRender,
 } from '../run/load-run-project';
@@ -231,14 +232,7 @@ export async function runRunCommand(
     // Always honor the configured render model (so a non-default model id actually
     // reaches the run-phase render, not just the SDK's gemini default).
     renderModel: config.model.render_model,
-    // Honor the configured decoding knobs at RENDER too, not only compile.
-    // Absent stays absent — the render then omits the keys entirely.
-    ...(config.model.temperature !== undefined
-      ? { renderTemperature: config.model.temperature }
-      : {}),
-    ...(config.model.reasoning_effort !== undefined
-      ? { renderReasoningEffort: config.model.reasoning_effort }
-      : {}),
+    ...renderDecodingInputs(config.model),
     ...(liveCustomRender
       ? {
           providerPlan,

--- a/packages/reactor-cli/src/commands/serve.ts
+++ b/packages/reactor-cli/src/commands/serve.ts
@@ -162,6 +162,13 @@ export interface BootReactorInput {
    */
   readonly renderModel?: string;
   /**
+   * The configured decoding temperature (`model.temperature`). Threaded so
+   * hosted renders honor `reactor.yml`; unset → the render omits the key.
+   */
+  readonly renderTemperature?: number;
+  /** The configured reasoning effort (`model.reasoning_effort`), verbatim. */
+  readonly renderReasoningEffort?: string;
+  /**
    * The reactor's `[sandbox]` config. Drives the workspace-scoped render sandbox
    * runner + the per-command shell timeout. Omitted → the `mode: none` default (no
    * runner; bounded LocalShell).
@@ -352,6 +359,12 @@ export async function bootReactorHandle(
     adapters,
     render,
     ...(input.renderModel !== undefined ? { renderModel: input.renderModel } : {}),
+    ...(input.renderTemperature !== undefined
+      ? { renderTemperature: input.renderTemperature }
+      : {}),
+    ...(input.renderReasoningEffort !== undefined
+      ? { renderReasoningEffort: input.renderReasoningEffort }
+      : {}),
     ...(liveCustomRender && input.providerPlan !== undefined && input.apiKey !== undefined
       ? {
           providerPlan: input.providerPlan,
@@ -514,6 +527,12 @@ export async function bootServe(
     stateDir: config.state.dir,
     model: config.model.compile_model,
     renderModel: config.model.render_model,
+    ...(config.model.temperature !== undefined
+      ? { renderTemperature: config.model.temperature }
+      : {}),
+    ...(config.model.reasoning_effort !== undefined
+      ? { renderReasoningEffort: config.model.reasoning_effort }
+      : {}),
     sandbox: config.sandbox,
     gateways: config.gateways,
     ...(providerPlan.custom ? { providerPlan } : {}),

--- a/packages/reactor-cli/src/commands/serve.ts
+++ b/packages/reactor-cli/src/commands/serve.ts
@@ -32,6 +32,7 @@ import {
 } from '../run/run-core';
 import {
   callRunProject,
+  renderDecodingInputs,
   type AssembledReactorLike,
   type RunAdapters,
   type RunRender,
@@ -527,12 +528,7 @@ export async function bootServe(
     stateDir: config.state.dir,
     model: config.model.compile_model,
     renderModel: config.model.render_model,
-    ...(config.model.temperature !== undefined
-      ? { renderTemperature: config.model.temperature }
-      : {}),
-    ...(config.model.reasoning_effort !== undefined
-      ? { renderReasoningEffort: config.model.reasoning_effort }
-      : {}),
+    ...renderDecodingInputs(config.model),
     sandbox: config.sandbox,
     gateways: config.gateways,
     ...(providerPlan.custom ? { providerPlan } : {}),

--- a/packages/reactor-cli/src/compile/run-compile.ts
+++ b/packages/reactor-cli/src/compile/run-compile.ts
@@ -60,8 +60,10 @@ export interface CompileRunOptions {
   readonly model: string;
   /** The SDK version (the cache key's second component). */
   readonly sdkVersion: string;
-  /** Decoding temperature (determinism knob). */
+  /** Decoding temperature (determinism knob). Unset → omitted from requests. */
   readonly temperature?: number;
+  /** Reasoning effort, passed verbatim to the provider. Unset → omitted. */
+  readonly reasoningEffort?: string;
   /** Max agentic turns per compile session. */
   readonly maxTurns?: number;
   /**
@@ -311,11 +313,13 @@ function deriveContractFingerprints(
   return out;
 }
 
-/** Shared per-session options (skill / temperature / maxTurns). */
+/** Shared per-session options (skill / temperature / effort / maxTurns). */
 function sessionOptions(options: CompileRunOptions): Record<string, unknown> {
   const base: Record<string, unknown> = { model: options.model };
   if (options.skill !== undefined) base['skill'] = options.skill;
   if (options.temperature !== undefined) base['temperature'] = options.temperature;
+  if (options.reasoningEffort !== undefined)
+    base['reasoningEffort'] = options.reasoningEffort;
   if (options.maxTurns !== undefined) base['maxTurns'] = options.maxTurns;
   return base;
 }

--- a/packages/reactor-cli/src/config.ts
+++ b/packages/reactor-cli/src/config.ts
@@ -22,7 +22,21 @@ export interface ModelConfig {
   readonly provider: string;
   readonly render_model: string;
   readonly compile_model: string;
-  readonly temperature: number;
+  /**
+   * Decoding temperature. Optional: when the `temperature:` line is absent from
+   * `reactor.yml`, NO temperature is sent (the provider applies its own
+   * default). Set `0` for reproducible greedy decoding on models that accept
+   * it; OpenAI reasoning models (gpt-5.x, o-series) reject any explicit value
+   * unless {@link reasoning_effort} is `none`.
+   */
+  readonly temperature?: number;
+  /**
+   * Reasoning effort for reasoning models, passed VERBATIM to the provider
+   * (values are model-dependent, e.g. `none`/`low`/`medium`/`high`; the
+   * provider validates). Optional: absent → omitted from requests. Reasoning
+   * models accept a custom temperature only with effort `none`.
+   */
+  readonly reasoning_effort?: string;
   readonly max_turns: number;
   /**
    * Override the provider's OpenAI-compatible base URL. Optional: a built-in
@@ -127,11 +141,13 @@ export interface ConfigOverrides {
 /** The defaults from `cli.md` §6 (the keyless, no-file baseline). */
 export const DEFAULT_CONFIG: ReactorConfig = Object.freeze({
   state: { dir: './.reactor' },
+  // No `temperature` here: an unset temperature must stay unset (omitted from
+  // requests) rather than silently becoming 0 — OpenAI reasoning models reject
+  // any explicit value. The init scaffold writes an explicit `temperature: 0`.
   model: {
     provider: 'openrouter',
     render_model: 'google/gemini-3.5-flash',
     compile_model: 'google/gemini-3.5-flash',
-    temperature: 0,
     max_turns: 200,
   },
   sandbox: {
@@ -350,6 +366,8 @@ function shapeRawConfig(tree: unknown): Partial<RawConfig> {
       out.model.api_key_env = model['api_key_env'];
     const temp = toNumber(model['temperature']);
     if (temp !== undefined) out.model.temperature = temp;
+    if (typeof model['reasoning_effort'] === 'string')
+      out.model.reasoning_effort = model['reasoning_effort'];
     const turns = toNumber(model['max_turns']);
     if (turns !== undefined) out.model.max_turns = turns;
   }
@@ -417,11 +435,17 @@ function mergeConfig(base: ReactorConfig, over: Partial<RawConfig>): ReactorConf
     ...(over.sandbox?.image !== undefined ? { image: over.sandbox.image } : {}),
     ...(over.sandbox?.network !== undefined ? { network: over.sandbox.network } : {}),
   };
+  // Temperature carries through only when SOME source set it (file or base):
+  // an absent `temperature:` line must yield an absent field, not 0, so the
+  // request can genuinely omit it (reasoning models reject explicit values).
+  const temperature = over.model?.temperature ?? base.model.temperature;
+  const reasoningEffort = over.model?.reasoning_effort ?? base.model.reasoning_effort;
   const model: ModelConfig = {
     provider: over.model?.provider ?? base.model.provider,
     render_model: over.model?.render_model ?? base.model.render_model,
     compile_model: over.model?.compile_model ?? base.model.compile_model,
-    temperature: over.model?.temperature ?? base.model.temperature,
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
     max_turns: over.model?.max_turns ?? base.model.max_turns,
     ...(over.model?.base_url !== undefined ? { base_url: over.model.base_url } : {}),
     ...(over.model?.api_key_env !== undefined

--- a/packages/reactor-cli/src/run/host.ts
+++ b/packages/reactor-cli/src/run/host.ts
@@ -30,7 +30,11 @@ import {
   type FreshnessReader,
   type ServeHandle,
 } from '../commands/serve';
-import type { RunAdapters, RunRender } from './load-run-project';
+import {
+  renderDecodingInputs,
+  type RunAdapters,
+  type RunRender,
+} from './load-run-project';
 import type { ConnectorFetch } from './connectors';
 import type { CompileCommandOptions } from '../commands/compile';
 import { createWorkerPool, type WorkerPool } from './worker-pool';
@@ -149,12 +153,7 @@ export async function bootHost(options: BootHostOptions = {}): Promise<HostHandl
       stateDir: entry.stateDir,
       model,
       renderModel: config.model.render_model,
-      ...(config.model.temperature !== undefined
-        ? { renderTemperature: config.model.temperature }
-        : {}),
-      ...(config.model.reasoning_effort !== undefined
-        ? { renderReasoningEffort: config.model.reasoning_effort }
-        : {}),
+      ...renderDecodingInputs(config.model),
       sandbox: config.sandbox,
       gateways: entry.gateways,
       ...(providerPlan.custom ? { providerPlan } : {}),

--- a/packages/reactor-cli/src/run/host.ts
+++ b/packages/reactor-cli/src/run/host.ts
@@ -149,6 +149,12 @@ export async function bootHost(options: BootHostOptions = {}): Promise<HostHandl
       stateDir: entry.stateDir,
       model,
       renderModel: config.model.render_model,
+      ...(config.model.temperature !== undefined
+        ? { renderTemperature: config.model.temperature }
+        : {}),
+      ...(config.model.reasoning_effort !== undefined
+        ? { renderReasoningEffort: config.model.reasoning_effort }
+        : {}),
       sandbox: config.sandbox,
       gateways: entry.gateways,
       ...(providerPlan.custom ? { providerPlan } : {}),

--- a/packages/reactor-cli/src/run/load-run-project.ts
+++ b/packages/reactor-cli/src/run/load-run-project.ts
@@ -22,6 +22,7 @@ import type {
 } from '@openprose/reactor/run/types';
 
 import type { CliCompiledProject } from './run-core';
+import type { ModelConfig } from '../config';
 
 // The typed SDK running handle (`@openprose/reactor/run/types`, a TYPE-ONLY entry
 // that never crosses the offline boundary). The CLI drives THIS — its async-by-
@@ -88,6 +89,27 @@ export interface CallRunProjectInput {
   readonly renderReasoningEffort?: string;
   /** The provider label for the receipt cost (set with a custom provider). */
   readonly providerLabel?: string;
+}
+
+/**
+ * The configured decoding knobs (`model.temperature` / `model.reasoning_effort`)
+ * as optional {@link CallRunProjectInput} fields. Absent stays absent — the
+ * render then omits the keys from the model request entirely, which reasoning
+ * models require. Shared by `run`, `serve`, and the multi-reactor host so the
+ * threading can never drift between entry points.
+ */
+export function renderDecodingInputs(model: ModelConfig): {
+  renderTemperature?: number;
+  renderReasoningEffort?: string;
+} {
+  return {
+    ...(model.temperature !== undefined
+      ? { renderTemperature: model.temperature }
+      : {}),
+    ...(model.reasoning_effort !== undefined
+      ? { renderReasoningEffort: model.reasoning_effort }
+      : {}),
+  };
 }
 
 /**
@@ -192,16 +214,18 @@ export async function callRunProject(
   // Thread the configured decoding knobs the same way: `reactor.yml`'s
   // `temperature`/`reasoning_effort` must govern run/serve renders, not only
   // compile. Absent stays absent so the render omits the keys.
-  if (input.renderTemperature !== undefined) {
+  if (input.renderTemperature !== undefined || input.renderReasoningEffort !== undefined) {
     render = {
       ...render,
-      render: { ...(render.render ?? {}), temperature: input.renderTemperature },
-    };
-  }
-  if (input.renderReasoningEffort !== undefined) {
-    render = {
-      ...render,
-      render: { ...(render.render ?? {}), reasoningEffort: input.renderReasoningEffort },
+      render: {
+        ...(render.render ?? {}),
+        ...(input.renderTemperature !== undefined
+          ? { temperature: input.renderTemperature }
+          : {}),
+        ...(input.renderReasoningEffort !== undefined
+          ? { reasoningEffort: input.renderReasoningEffort }
+          : {}),
+      },
     };
   }
   if (input.providerPlan !== undefined && input.apiKey !== undefined) {

--- a/packages/reactor-cli/src/run/load-run-project.ts
+++ b/packages/reactor-cli/src/run/load-run-project.ts
@@ -74,6 +74,18 @@ export interface CallRunProjectInput {
    * provider, whose endpoint would 404 on the default model id.
    */
   readonly renderModel?: string;
+  /**
+   * The configured decoding temperature (`model.temperature`). Threaded into the
+   * render so run/serve honor `reactor.yml` exactly like compile does. Unset →
+   * the render omits the key (the provider's default; required by reasoning
+   * models, which reject explicit values).
+   */
+  readonly renderTemperature?: number;
+  /**
+   * The configured reasoning effort (`model.reasoning_effort`), passed verbatim.
+   * Unset → omitted.
+   */
+  readonly renderReasoningEffort?: string;
   /** The provider label for the receipt cost (set with a custom provider). */
   readonly providerLabel?: string;
 }
@@ -176,6 +188,21 @@ export async function callRunProject(
   // and simply honors the config for the default provider.
   if (input.renderModel !== undefined) {
     render = { ...render, render: { ...(render.render ?? {}), model: input.renderModel } };
+  }
+  // Thread the configured decoding knobs the same way: `reactor.yml`'s
+  // `temperature`/`reasoning_effort` must govern run/serve renders, not only
+  // compile. Absent stays absent so the render omits the keys.
+  if (input.renderTemperature !== undefined) {
+    render = {
+      ...render,
+      render: { ...(render.render ?? {}), temperature: input.renderTemperature },
+    };
+  }
+  if (input.renderReasoningEffort !== undefined) {
+    render = {
+      ...render,
+      render: { ...(render.render ?? {}), reasoningEffort: input.renderReasoningEffort },
+    };
   }
   if (input.providerPlan !== undefined && input.apiKey !== undefined) {
     const { buildLiveProvider } = await import('../model/live-provider');

--- a/packages/reactor/README.md
+++ b/packages/reactor/README.md
@@ -144,8 +144,10 @@ The render is one bounded `@openai/agents` session, and **every knob that SDK
 anticipates is reachable** — no lossy wrapper. The harness owns only four fields
 (`instructions` / `tools` / `outputType` / `name`); setting them is a *compile
 error* (extend via `instructionsSuffix` / `extraTools` instead). Everything else
-passes through verbatim, layered: Tier-A sugar (`temperature` / `seed` / `model`
-/ `maxTurns` / `signal`), Tier-B passthrough (`agent` / `runConfig` /
+passes through verbatim, layered: Tier-A sugar (`temperature` / `seed` /
+`reasoningEffort` / `model` / `maxTurns` / `signal` — an unset `temperature` is
+omitted from requests, which reasoning models require), Tier-B passthrough
+(`agent` / `runConfig` /
 `runOptions`), and a Tier-C `agentFactory` / `runnerFactory` backstop. The same
 `RenderOptions` is forwarded by the facade's `render` option to every node:
 

--- a/packages/reactor/src/adapters/agent-compile/__tests__/compile-session.test.ts
+++ b/packages/reactor/src/adapters/agent-compile/__tests__/compile-session.test.ts
@@ -13,6 +13,8 @@
 import { deepEqual, equal, notEqual, ok } from "node:assert/strict";
 import { test } from "node:test";
 
+import type { ModelSettings } from "@openai/agents";
+
 import { ATOMIC_FACET, asFacet, asFingerprint} from "../../../shapes";
 import {
   atomicCanonicalizer,
@@ -249,6 +251,50 @@ test("compile-session: postcondition session → a deterministic commit-gate val
   equal(result.ref.mode, "deterministic");
   equal(result.set.deterministic.length, 1);
   equal(result.set.deterministic[0]?.id, "has-funding");
+});
+
+// ---------------------------------------------------------------------------
+// Decoding settings on the wire — what a compile session actually sends
+// ---------------------------------------------------------------------------
+
+/** Pull `modelSettings` out of a captured SDK ModelRequest. */
+function settingsOf(requests: unknown[]): ModelSettings {
+  ok(requests.length > 0, "the fake provider captured at least one request");
+  return (requests[0] as { modelSettings: ModelSettings }).modelSettings;
+}
+
+test("compile-session: NO configured temperature → the request's modelSettings OMITS the key", async () => {
+  // The reasoning-model day-one shape: nothing configures a temperature, so the
+  // session must send NONE (the provider default stands; gpt-5.5-class models
+  // 400 on any explicit value).
+  const requests: unknown[] = [];
+  await compileForme(loadSampleSet(), CONTRACT_FPS, {
+    skill: "TEST SKILL",
+    provider: fakeStructuredProvider(FORME_OUTPUT, {
+      onRequest: (r) => requests.push(r),
+    }),
+  });
+  const settings = settingsOf(requests);
+  equal(
+    "temperature" in settings,
+    false,
+    "an unset temperature must not be coerced to a number on the wire",
+  );
+});
+
+test("compile-session: explicit temperature: 0 → the request sends exactly 0; effort rides verbatim", async () => {
+  const requests: unknown[] = [];
+  await compileForme(loadSampleSet(), CONTRACT_FPS, {
+    skill: "TEST SKILL",
+    temperature: 0,
+    reasoningEffort: "none",
+    provider: fakeStructuredProvider(FORME_OUTPUT, {
+      onRequest: (r) => requests.push(r),
+    }),
+  });
+  const settings = settingsOf(requests);
+  equal(settings.temperature, 0, "greedy compiles must survive end to end");
+  equal(settings.reasoning?.effort, "none");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/reactor/src/adapters/agent-compile/__tests__/fake-provider.ts
+++ b/packages/reactor/src/adapters/agent-compile/__tests__/fake-provider.ts
@@ -19,6 +19,11 @@ export interface FakeModelOptions {
   /** The token usage the run reports (drives the receipt Cost). */
   readonly inputTokens?: number;
   readonly outputTokens?: number;
+  /**
+   * Observe each SDK `ModelRequest` before the canned reply — lets a test
+   * assert what the session actually sends (e.g. `modelSettings.temperature`).
+   */
+  readonly onRequest?: (request: unknown) => void;
 }
 
 /**
@@ -33,7 +38,8 @@ export function fakeStructuredProvider(
   const outputTokens = options.outputTokens ?? 20;
 
   const model: Model = {
-    async getResponse(): Promise<ModelResponse> {
+    async getResponse(request: unknown): Promise<ModelResponse> {
+      options.onRequest?.(request);
       const usage = new Usage({
         inputTokens,
         outputTokens,

--- a/packages/reactor/src/adapters/agent-compile/session.ts
+++ b/packages/reactor/src/adapters/agent-compile/session.ts
@@ -16,8 +16,9 @@
  *
  * This is the SAME agent machinery the Phase-1 render uses (the SKILL is the
  * system prompt that makes a session a Prose-aware render; the scoped OpenRouter
- * provider; temperature 0 + seed for reproducibility; usage → receipt `Cost`),
- * reused for the compile phase rather than re-implemented.
+ * provider; temperature + seed for reproducibility when configured — an unset
+ * temperature is omitted from the request; usage → receipt `Cost`), reused for
+ * the compile phase rather than re-implemented.
  *
  * Offline-build guard (identical discipline to agent-render): this module imports
  * `@openai/agents` (Agent/Runner) + (transitively, via the *-output schemas) `zod`,
@@ -43,7 +44,6 @@ import type { Cost, WakeSource } from "../../shapes";
 import {
   createOpenRouterProvider,
   DEFAULT_RENDER_MODEL,
-  DEFAULT_TEMPERATURE,
 } from "../agent-render/provider";
 import { usageToCost, type RenderUsage } from "../agent-render/cost";
 import { readSkill } from "../agent-render/instructions";
@@ -107,10 +107,20 @@ export interface CompileSessionConfig {
   readonly skill?: string;
   /** Path to the SKILL, when `skill` is not supplied. */
   readonly skillPath?: string;
-  /** Decoding temperature. Defaults to 0 (greedy). */
+  /**
+   * Decoding temperature. Unset → the key is OMITTED from the request (the
+   * provider's default). Set `0` for reproducible greedy compiles on models
+   * that accept it; OpenAI reasoning models reject any explicit value unless
+   * {@link reasoningEffort} is `none`.
+   */
   readonly temperature?: number;
   /** Best-effort reproducibility seed, passed through `providerData.seed`. */
   readonly seed?: number;
+  /**
+   * Reasoning effort, passed VERBATIM into `modelSettings.reasoning.effort`
+   * (values are model-dependent; the provider validates). Unset → omitted.
+   */
+  readonly reasoningEffort?: string;
   /**
    * Max agentic turns for one compile session. Defaults to
    * {@link DEFAULT_COMPILE_MAX_TURNS} (D1: a high explicit cap). Pass `null` to
@@ -181,7 +191,10 @@ export async function runCompileSession(
 
   const skill = config.skill ?? readSkill(config.skillPath);
   const model = config.model ?? DEFAULT_RENDER_MODEL;
-  const temperature = config.temperature ?? DEFAULT_TEMPERATURE;
+  // No temperature default: unset stays unset all the way to the request body,
+  // where the key is omitted (required by OpenAI reasoning models, which 400 on
+  // any explicit value). Pass 0 explicitly for reproducible greedy compiles.
+  const temperature = config.temperature;
   // `null` is a deliberate unbounded opt-in (D1); distinguish "not supplied"
   // (→ the high default cap) from an explicit `null` (`??` would erase it).
   const maxTurns =
@@ -192,7 +205,13 @@ export async function runCompileSession(
   // Merge the harness decoding sugar with the consumer's agent.modelSettings
   // (consumer wins wholesale; sugar fills only unset fields — decision #3).
   const modelSettings = mergeModelSettings(
-    { temperature, ...(config.seed !== undefined ? { seed: config.seed } : {}) },
+    {
+      ...(temperature !== undefined ? { temperature } : {}),
+      ...(config.seed !== undefined ? { seed: config.seed } : {}),
+      ...(config.reasoningEffort !== undefined
+        ? { reasoningEffort: config.reasoningEffort }
+        : {}),
+    },
     config.agent?.modelSettings,
   );
 

--- a/packages/reactor/src/adapters/agent-render/__tests__/passthrough.test.ts
+++ b/packages/reactor/src/adapters/agent-render/__tests__/passthrough.test.ts
@@ -98,6 +98,42 @@ test("mergeModelSettings: no consumer settings → just the harness sugar", () =
   equal(merged.providerData, undefined);
 });
 
+test("mergeModelSettings: NO temperature anywhere → the key is OMITTED, not defaulted", () => {
+  // The load-bearing omission: reasoning models reject any explicit temperature,
+  // so an unset temperature must never be coerced to a number on its way to the
+  // request body.
+  const merged = mergeModelSettings({});
+  equal("temperature" in merged, false, "no temperature key may appear");
+  equal(merged.providerData, undefined);
+});
+
+test("mergeModelSettings: unset harness temperature leaves a consumer's explicit 0 intact", () => {
+  const merged = mergeModelSettings({}, { temperature: 0 });
+  equal(merged.temperature, 0, "an explicit (falsy) consumer 0 survives");
+});
+
+test("mergeModelSettings: consumer's explicit 0 beats a non-zero harness sugar (falsy wins wholesale)", () => {
+  const merged = mergeModelSettings({ temperature: 0.7 }, { temperature: 0 });
+  equal(merged.temperature, 0, "consumer 0 must not be trampled by the sugar");
+});
+
+test("mergeModelSettings: reasoningEffort sugar fills reasoning.effort; unset → omitted", () => {
+  const filled = mergeModelSettings({ reasoningEffort: "none" });
+  deepEqual(filled.reasoning, { effort: "none" });
+  equal("temperature" in filled, false);
+
+  const omitted = mergeModelSettings({});
+  equal("reasoning" in omitted, false, "no effort sugar → no reasoning key");
+});
+
+test("mergeModelSettings: consumer's own reasoning wins wholesale over the effort sugar", () => {
+  const merged = mergeModelSettings(
+    { reasoningEffort: "none" },
+    { reasoning: { effort: "high" } },
+  );
+  deepEqual(merged.reasoning, { effort: "high" });
+});
+
 // ---------------------------------------------------------------------------
 // (ii) resolveRunConfig — per-run tracing (NOT the global mutation)
 // ---------------------------------------------------------------------------

--- a/packages/reactor/src/adapters/agent-render/__tests__/temperature-omission.test.ts
+++ b/packages/reactor/src/adapters/agent-render/__tests__/temperature-omission.test.ts
@@ -1,0 +1,195 @@
+// Decoding settings on the WIRE — offline proof that a render's outgoing model
+// request carries EXACTLY the configured temperature/effort, through the real
+// async harness (createAgentRender → mountDag → ingestAsync → SDK ModelRequest):
+//
+//   - no configured temperature → NO temperature key in `modelSettings` (the
+//     provider's default stands; OpenAI reasoning models reject any explicit
+//     value, so omission must be representable end to end)
+//   - an explicit `temperature: 0` → exactly 0 (greedy decoding preserved —
+//     the falsy value must survive every threading hop)
+//   - `reasoningEffort` rides verbatim into `modelSettings.reasoning.effort`
+//
+// The fake provider replies like a well-behaved render (one workspace write,
+// then the structured `done` signal), so the captured request is the genuine
+// SDK request a live model would receive — no key, no network.
+
+import { equal } from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  Usage,
+  type Model,
+  type ModelProvider,
+  type ModelResponse,
+  type ModelSettings,
+} from "@openai/agents";
+
+import { asNodeId } from "../../../shapes";
+import {
+  atomicCanonicalizer,
+  type ReconcilerTopology,
+  InMemoryWorldModelStore,
+} from "../../../sdk";
+import { mountDag } from "../../../sdk/mounted-dag";
+import { contractFingerprint } from "../../../scenario/fixture";
+import { dispositionOf } from "../../../scenario/trace";
+import { createAgentRender, type AgentRenderConfig } from "../index";
+import { WM_WRITE_WORKSPACE_TOOL } from "../tools";
+import type { CompiledContractView } from "../instructions";
+
+const NODE = "probe";
+const OUTPUT_PATH = "state/probe.md";
+
+const CONTRACT: CompiledContractView = {
+  name: "Probe",
+  maintains: [`a file at \`${OUTPUT_PATH}\` containing "ok".`],
+  requires: [],
+  continuity: "Re-render only when the contract changes.",
+  execution: `Write \`${OUTPUT_PATH}\` containing "ok", then report "done".`,
+};
+
+function probeTopology(): ReconcilerTopology {
+  const fp = contractFingerprint({
+    id: NODE,
+    kind: "gateway",
+    name: CONTRACT.name,
+    requires: [],
+    maintains: CONTRACT.maintains as string[],
+    continuity: CONTRACT.continuity ?? "",
+    render: () => {
+      throw new Error("unused");
+    },
+    canonicalizer: atomicCanonicalizer,
+  });
+  return {
+    topology: {
+      nodes: [
+        { node: asNodeId(NODE), contract_fingerprint: fp, wake_source: "external" },
+      ],
+      edges: [],
+      entry_points: [asNodeId(NODE)],
+      acyclic: true,
+    },
+    contract_fingerprints: { [NODE]: fp },
+  };
+}
+
+/**
+ * A two-turn fake `ModelProvider` that records each request's `modelSettings`:
+ * turn 1 writes the probe file via `wm_write_workspace`, turn 2 emits the
+ * structured `done` signal — the proven well-behaved-render shape.
+ */
+function capturingProvider(captured: ModelSettings[]): ModelProvider {
+  let turn = 0;
+  const model: Model = {
+    async getResponse(request: unknown): Promise<ModelResponse> {
+      captured.push(
+        (request as { modelSettings: ModelSettings }).modelSettings,
+      );
+      const usage = new Usage({
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      });
+      turn += 1;
+      if (turn === 1) {
+        return {
+          usage,
+          output: [
+            {
+              type: "function_call",
+              callId: "call_write",
+              name: WM_WRITE_WORKSPACE_TOOL,
+              arguments: JSON.stringify({ path: OUTPUT_PATH, content: "ok" }),
+            },
+          ],
+        } as unknown as ModelResponse;
+      }
+      return {
+        usage,
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [
+              {
+                type: "output_text",
+                text: JSON.stringify({
+                  status: "done",
+                  semantic_diff: { summary: "wrote probe" },
+                }),
+              },
+            ],
+          },
+        ],
+      } as unknown as ModelResponse;
+    },
+    // eslint-disable-next-line require-yield
+    async *getStreamedResponse() {
+      throw new Error("fake model does not stream");
+    },
+  };
+  return {
+    getModel(): Model {
+      return model;
+    },
+  };
+}
+
+/** Drive ONE render with the given decoding config; return the first request's settings. */
+async function settingsSentBy(
+  decoding: Partial<
+    Pick<AgentRenderConfig, "temperature" | "reasoningEffort" | "model">
+  >,
+): Promise<ModelSettings> {
+  const store = new InMemoryWorldModelStore();
+  const captured: ModelSettings[] = [];
+  const render = createAgentRender({
+    store,
+    contractFor: () => CONTRACT,
+    skill: "TEST SKILL",
+    provider: capturingProvider(captured),
+    ...decoding,
+  });
+  const dag = mountDag({
+    topology: probeTopology(),
+    mounts: {},
+    asyncMounts: { [NODE]: { render, canonicalizer: atomicCanonicalizer } },
+    store,
+  });
+  const results = await dag.ingestAsync(NODE);
+  equal(dispositionOf(results, NODE), "rendered");
+  equal(captured.length, 2, "the fake render runs exactly two turns");
+  return captured[0]!;
+}
+
+test("agent-render: NO configured temperature → the request's modelSettings OMITS the key (reasoning-model id)", async () => {
+  // The exact day-one failure shape: a reasoning model id and no temperature
+  // configured anywhere. The request must carry no temperature at all — the
+  // provider default stands and no 400 can occur.
+  const settings = await settingsSentBy({ model: "openai/gpt-5.5" });
+  equal(
+    "temperature" in settings,
+    false,
+    "an unset temperature must not be coerced to a number on the wire",
+  );
+});
+
+test("agent-render: explicit temperature: 0 → the request sends exactly 0 (no falsy loss)", async () => {
+  const settings = await settingsSentBy({
+    model: "google/gemini-3.5-flash",
+    temperature: 0,
+  });
+  equal(settings.temperature, 0, "greedy decoding must survive end to end");
+});
+
+test("agent-render: reasoningEffort rides verbatim into modelSettings.reasoning.effort", async () => {
+  const settings = await settingsSentBy({
+    model: "openai/gpt-5.5",
+    temperature: 0,
+    reasoningEffort: "none",
+  });
+  equal(settings.temperature, 0);
+  equal(settings.reasoning?.effort, "none");
+});

--- a/packages/reactor/src/adapters/agent-render/index.ts
+++ b/packages/reactor/src/adapters/agent-render/index.ts
@@ -19,9 +19,11 @@
  *     does NOT return file contents in `finalOutput` (a small done/failed signal
  *     only, output-schema.ts), and it does NOT commit — `commitPublished` is the
  *     harness's job in `mountDag`'s async spawn.
- *   - DETERMINISM KNOBS. temperature 0 + seed via `providerData`; the compiled
- *     canonicalizer (the harness's, on commit) is the fingerprint-stable
- *     backstop, never a model call.
+ *   - DETERMINISM KNOBS. temperature + seed (via `providerData`) when
+ *     configured — an unset temperature is OMITTED from the request (the
+ *     provider's default; OpenAI reasoning models reject explicit values); the
+ *     compiled canonicalizer (the harness's, on commit) is the
+ *     fingerprint-stable backstop, never a model call.
  *
  * Offline-build guard: this module imports `@openai/agents` (Agent/Runner) +
  * (transitively, via tools.ts/output-schema.ts) `zod`, all dev/optional deps.
@@ -40,10 +42,7 @@ import type {
 } from "../../sdk/render-atom";
 import type { AsyncMountedRender } from "../../sdk/mounted-dag";
 import type { WorldModelFiles, WorldModelStore } from "../../world-model";
-import {
-  DEFAULT_RENDER_MODEL,
-  DEFAULT_TEMPERATURE,
-} from "./provider";
+import { DEFAULT_RENDER_MODEL } from "./provider";
 import {
   mapRenderOutput,
   renderOutputSchema,
@@ -203,7 +202,10 @@ export function createAgentRender(
 
   const skill = config.skill ?? readSkill(config.skillPath);
   const model = config.model ?? DEFAULT_RENDER_MODEL;
-  const temperature = config.temperature ?? DEFAULT_TEMPERATURE;
+  // No temperature default: unset stays unset all the way to the request body,
+  // where the key is omitted (required by OpenAI reasoning models, which 400 on
+  // any explicit value). Pass 0 explicitly for greedy decoding.
+  const temperature = config.temperature;
   // `null` is a DELIBERATE unbounded opt-in, so distinguish "not supplied"
   // (→ the high default cap) from an explicit `null` (→ SDK bypasses the guard).
   // `??` would collapse `null` into the default, erasing the opt-in.
@@ -272,11 +274,17 @@ export function createAgentRender(
       ctx.prior.files,
     );
 
-    // Merge the harness decoding sugar (temperature/seed) with the consumer's
-    // `agent.modelSettings` — consumer wins wholesale, sugar fills only unset
-    // fields (decision #3).
+    // Merge the harness decoding sugar (temperature/seed/reasoningEffort) with
+    // the consumer's `agent.modelSettings` — consumer wins wholesale, sugar
+    // fills only unset fields (decision #3).
     const modelSettings = mergeModelSettings(
-      { temperature, ...(config.seed !== undefined ? { seed: config.seed } : {}) },
+      {
+        ...(temperature !== undefined ? { temperature } : {}),
+        ...(config.seed !== undefined ? { seed: config.seed } : {}),
+        ...(config.reasoningEffort !== undefined
+          ? { reasoningEffort: config.reasoningEffort }
+          : {}),
+      },
       config.agent?.modelSettings,
     );
 

--- a/packages/reactor/src/adapters/agent-render/passthrough.ts
+++ b/packages/reactor/src/adapters/agent-render/passthrough.ts
@@ -12,9 +12,10 @@
  *
  * The escape-hatch contract (API-ANALYSIS §4):
  *   - Tier A — harness-specific sugar (`provider`/`model`/`maxTurns`/`signal`/
- *     `temperature`/`seed`/skill+workspace knobs). These are NOT plain
- *     `@openai/agents` fields; they map onto the SDK config, and the sugar
- *     (`temperature`/`seed`) FILLS ONLY fields the consumer left unset.
+ *     `temperature`/`seed`/`reasoningEffort`/skill+workspace knobs). These are
+ *     NOT plain `@openai/agents` fields; they map onto the SDK config, and the
+ *     sugar (`temperature`/`seed`/`reasoningEffort`) FILLS ONLY fields the
+ *     consumer left unset.
  *   - Tier B — the verbatim `@openai/agents` passthrough: `agent`
  *     (`Partial<AgentConfiguration>` minus the reserved four), `runConfig`
  *     (`Partial<RunConfig>`), `runOptions` (per-run `NonStreamRunOptions` minus
@@ -168,10 +169,23 @@ export interface RenderOptions {
    * `runOptions` (where it is Omit-ed).
    */
   readonly signal?: AbortSignal;
-  /** Decoding temperature — sugar for `agent.modelSettings.temperature`. Defaults 0. */
+  /**
+   * Decoding temperature — sugar for `agent.modelSettings.temperature`. Unset →
+   * the key is OMITTED from the request (the provider applies its own default).
+   * Set `0` for greedy decoding on models that accept it; OpenAI reasoning
+   * models (gpt-5.x, o-series) reject any explicit value unless
+   * {@link reasoningEffort} is `none`.
+   */
   readonly temperature?: number;
   /** Reproducibility seed — sugar for `agent.modelSettings.providerData.seed`. */
   readonly seed?: number;
+  /**
+   * Reasoning effort — sugar for `agent.modelSettings.reasoning.effort`, passed
+   * VERBATIM (values are model-dependent; the provider validates). Unset → the
+   * key is omitted. OpenAI reasoning models accept a custom temperature only
+   * with effort `none`.
+   */
+  readonly reasoningEffort?: string;
 
   // ── Tier B: the @openai/agents passthrough (closes the P0 gap) ──
   /**
@@ -244,12 +258,23 @@ export interface RenderOptions {
 /**
  * Merge the harness's decoding settings with the consumer's `agent.modelSettings`.
  * Decision #3 precedence: the consumer's explicit `agent.modelSettings.*` win
- * WHOLESALE; the Tier-A `temperature`/`seed` sugar FILLS ONLY fields the consumer
- * left unset. `providerData` is shallow-merged so the `seed` sugar coexists with
- * a consumer's own `providerData` (the consumer's keys still win).
+ * WHOLESALE; the Tier-A `temperature`/`seed`/`reasoningEffort` sugar FILLS ONLY
+ * fields the consumer left unset. `providerData` is shallow-merged so the `seed`
+ * sugar coexists with a consumer's own `providerData` (the consumer's keys still
+ * win).
+ *
+ * A temperature that resolves to undefined is OMITTED from the returned
+ * settings — the key never reaches the request body, so the provider applies
+ * its own default. OpenAI reasoning models reject any explicit temperature
+ * (unless reasoning effort is `none`), so "no temperature" must stay
+ * representable on the wire rather than being coerced to a number here.
  */
 export function mergeModelSettings(
-  harness: { readonly temperature: number; readonly seed?: number },
+  harness: {
+    readonly temperature?: number;
+    readonly seed?: number;
+    readonly reasoningEffort?: string;
+  },
   consumer?: ModelSettings,
 ): ModelSettings {
   const sugarProviderData =
@@ -260,6 +285,18 @@ export function mergeModelSettings(
     consumer?.temperature !== undefined
       ? consumer.temperature
       : harness.temperature;
+
+  // The effort sugar rides verbatim: the SDK types enumerate today's effort
+  // levels, but the wire accepts whatever the model supports, so a newer value
+  // must not be rejected at compile time here.
+  const reasoning =
+    consumer?.reasoning !== undefined
+      ? consumer.reasoning
+      : harness.reasoningEffort !== undefined
+        ? ({
+            effort: harness.reasoningEffort,
+          } as ModelSettings['reasoning'])
+        : undefined;
 
   const providerData =
     consumer?.providerData !== undefined || sugarProviderData !== undefined
@@ -273,7 +310,8 @@ export function mergeModelSettings(
 
   return {
     ...(consumer ?? {}),
-    temperature,
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(reasoning !== undefined ? { reasoning } : {}),
     ...(providerData !== undefined ? { providerData } : {}),
   };
 }

--- a/packages/reactor/src/adapters/agent-render/provider.ts
+++ b/packages/reactor/src/adapters/agent-render/provider.ts
@@ -42,7 +42,12 @@ export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 /** The render model. A bare string resolved by the scoped provider's getModel. */
 export const DEFAULT_RENDER_MODEL = "google/gemini-3.5-flash";
 
-/** Greedy decoding — determinism knob #1 (research §4.1). */
+/**
+ * Greedy decoding — determinism knob #1 (research §4.1). No longer applied
+ * implicitly: an unset temperature is OMITTED from requests (OpenAI reasoning
+ * models reject explicit values), so pass this explicitly where greedy decoding
+ * is wanted. Kept exported for consumers that reference the canonical value.
+ */
 export const DEFAULT_TEMPERATURE = 0;
 
 /** The provider label that rides into the receipt `Cost` (research §3, §4.2). */
@@ -227,7 +232,7 @@ export function createOpenRouterProvider(
 export interface SmokeRunConfig extends OpenRouterProviderConfig {
   /** Model id. Defaults to {@link DEFAULT_RENDER_MODEL}. */
   readonly model?: string;
-  /** Decoding temperature. Defaults to {@link DEFAULT_TEMPERATURE}. */
+  /** Decoding temperature. Unset → omitted from the request (provider default). */
   readonly temperature?: number;
   /** Best-effort reproducibility seed, passed through `providerData.seed`. */
   readonly seed?: number;
@@ -260,7 +265,10 @@ export async function smokeRun(
   setTracingDisabled(true);
 
   const model = config.model ?? DEFAULT_RENDER_MODEL;
-  const temperature = config.temperature ?? DEFAULT_TEMPERATURE;
+  // Unset temperature is omitted, not defaulted: the probe must work against
+  // reasoning models (which reject explicit values), e.g. via `doctor --live`
+  // with a configured reasoning render model.
+  const temperature = config.temperature;
   const provider = config.provider ?? createOpenRouterProvider(config);
 
   const agent = new Agent({
@@ -270,7 +278,7 @@ export async function smokeRun(
       "Answer in the fewest words possible.",
     model,
     modelSettings: {
-      temperature,
+      ...(temperature !== undefined ? { temperature } : {}),
       ...(config.seed !== undefined
         ? { providerData: { seed: config.seed } }
         : {}),

--- a/skills/open-prose/reactor.md
+++ b/skills/open-prose/reactor.md
@@ -145,8 +145,10 @@ model:
   provider: openrouter         # ask the user — see note below
   render_model: google/gemini-3.5-flash
   compile_model: google/gemini-3.5-flash
-  temperature: 0
+  temperature: 0               # optional — delete the line to send no temperature
   max_turns: 200
+  # reasoning_effort: none     # reasoning models (gpt-5.x, o-series) reject an
+                               # explicit temperature unless effort is none
 
 sandbox:
   mode: none                   # none (default, bounded shell) | docker (network-disabled container)


### PR DESCRIPTION
## Problem

Two related bugs made OpenAI reasoning models (gpt-5.5) unusable:

1. **Temperature could not be omitted.** The config hard-defaulted a missing `temperature:` to 0, the render/compile sessions coerced unset to 0, and `mergeModelSettings` always attached a numeric key. Reasoning models reject any explicit temperature (gpt-5.5 returns `400 Unsupported value: 'temperature' does not support 0 with this model`), and deleting the line from reactor.yml changed nothing — there was no working configuration.
2. **Run/serve renders ignored the configured temperature.** Only the compile path forwarded `model.temperature`; run, serve, and the multi-reactor host never threaded it, so renders silently used the SDK default.

## Change

- `model.temperature` is now optional end to end. Absent means the key is omitted from the request body (the provider's default applies — accepted by every model). An explicit value, including `0`, is sent verbatim.
- run/serve/host thread `model.temperature` into renders exactly like `render_model`, so reactor.yml governs both compile and render.
- New optional `model.reasoning_effort` key (SDK sugar: `reasoningEffort`), passed verbatim to the provider. Reasoning models accept a custom temperature only with effort `none`, so tuned-temperature setups stay expressible: `temperature: 0` + `reasoning_effort: none`.
- The temperature-rejection 400 now maps to an actionable hint naming the reactor.yml line. `doctor --live` no longer pins temperature 0 in its probe.
- The init scaffold keeps `temperature: 0` (reproducible runs for the default models) with a comment explaining when to delete it.

## Behavior change to be aware of

A project whose reactor.yml has **no** `temperature:` line previously sent an implicit 0; it now sends no temperature, so decoding follows the provider default. Scaffolded projects are unaffected (the scaffold writes an explicit 0). To keep greedy decoding, add `temperature: 0` — and on gpt-5.5-class models, pair it with `reasoning_effort: none`.

## Tests

- `mergeModelSettings`: unset → no temperature key; explicit/falsy 0 wins; effort sugar fills `reasoning.effort` and consumer settings still win wholesale.
- Render + compile sessions: fake-provider capture of the outgoing SDK request proves no temperature key when unset, exactly 0 when configured, and effort threading.
- CLI: config parsing (absent vs 0 vs 0.7 vs effort string), run-path threading into the nested render options (including falsy 0 and the previously unpinned `render_model` threading), scaffold shape.

All of the omission tests fail against the previous behavior.