### PR TITLE
feat(reactor-devtools): export a run as one self-contained HTML file (gist view)

### DIFF
--- a/packages/reactor-devtools/README.md
+++ b/packages/reactor-devtools/README.md
@@ -31,6 +31,7 @@ and **S5** (facet / diamond polish) are follow-ons (see below).
 reactor-devtools <state-dir> [--port 4555] [--host 127.0.0.1] [--describe]
 reactor-devtools --example surprise-cost [--describe]   # bundled fixture, no path
 reactor-devtools --example surprise-cost --copy-to ./.reactor [--force]  # seed it into your own dir
+reactor-devtools <state-dir> --export run.html [--source ./src] [--title "…"]  # one shareable HTML file
 ```
 
 **No global install?** The `reactor-devtools` bin ships only in this package, so a
@@ -88,6 +89,45 @@ reactor-devtools ./.reactor --describe        # replay a ledger in YOUR tree
 It refuses a non-empty / already-a-state-dir `<dir>` unless you pass `--force`,
 and the confirmation is explicit that this is the **sample** ledger, not your own
 computed run — your real receipts come from `reactor serve`/`run` with a model key.
+
+### `--export <file.html>` — the gist view (one shareable file)
+
+`--export` writes the whole run as **one self-contained HTML file**, laid out the
+way a gist presents a snippet:
+
+1. **Contract** — the `.prose.md` source(s), each with a working *copy* button
+   (paste into your own tree and re-run).
+2. **Run** — the full run artifact, collapsed by default: the per-frame receipt
+   timeline (status, wake source, moved facets, fresh tokens, woken
+   subscribers), per-node dispositions with a per-node **chain-verify** glyph,
+   the cost rollup by surprise-cause, the topology edge list, and the raw
+   as-persisted receipts.
+3. **Outputs** — each node's published world-model at its **last rendered
+   version**. JSON pretty-prints; an `.html`/`.svg` asset gets a **live preview
+   in a no-token sandboxed iframe** (scripts blocked), an **open in tab** button
+   (a `blob:` URL built from the embedded source — the artifact runs live there,
+   in an isolated origin detached via `noopener`; an explicit user action, unlike
+   the always-sandboxed inline preview), and its escaped source underneath.
+
+```bash
+reactor-devtools --example masked-relay --export run.html \
+  --source skills/open-prose/examples/masked-relay/src \
+  --title "Masked Relay — customer-signal fan-out"
+```
+
+Reactor state-dirs carry no source snapshot today, so the contract block is
+opt-in via `--source <file-or-dir>` (a `.prose.md` file, or a directory whose
+`*.prose.md` — including a `src/` child — are embedded; `index.prose.md` sorts
+first). Without it the export says so honestly instead of fabricating one.
+
+The file embeds **no external assets and makes no network requests**; its inline
+script contains exactly two handlers — the copy button and the open-in-tab blob
+handler (the latter being the documented live-run escape hatch above). Exit
+codes mirror `--describe`: clean (or
+legitimately empty) chain → `0`; detected tamper → `1` — the file is still
+written and carries the tamper verdict, because an export that shows the broken
+chain is more useful than no export. An existing target is refused without
+`--force`.
 
 A `<state-dir>` you pass by path must **exist** and look like a reactor state-dir
 (a `receipts.json` or a `compile/` directory inside it). A non-existent path or a

--- a/packages/reactor-devtools/src/cli.ts
+++ b/packages/reactor-devtools/src/cli.ts
@@ -12,6 +12,7 @@ import {
   cpSync,
   mkdirSync,
   readdirSync,
+  writeFileSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
 
@@ -23,6 +24,7 @@ import {
   isReactorStateDir,
   SHIPPED_EXAMPLES,
 } from "./data";
+import { renderRunExport } from "./export";
 
 // --- The bundled `--example` registry (G2) ---------------------------------
 //
@@ -111,8 +113,30 @@ interface ParsedArgs {
    * `--example`.
    */
   readonly copyTo: string | undefined;
-  /** `--force`: overwrite a non-empty / existing state-dir on `--copy-to`. */
+  /** `--force`: overwrite an existing target on `--copy-to` / `--export`. */
   readonly force: boolean;
+  /**
+   * `--export <file.html>`: write the run as ONE self-contained HTML file (the
+   * gist view: copyable contract → expandable receipt timeline → output
+   * assets). Works with `<state-dir>` or `--example`; no server, no browser.
+   */
+  readonly exportPath: string | undefined;
+  /**
+   * `--source <path>`: a `.prose.md` file or directory of them to embed as the
+   * export's copyable contract block. Only meaningful with `--export` (reactor
+   * state-dirs carry no source snapshot today, so the contract is opt-in).
+   */
+  readonly sourcePath: string | undefined;
+  /** `--title <text>`: the export page title (defaults to a state-dir-derived one). */
+  readonly title: string | undefined;
+  /**
+   * Export-family flags (`--export`/`--source`/`--title`) seen WITHOUT a value
+   * (end of argv, or the next token is itself an option). Refused in `main`
+   * like {@link unknown} — a bare `--export` must never fall through to the
+   * blocking server, and `--export --force` must never write a file named
+   * `--force` (bug#6 family).
+   */
+  readonly missingValue: readonly string[];
   /**
    * Any tokens that look like options (`-x` / `--foo`) but are not recognized.
    * An unknown flag must error with usage and exit non-zero — never fall through
@@ -143,7 +167,22 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
   let json = false;
   let copyTo: string | undefined;
   let force = false;
+  let exportPath: string | undefined;
+  let sourcePath: string | undefined;
+  let title: string | undefined;
   const unknown: string[] = [];
+  // Flags whose value is missing (next token absent or itself an option).
+  // bug#6 family: `--export` with no value must NOT fall through to server
+  // mode (or to a file literally named like the next flag) — collect and
+  // refuse in main, exactly like `unknown`.
+  const missingValue: string[] = [];
+  const takeValue = (flag: string, v: string | undefined): string | undefined => {
+    if (v === undefined || v.startsWith("-")) {
+      missingValue.push(flag);
+      return undefined;
+    }
+    return v;
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--help" || arg === "-h") {
@@ -160,6 +199,15 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
       example = argv[++i];
     } else if (arg === "--copy-to") {
       copyTo = argv[++i];
+    } else if (arg === "--export") {
+      exportPath = takeValue("--export", argv[i + 1]);
+      if (exportPath !== undefined) i++;
+    } else if (arg === "--source") {
+      sourcePath = takeValue("--source", argv[i + 1]);
+      if (sourcePath !== undefined) i++;
+    } else if (arg === "--title") {
+      title = takeValue("--title", argv[i + 1]);
+      if (title !== undefined) i++;
     } else if (arg === "--port" || arg === "-p") {
       port = Number(argv[++i]);
     } else if (arg === "--host") {
@@ -187,7 +235,11 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
     json,
     copyTo,
     force,
+    exportPath,
+    sourcePath,
+    title,
     unknown,
+    missingValue,
   };
 }
 
@@ -197,6 +249,7 @@ Usage:
   reactor-devtools <state-dir> [--port <n>] [--host <h>] [--describe]
   reactor-devtools --example <name> [--describe]   # replay a bundled fixture
   reactor-devtools --example <name> --copy-to <dir> [--force]  # seed a sample ledger
+  reactor-devtools <state-dir> --export <file.html> [--source <path>] [--title <t>]
 
 Arguments:
   <state-dir>   A saved Reactor state directory (receipts + compile/topology.json).
@@ -210,7 +263,18 @@ Options:
                  way to drop a real-shaped SAMPLE ledger into your OWN project, so
                  \`reactor-devtools <dir> --describe\` replays a ledger sitting in
                  your tree). Refuses a non-empty / existing state-dir unless --force.
-      --force   Overwrite a non-empty / existing state-dir on --copy-to.
+      --force   Overwrite an existing target on --copy-to / --export.
+      --export <file.html>  Write the run as ONE self-contained HTML file — the
+                 gist view: the copyable .prose.md contract on top, the receipt
+                 timeline (frames, per-node chain-verify, cost rollup, raw
+                 receipts) expandable in the middle, and each node's published
+                 world-model assets below. No server, no browser, no network.
+                 Exit 0 on a clean chain; exit 1 when chain-verify fails (the
+                 file is still written and shows the tamper).
+      --source <path>   A .prose.md file or a directory of them to embed as the
+                 export's contract block (reactor state-dirs carry no source
+                 snapshot today). Only valid with --export.
+      --title <text>    Page title for --export (defaults to the state-dir name).
   -p, --port    Port to listen on (default 4555).
       --host    Host to bind (default 127.0.0.1).
       --describe Print a headless run summary (per-node + per-frame
@@ -298,6 +362,15 @@ async function main(): Promise<void> {
     process.stderr.write(USAGE);
     process.exit(1);
   }
+  // A flag that REQUIRES a value but got none (bug#6 family): refuse before
+  // any mode dispatch, so a bare `--export` can never bind the server port.
+  if (args.missingValue.length > 0) {
+    process.stderr.write(
+      `error: option${args.missingValue.length > 1 ? "s" : ""} missing a value: ${args.missingValue.join(", ")}\n` +
+        `  e.g. reactor-devtools --example masked-relay --export run.html\n`,
+    );
+    process.exit(1);
+  }
   if (args.stateDir === undefined && args.example === undefined) {
     process.stdout.write(USAGE);
     process.exit(1);
@@ -314,6 +387,32 @@ async function main(): Promise<void> {
     process.stderr.write(
       `error: --json only applies with --describe (the machine-readable run summary).\n` +
         `  e.g. reactor-devtools --example masked-relay --describe --json\n`,
+    );
+    process.exit(1);
+  }
+
+  // `--export` is its own terminal mode (like `--describe`): refuse ambiguous
+  // combinations loudly instead of silently picking one. `--source`/`--title`
+  // shape the export document, so they are meaningless without it.
+  if (args.exportPath !== undefined && args.describe) {
+    process.stderr.write(
+      `error: pass either --export <file.html> OR --describe, not both.\n`,
+    );
+    process.exit(1);
+  }
+  if (args.exportPath !== undefined && args.copyTo !== undefined) {
+    process.stderr.write(
+      `error: pass either --export <file.html> OR --copy-to <dir>, not both.\n`,
+    );
+    process.exit(1);
+  }
+  if (
+    (args.sourcePath !== undefined || args.title !== undefined) &&
+    args.exportPath === undefined
+  ) {
+    process.stderr.write(
+      `error: --source/--title only apply with --export <file.html>.\n` +
+        `  e.g. reactor-devtools --example masked-relay --export run.html --source ./src\n`,
     );
     process.exit(1);
   }
@@ -387,6 +486,58 @@ async function main(): Promise<void> {
       }
       process.exit(1);
     }
+  }
+
+  // `--export <file.html>`: the gist view — one self-contained HTML file
+  // bundling contract (copyable) + run artifact (expandable) + output assets.
+  // Headless like `--describe`, and the SAME exit-code contract: clean (or
+  // legitimately empty) chain → 0; detected tamper → 1 — but the file is
+  // ALWAYS written on a readable ledger, because an export that shows the
+  // tamper badge is more useful than no export at all.
+  if (args.exportPath !== undefined) {
+    const target = resolve(args.exportPath);
+    if (existsSync(target) && !args.force) {
+      process.stderr.write(
+        `error: ${args.exportPath} already exists — refusing to overwrite.\n` +
+          `  re-run with --force to overwrite it.\n`,
+      );
+      process.exit(1);
+    }
+    let opened;
+    try {
+      opened = openStateDir(stateDir);
+    } catch (err) {
+      process.stderr.write(
+        `reactor-devtools --export: cannot read state-dir "${stateDir}": ${String(err)}\n`,
+      );
+      process.exit(1);
+    }
+    let result;
+    try {
+      result = renderRunExport(opened, {
+        synthetic,
+        ...(args.sourcePath !== undefined ? { sourcePath: args.sourcePath } : {}),
+        ...(args.title !== undefined ? { title: args.title } : {}),
+      });
+    } catch (err) {
+      // Most likely a bad --source path; name it rather than a bare stack.
+      process.stderr.write(
+        `reactor-devtools --export: ${String(err)}\n`,
+      );
+      process.exit(1);
+    }
+    writeFileSync(target, result.html);
+    process.stdout.write(
+      `reactor-devtools: exported ${result.sourceCount} source file(s) + the run artifact + outputs\n` +
+        `  ${target}\n` +
+        (result.chainOk
+          ? ``
+          : `  CHAIN-VERIFY FAILED — the export carries the tamper verdict.\n`) +
+        (result.sourceCount === 0 && args.sourcePath === undefined
+          ? `  (no .prose.md contract embedded — pass --source <file-or-dir> to include one)\n`
+          : ``),
+    );
+    process.exit(result.chainOk ? 0 : 1);
   }
 
   // `--describe`: headless run summary, no server, no browser.

--- a/packages/reactor-devtools/src/export/export.test.ts
+++ b/packages/reactor-devtools/src/export/export.test.ts
@@ -1,0 +1,302 @@
+// `--export` surface tests: the gist-view HTML file (contract + run artifact +
+// outputs in one self-contained document). CLI-level tests spawn the built
+// `dist/cli.js` (the exact bin a global install puts on PATH, same convention
+// as cli.test.ts); unit-level tests exercise the renderer's escaping and
+// source collection directly.
+//
+// (Runtime test: it runs from `dist/export/` against `dist/cli.js`.)
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createFileSystemStorageAdapter,
+  createFileSystemWorldModelStore,
+} from "@openprose/reactor";
+import { createReceipt, createNullSignature } from "@openprose/reactor/internals";
+
+import { collectSources, renderRunExport } from "./index";
+import { openStateDir } from "../data";
+
+const CLI = join(__dirname, "..", "cli.js");
+const MASKED_RELAY = join(__dirname, "..", "..", "fixtures", "masked-relay");
+
+function run(args: readonly string[], cwd?: string) {
+  // Unrelated cwd by default, mimicking a global install (cli.test.ts).
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: cwd ?? tmpdir(),
+    encoding: "utf8",
+  });
+}
+
+test("--example masked-relay --export writes a self-contained gist-view file (exit 0)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rdt-export-"));
+  const out = join(dir, "run.html");
+  const res = run(["--example", "masked-relay", "--export", out]);
+  assert.equal(res.status, 0, `clean chain → exit 0 (stderr: ${res.stderr})`);
+  assert.ok(existsSync(out), "the export file is written");
+  const html = readFileSync(out, "utf8");
+  // The three sections of the gist view, in order.
+  const iContract = html.indexOf("<h2>Contract");
+  const iRun = html.indexOf("<h2>Run");
+  const iOutputs = html.indexOf("<h2>Outputs");
+  assert.ok(iContract >= 0 && iRun > iContract && iOutputs > iRun,
+    "Contract → Run → Outputs sections render in order");
+  // The chain verdict is in the document (trust-first).
+  assert.ok(html.includes("chain ✓ verified"), "the clean chain badge renders");
+  // Run artifact content: a known node and the receipt timeline.
+  assert.ok(html.includes("signal-ledger"), "a known node appears in the run");
+  assert.ok(html.includes("Raw receipts"), "the raw-receipt expansion is present");
+  // Outputs: the published world-model files made it in.
+  assert.ok(html.includes("truth.json"), "published world-model files render");
+  // No source snapshot in a reactor state-dir → the hint, not a fabrication.
+  assert.ok(/no .*source embedded|No .*source embedded/i.test(html) ||
+    html.includes("No <code>.prose.md</code> source embedded"),
+    "an absent contract is stated, never fabricated");
+  assert.ok(res.stdout.includes("--source"), "stdout hints at --source");
+});
+
+test("--export --source <dir> embeds the .prose.md contract, escaped", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rdt-export-src-"));
+  const srcDir = join(dir, "contracts");
+  mkdirSync(srcDir);
+  // A source carrying HTML-special chars — must appear escaped, never live.
+  writeFileSync(
+    join(srcDir, "demo.prose.md"),
+    "### Maintains\n\n- `report`: <script>alert(1)</script> & \"quotes\"\n",
+  );
+  const out = join(dir, "run.html");
+  const res = run([
+    "--example", "masked-relay",
+    "--export", out,
+    "--source", srcDir,
+    "--title", "Escaping Probe",
+  ]);
+  assert.equal(res.status, 0, `exit 0 (stderr: ${res.stderr})`);
+  const html = readFileSync(out, "utf8");
+  assert.ok(html.includes("demo.prose.md"), "the source filename renders");
+  assert.ok(
+    html.includes("&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quotes&quot;"),
+    "source text is HTML-escaped",
+  );
+  assert.ok(!html.includes("<script>alert(1)</script>"),
+    "the hostile tag never appears live");
+  assert.ok(html.includes("<title>Escaping Probe — reactor run</title>"),
+    "--title sets the page title (escaped path)");
+});
+
+test("--export refuses an existing file without --force, overwrites with it", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rdt-export-force-"));
+  const out = join(dir, "run.html");
+  writeFileSync(out, "precious");
+  const refused = run(["--example", "masked-relay", "--export", out]);
+  assert.equal(refused.status, 1, "existing target refused");
+  assert.ok(/refusing to overwrite/.test(refused.stderr), "names the refusal");
+  assert.equal(readFileSync(out, "utf8"), "precious", "target untouched");
+  const forced = run(["--example", "masked-relay", "--export", out, "--force"]);
+  assert.equal(forced.status, 0, "--force overwrites");
+  assert.ok(readFileSync(out, "utf8").startsWith("<!doctype html>"));
+});
+
+test("--source / --title without --export error non-zero", () => {
+  const res = run(["--example", "masked-relay", "--describe", "--source", "/tmp"]);
+  assert.equal(res.status, 1);
+  assert.ok(/--source\/--title only apply with --export/.test(res.stderr));
+});
+
+test("--export with --describe is refused as ambiguous", () => {
+  const res = run(["--example", "masked-relay", "--describe", "--export", "x.html"]);
+  assert.equal(res.status, 1);
+  assert.ok(/not both/.test(res.stderr));
+});
+
+test("--export on a missing --source path fails loudly, writes nothing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rdt-export-badsrc-"));
+  const out = join(dir, "run.html");
+  const res = run([
+    "--example", "masked-relay",
+    "--export", out,
+    "--source", join(dir, "does-not-exist"),
+  ]);
+  assert.equal(res.status, 1, "bad --source → non-zero");
+  assert.ok(!existsSync(out), "no half-export is left behind");
+});
+
+/**
+ * Synthesize a minimal, CHAIN-VALID state-dir whose one node publishes
+ * `report.html` — built from the same SDK primitives the real run path uses
+ * (commitPublished → createReceipt → appendReceipt), so chain-verify passes
+ * for real, not by mocking. Shared by the html-preview and tamper tests.
+ */
+function synthesizeHtmlStateDir(stateDir: string, assetHtml: string): void {
+  const store = createFileSystemWorldModelStore({
+    directory: join(stateDir, "world-models"),
+  });
+  const commit = store.commitPublished("responsibility.page-renderer", {
+    "report.html": new TextEncoder().encode(assetHtml),
+  });
+  const fp = (s: string): string =>
+    `sha256:${createHash("sha256").update(s).digest("hex")}`;
+  const storage = createFileSystemStorageAdapter({ directory: stateDir });
+  storage.appendReceipt(
+    createReceipt({
+      node: "responsibility.page-renderer",
+      contract_fingerprint: fp("contract"),
+      wake: { source: "external", refs: [] },
+      input_fingerprints: [fp("input")],
+      fingerprints: commit.fingerprints,
+      semantic_diff: {},
+      prev: null,
+      status: "rendered",
+      cost: {
+        provider: "demo",
+        model: "demo",
+        tokens: { fresh: 100, reused: 0 },
+        surprise_cause: "external",
+      },
+      sig: createNullSignature(),
+    }),
+  );
+  mkdirSync(join(stateDir, "compile"), { recursive: true });
+  writeFileSync(
+    join(stateDir, "compile", "topology.json"),
+    JSON.stringify({
+      nodes: [{ node: "responsibility.page-renderer" }],
+      edges: [],
+      entry_points: ["responsibility.page-renderer"],
+      acyclic: true,
+    }),
+  );
+}
+
+test("--export previews an .html world-model asset in a sandboxed iframe", () => {
+  const stateDir = mkdtempSync(join(tmpdir(), "rdt-export-html-"));
+  const hostileHtml =
+    "<!doctype html><h1>Weekly signal report</h1><script>alert(1)</script>";
+  synthesizeHtmlStateDir(stateDir, hostileHtml);
+
+  const out = join(stateDir, "run.html");
+  const res = run([stateDir, "--export", out]);
+  assert.equal(res.status, 0, `chain-valid synthetic dir exports clean (stderr: ${res.stderr})`);
+  const html = readFileSync(out, "utf8");
+  assert.ok(html.includes("report.html"), "the asset filename renders");
+  assert.ok(
+    html.includes(`<iframe class="preview" sandbox=""`),
+    "the .html asset previews in a NO-TOKEN sandboxed iframe (scripts blocked)",
+  );
+  assert.ok(
+    html.includes("srcdoc=\"&lt;!doctype html&gt;"),
+    "the srcdoc attribute is HTML-escaped",
+  );
+  assert.ok(
+    !html.includes("<script>alert(1)</script>"),
+    "the hostile asset script never appears live in the export document",
+  );
+  assert.ok(html.includes("view source"), "the escaped source sits under the preview");
+  // The open-in-tab affordance: a button wired to the embedded source by id,
+  // typed text/html, backed by the blob: handler in the inline script. It must
+  // sit ON THE SUMMARY ROW — visible while the node is still collapsed, not
+  // buried inside the expanded body.
+  assert.ok(
+    /<button class="open" data-open="asset-\d+" data-type="text\/html">open in tab<\/button><\/summary>/.test(html),
+    "an .html asset gets an open-in-tab button on the collapsed summary row",
+  );
+  const openId = /data-open="(asset-\d+)"/.exec(html)?.[1];
+  assert.ok(openId !== undefined && html.includes(`<pre id="${openId}">`),
+    "the button's data-open id resolves to the embedded source pre");
+  assert.ok(html.includes("URL.createObjectURL"), "the blob open handler ships inline");
+  assert.ok(html.includes(`window.open(url, "_blank", "noopener")`),
+    "the artifact tab is detached from the export page (noopener)");
+});
+
+test("--export on a TAMPERED ledger exits 1 but still writes the verdict-bearing file", () => {
+  // The documented honesty contract: tamper → exit 1, file still written and
+  // carrying the tamper verdict (an export that shows the broken chain beats
+  // no export). Tamper = edit a receipt field on disk WITHOUT re-stamping its
+  // content_hash, exactly what chain-verify against the raw trail must catch.
+  const stateDir = mkdtempSync(join(tmpdir(), "rdt-export-tamper-"));
+  synthesizeHtmlStateDir(stateDir, "<!doctype html><h1>ok</h1>");
+  const trail = join(stateDir, "receipts.json");
+  writeFileSync(
+    trail,
+    readFileSync(trail, "utf8").replace(
+      "responsibility.page-renderer",
+      "responsibility.evil-twin",
+    ),
+  );
+
+  const out = join(stateDir, "run.html");
+  const res = run([stateDir, "--export", out]);
+  assert.equal(res.status, 1, "detected tamper → exit 1");
+  assert.ok(/CHAIN-VERIFY FAILED/.test(res.stdout), "stdout names the failure");
+  assert.ok(existsSync(out), "the file is STILL written");
+  const html = readFileSync(out, "utf8");
+  assert.ok(html.includes("chain ✗ TAMPERED"), "the tamper badge renders");
+  assert.ok(html.includes("CHAIN-VERIFY FAILED"), "the per-node errors render");
+});
+
+test("--export/--source/--title with a missing value refuse before any mode dispatch", () => {
+  // bug#6 family: a bare `--export` must NEVER fall through to the blocking
+  // server, and `--export --force` must never write a file named `--force`.
+  const bare = run(["--example", "masked-relay", "--export"]);
+  assert.equal(bare.status, 1, "bare --export exits 1, never binds a port");
+  assert.ok(/missing a value: --export/.test(bare.stderr), "names the flag");
+  const eaten = run(["--example", "masked-relay", "--export", "--force"]);
+  assert.equal(eaten.status, 1, "--export followed by a flag exits 1");
+  assert.ok(/missing a value: --export/.test(eaten.stderr));
+});
+
+test("--source matching no *.prose.md files fails loudly, writes nothing", () => {
+  // An explicit --source that yields zero sources is a caller mistake (typo'd
+  // dir), not a legitimate no-contract run — never a quiet contract-less export.
+  const dir = mkdtempSync(join(tmpdir(), "rdt-export-emptysrc-"));
+  mkdirSync(join(dir, "not-prose"));
+  writeFileSync(join(dir, "not-prose", "notes.md"), "not a contract");
+  const out = join(dir, "run.html");
+  const res = run([
+    "--example", "masked-relay",
+    "--export", out,
+    "--source", join(dir, "not-prose"),
+  ]);
+  assert.equal(res.status, 1, "empty --source → non-zero");
+  assert.ok(/matched no \*\.prose\.md files/.test(res.stderr), "names the problem");
+  assert.ok(!existsSync(out), "no half-export is left behind");
+});
+
+// --- unit level --------------------------------------------------------------
+
+test("collectSources: a single file, a dir, and the src/ child convention", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rdt-collect-"));
+  writeFileSync(join(dir, "zeta.prose.md"), "z");
+  writeFileSync(join(dir, "index.prose.md"), "i");
+  writeFileSync(join(dir, "notes.md"), "not prose"); // ignored: wrong extension
+  mkdirSync(join(dir, "src"));
+  writeFileSync(join(dir, "src", "alpha.prose.md"), "a");
+
+  const single = collectSources(join(dir, "zeta.prose.md"), "/nowhere");
+  assert.deepEqual(single.map((s) => s.name), ["zeta.prose.md"]);
+
+  const fromDir = collectSources(dir, "/nowhere");
+  assert.deepEqual(
+    fromDir.map((s) => s.name),
+    ["index.prose.md", "alpha.prose.md", "zeta.prose.md"],
+    "index.prose.md first, then alphabetical; src/ child included; .md ignored",
+  );
+});
+
+test("renderRunExport: chainOk mirrors --describe and sources count through", () => {
+  const opened = openStateDir(MASKED_RELAY);
+  const result = renderRunExport(opened, { synthetic: true });
+  assert.equal(result.chainOk, true, "the shipped fixture chain-verifies");
+  assert.equal(result.sourceCount, 0, "a reactor state-dir has no source snapshot");
+  assert.ok(result.html.includes("synthetic sample ledger"),
+    "the synthetic banner renders in the document");
+  // Self-containment: no external fetches of any kind.
+  assert.ok(!/src=["']https?:/.test(result.html), "no external src= URLs");
+  assert.ok(!/href=["']https?:/.test(result.html), "no external href= URLs");
+});

--- a/packages/reactor-devtools/src/export/index.ts
+++ b/packages/reactor-devtools/src/export/index.ts
@@ -1,0 +1,581 @@
+// The EXPORT surface — `reactor-devtools <state-dir> --export <file.html>`.
+//
+// One self-contained, dependency-free HTML file bundling the three faces of a
+// run the way a gist bundles a snippet (the "gist view"):
+//
+//   1. CONTRACT — the `.prose.md` source(s), copyable verbatim (the part a
+//      reader pastes into their own tree to re-run).
+//   2. RUN — the receipt timeline (the full run artifact), collapsed by
+//      default: per-frame dispositions, moved facets, per-node chain-verify,
+//      the cost rollup, and the raw as-persisted receipts.
+//   3. OUTPUTS — each node's published world-model at its LAST rendered
+//      version (the assets the run actually produced).
+//
+// Everything here is a PURE FORMATTER over the same data layer the SPA and
+// `--describe` consume (`openStateDir` → `buildSnapshot` / `describeStateDir` /
+// `readNodeWorldModel`) — nothing is re-derived. The output file embeds no
+// external assets and runs no network requests; the inline script contains
+// exactly two handlers: copy-to-clipboard, and the open-in-tab blob handler
+// (which DOES run an asset live in an isolated origin on an explicit click —
+// see the OPEN note on the script). All embedded text (sources, receipts,
+// world-model files) is HTML-escaped, and the inline `.html` previews stay
+// inside a no-token sandboxed `srcdoc` iframe (scripts blocked), so a hostile
+// world-model file cannot run code in the export page itself.
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import {
+  buildSnapshot,
+  describeStateDir,
+  readNodeWorldModel,
+  type OpenedStateDir,
+  type ReplaySnapshot,
+  type DescribeData,
+  type WorldModelFileView,
+} from "../data";
+
+/** One embedded `.prose.md` source file (the copyable contract block). */
+export interface SourceFile {
+  /** Display name (the basename, e.g. `signal-inbox.prose.md`). */
+  readonly name: string;
+  /** The verbatim file text. */
+  readonly text: string;
+}
+
+/** One node's published outputs at its last rendered version. */
+export interface NodeOutput {
+  readonly node: string;
+  readonly label: string;
+  /** The content-addressed version exported (= last rendered `@atomic`). */
+  readonly version: string;
+  readonly files: readonly WorldModelFileView[];
+}
+
+export interface RunExportOptions {
+  /** Page title; defaults to the beats title, else the state-dir basename. */
+  readonly title?: string;
+  /** Shipped sample (`--example`) — stamps the illustrative-figures banner. */
+  readonly synthetic?: boolean;
+  /**
+   * `--source <path>`: a `.prose.md` file or a directory of them to embed as
+   * the contract block. When omitted, the exporter auto-detects a source
+   * snapshot INSIDE the state-dir (`root.prose.md` / `sources/*.prose.md`, the
+   * VM run-envelope convention) and embeds nothing if there is none.
+   */
+  readonly sourcePath?: string;
+}
+
+export interface RunExportResult {
+  /** The complete, self-contained HTML document. */
+  readonly html: string;
+  /** Mirror of the `--describe` chain-verify verdict (drives the exit code). */
+  readonly chainOk: boolean;
+  /** How many source files were embedded (0 = no contract block). */
+  readonly sourceCount: number;
+}
+
+/** Raw-receipts JSON above this byte size is omitted from the export (with an
+ * honest note) so a huge ledger cannot balloon the artifact. */
+const RAW_RECEIPTS_BYTE_CAP = 4 * 1024 * 1024;
+
+const PROSE_EXT = ".prose.md";
+
+/**
+ * Collect the `.prose.md` sources to embed. Explicit `sourcePath` wins: a file
+ * embeds that file; a directory embeds every `*.prose.md` directly inside it
+ * AND inside a conventional `src/` child (the example-package layout). With no
+ * `sourcePath`, fall back to a source snapshot inside the state-dir itself —
+ * `root.prose.md` plus `sources/*.prose.md` (the VM run-envelope convention;
+ * reactor state-dirs do not write these today, so this is forward-compat).
+ * `index.prose.md` sorts first; the rest alphabetical.
+ */
+export function collectSources(
+  sourcePath: string | undefined,
+  stateDir: string,
+): SourceFile[] {
+  const out: SourceFile[] = [];
+  const pushFile = (path: string): void => {
+    out.push({ name: basename(path), text: readFileSync(path, "utf8") });
+  };
+  const pushDirProse = (dir: string): void => {
+    if (!existsSync(dir)) return;
+    for (const name of readdirSync(dir).sort()) {
+      if (name.endsWith(PROSE_EXT)) pushFile(join(dir, name));
+    }
+  };
+
+  if (sourcePath !== undefined) {
+    const st = statSync(sourcePath); // missing path throws — caller surfaces it
+    if (st.isFile()) {
+      pushFile(sourcePath);
+    } else {
+      pushDirProse(sourcePath);
+      pushDirProse(join(sourcePath, "src"));
+    }
+    // An explicit --source that matches NOTHING is a caller mistake (typo'd or
+    // wrong dir), not a no-contract run — fail loudly before any file is
+    // written rather than shipping a quiet contract-less export.
+    if (out.length === 0) {
+      throw new Error(
+        `--source matched no *.prose.md files at ${sourcePath} (looked in it and its src/ child)`,
+      );
+    }
+  } else {
+    const root = join(stateDir, "root.prose.md");
+    if (existsSync(root)) pushFile(root);
+    pushDirProse(join(stateDir, "sources"));
+  }
+
+  out.sort((a, b) =>
+    a.name === "index.prose.md" ? -1
+    : b.name === "index.prose.md" ? 1
+    : a.name.localeCompare(b.name),
+  );
+  return out;
+}
+
+/**
+ * Collect each node's published world-model at its LAST `rendered` version —
+ * the run's output assets. Ordered by topology node order (receipt-only nodes
+ * like `ingress.*` follow, first-seen). Nodes whose version cannot be read
+ * back (no `world-models/` dir, pruned version) are silently absent — the
+ * outputs section says so rather than fabricating content.
+ */
+export function collectOutputs(
+  opened: OpenedStateDir,
+  snapshot: ReplaySnapshot,
+): NodeOutput[] {
+  const lastRendered = new Map<string, string>();
+  for (const f of snapshot.frames) {
+    if (f.status === "rendered" && f.atomicVersion !== "") {
+      lastRendered.set(f.node, f.atomicVersion);
+    }
+  }
+  const order: string[] = snapshot.nodes.map((n) => n.id);
+  for (const node of lastRendered.keys()) {
+    if (!order.includes(node)) order.push(node);
+  }
+  const out: NodeOutput[] = [];
+  for (const node of order) {
+    const version = lastRendered.get(node);
+    if (version === undefined) continue;
+    const wm = readNodeWorldModel(opened, node, version);
+    if (wm === null) continue;
+    out.push({ node, label: labelFor(snapshot, node), version, files: wm.files });
+  }
+  return out;
+}
+
+/** Friendly label with the same fallback `--describe` uses (short name). */
+function labelFor(snapshot: ReplaySnapshot, node: string): string {
+  const l = snapshot.labels[node];
+  if (l) return l;
+  const dot = node.indexOf(".");
+  return dot >= 0 ? node.slice(dot + 1) : node;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Pretty-print a text body when it parses as JSON; otherwise return as-is. */
+function prettyMaybeJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function fmtTokens(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+/**
+ * Render the gist-view export for an opened state-dir. Pure over the data
+ * layer; the caller writes `result.html` to disk and maps `result.chainOk`
+ * onto the exit code exactly like `--describe`.
+ */
+export function renderRunExport(
+  opened: OpenedStateDir,
+  options: RunExportOptions = {},
+): RunExportResult {
+  const snapshot = buildSnapshot(opened);
+  const describe = describeStateDir(opened, {
+    synthetic: options.synthetic ?? false,
+  });
+  const data = describe.data;
+  const sources = collectSources(options.sourcePath, opened.stateDir);
+  const outputs = collectOutputs(opened, snapshot);
+  const title =
+    options.title ??
+    (snapshot.beats?.title || basename(opened.stateDir) || "reactor run");
+
+  const html = renderDocument({
+    title,
+    synthetic: options.synthetic ?? false,
+    snapshot,
+    data,
+    describeText: describe.text,
+    rawReceipts: opened.rawReceipts,
+    sources,
+    outputs,
+  });
+  return { html, chainOk: describe.chainOk, sourceCount: sources.length };
+}
+
+// --- the document ------------------------------------------------------------
+
+interface DocumentInput {
+  readonly title: string;
+  readonly synthetic: boolean;
+  readonly snapshot: ReplaySnapshot;
+  readonly data: DescribeData;
+  readonly describeText: string;
+  readonly rawReceipts: readonly unknown[] | null;
+  readonly sources: readonly SourceFile[];
+  readonly outputs: readonly NodeOutput[];
+}
+
+function renderDocument(input: DocumentInput): string {
+  const { title, synthetic, snapshot, data, sources, outputs } = input;
+  const chainBadge = data.chainVerify.ok
+    ? `<span class="badge ok">chain ✓ verified</span>`
+    : `<span class="badge bad">chain ✗ TAMPERED</span>`;
+  const stats =
+    `${data.topology.nodes} nodes · ${data.topology.edges} edges · ` +
+    `${data.receipts} receipts — rendered ${data.dispositions.rendered} · ` +
+    `skipped ${data.dispositions.skipped} · failed ${data.dispositions.failed} — ` +
+    `fresh ${fmtTokens(data.costRollup.total.fresh)} tokens`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)} — reactor run</title>
+<style>${CSS}</style>
+</head>
+<body>
+<header>
+  <h1>${escapeHtml(title)}</h1>
+  <p class="meta">${escapeHtml(stats)} ${chainBadge}</p>
+  <p class="meta dim">state-dir ${escapeHtml(basename(snapshot.stateDir) || snapshot.stateDir)}</p>
+  ${synthetic ? `<p class="meta synthetic">synthetic sample ledger — token counts are illustrative, not a bill</p>` : ""}
+</header>
+${renderContractSection(sources)}
+${renderRunSection(input)}
+${renderOutputsSection(outputs)}
+<footer>generated by <code>reactor-devtools --export</code> · self-contained · no network</footer>
+<script>${COPY_SCRIPT}</script>
+</body>
+</html>
+`;
+}
+
+// §1 CONTRACT — the copyable prose block(s).
+function renderContractSection(sources: readonly SourceFile[]): string {
+  if (sources.length === 0) {
+    return `<section>
+  <h2>Contract</h2>
+  <p class="dim">No <code>.prose.md</code> source embedded — the state-dir carries no source
+  snapshot. Re-export with <code>--source &lt;file-or-dir&gt;</code> to include the contract.</p>
+</section>`;
+  }
+  const blocks = sources
+    .map((s, i) => {
+      const id = `src-${i}`;
+      return `<details class="src"${sources.length === 1 ? " open" : ""}>
+  <summary><code>${escapeHtml(s.name)}</code><button class="copy" data-copy="${id}">copy</button></summary>
+  <pre id="${id}"><code>${escapeHtml(s.text)}</code></pre>
+</details>`;
+    })
+    .join("\n");
+  return `<section>
+  <h2>Contract <span class="dim">— ${sources.length} source file${sources.length === 1 ? "" : "s"}, copy &amp; re-run with <code>prose run</code> / <code>reactor run</code></span></h2>
+${blocks}
+</section>`;
+}
+
+// §2 RUN — the expandable full run artifact.
+function renderRunSection(input: DocumentInput): string {
+  const { snapshot, data } = input;
+
+  if (data.empty) {
+    return `<section>
+  <h2>Run</h2>
+  <p class="dim">Ledger empty — this state-dir is compiled-but-unrun.</p>
+</section>`;
+  }
+
+  const frameRows = data.frames
+    .map(
+      (f) => `<tr class="${escapeHtml(f.status)}">
+  <td class="num">${f.index}</td>
+  <td>${escapeHtml(f.label)}</td>
+  <td class="status">${escapeHtml(f.status)}</td>
+  <td>${escapeHtml(f.wakeSource)}</td>
+  <td>${escapeHtml(f.movedFacets.join(", ") || "—")}</td>
+  <td class="num">${fmtTokens(f.fresh)}</td>
+  <td>${escapeHtml(f.wokenSubscribers.join(", ") || "—")}</td>
+</tr>`,
+    )
+    .join("\n");
+
+  const nodeRows = data.nodes
+    .map(
+      (n) => `<tr>
+  <td>${escapeHtml(n.label)}${n.offTopology ? ` <span class="bad-text">(off-topology)</span>` : ""}</td>
+  <td class="num">${n.rendered}</td>
+  <td class="num">${n.skipped}</td>
+  <td class="num">${n.failed}</td>
+  <td class="num">${fmtTokens(n.fresh)}</td>
+  <td>${n.chainOk ? `<span class="ok-text">chain ✓</span>` : `<span class="bad-text">chain ✗</span>`}</td>
+</tr>`,
+    )
+    .join("\n");
+
+  const costRows = Object.entries(data.costRollup.bySurpriseCause)
+    .filter(([, b]) => b.receipts > 0)
+    .map(
+      ([cause, b]) => `<tr>
+  <td>${escapeHtml(cause)}</td>
+  <td class="num">${b.receipts}</td>
+  <td class="num">${fmtTokens(b.fresh)}</td>
+  <td class="num">${fmtTokens(b.reused)}</td>
+</tr>`,
+    )
+    .join("\n");
+
+  const edgeList = snapshot.edges
+    .map(
+      (e) =>
+        `<li><code>${escapeHtml(e.producer)}</code> —<span class="facet">${escapeHtml(e.facet)}</span>→ <code>${escapeHtml(e.subscriber)}</code></li>`,
+    )
+    .join("\n");
+
+  const chainErrors = data.chainVerify.ok
+    ? ""
+    : `<div class="tamper"><strong>CHAIN-VERIFY FAILED</strong><ul>${data.chainVerify.errors
+        .map((e) => `<li>${escapeHtml(e)}</li>`)
+        .join("")}</ul></div>`;
+
+  // The raw as-persisted receipts: the deepest layer of the artifact. Capped so
+  // a huge ledger cannot balloon the file — the cap is NAMED in the output.
+  let rawBlock = `<p class="dim">raw trail unavailable</p>`;
+  if (input.rawReceipts !== null) {
+    const rawJson = JSON.stringify(input.rawReceipts, null, 2);
+    rawBlock =
+      Buffer.byteLength(rawJson, "utf8") <= RAW_RECEIPTS_BYTE_CAP
+        ? `<pre><code>${escapeHtml(rawJson)}</code></pre>`
+        : `<p class="dim">omitted — raw receipts exceed ${RAW_RECEIPTS_BYTE_CAP / (1024 * 1024)} MB; read them from the state-dir's <code>receipts.json</code></p>`;
+  }
+
+  return `<section>
+  <h2>Run <span class="dim">— receipt timeline, expand for the full artifact</span></h2>
+  ${chainErrors}
+  <details>
+    <summary>${data.receipts} receipts · rendered ${data.dispositions.rendered} / skipped ${data.dispositions.skipped} / failed ${data.dispositions.failed} · ${data.chainVerify.ok ? "chain ✓" : "chain ✗"}</summary>
+    <h3>Frames</h3>
+    <table>
+      <thead><tr><th>#</th><th>node</th><th>status</th><th>wake</th><th>moved facets</th><th>fresh tokens</th><th>woke</th></tr></thead>
+      <tbody>
+${frameRows}
+      </tbody>
+    </table>
+    <h3>Per node</h3>
+    <table>
+      <thead><tr><th>node</th><th>rendered</th><th>skipped</th><th>failed</th><th>fresh tokens</th><th>chain</th></tr></thead>
+      <tbody>
+${nodeRows}
+      </tbody>
+    </table>
+    <h3>Cost by surprise-cause</h3>
+    <table>
+      <thead><tr><th>cause</th><th>receipts</th><th>fresh tokens</th><th>reused tokens</th></tr></thead>
+      <tbody>
+${costRows}
+      </tbody>
+    </table>
+    <details>
+      <summary>Topology — ${snapshot.edges.length} subscription edges</summary>
+      <ul class="edges">
+${edgeList}
+      </ul>
+    </details>
+    <details>
+      <summary>Raw receipts (as persisted, chain-verifiable)</summary>
+      ${rawBlock}
+    </details>
+  </details>
+</section>`;
+}
+
+// §3 OUTPUTS — each node's published truth at its last rendered version.
+function renderOutputsSection(outputs: readonly NodeOutput[]): string {
+  if (outputs.length === 0) {
+    return `<section>
+  <h2>Outputs</h2>
+  <p class="dim">No published world-models readable from this state-dir
+  (no <code>world-models/</code> directory, or no rendered receipts).</p>
+</section>`;
+  }
+  let assetId = 0;
+  const blocks = outputs
+    .map((o) => {
+      // Pre-assign the per-file source ids so the SUMMARY can carry the
+      // open-in-tab button(s) for previewable assets — the affordance must be
+      // visible while the node is still COLLAPSED (the embedded source the
+      // button reads lives in the DOM either way). One asset → the plain
+      // label; several → each button names its file.
+      const ids = o.files.map(() => `asset-${assetId++}`);
+      const previewable = o.files
+        .map((f, i) => ({ f, id: ids[i]! }))
+        .filter(({ f }) => f.text !== null && isPreviewableAsset(f.path));
+      const openButtons = previewable
+        .map(
+          ({ f, id }) =>
+            `<button class="open" data-open="${id}" data-type="${assetContentType(f.path)}">${
+              previewable.length === 1 ? "open in tab" : `open ${escapeHtml(f.path)}`
+            }</button>`,
+        )
+        .join("");
+      const files = o.files
+        .map((f, i) => renderOutputFile(o.node, f, ids[i]!))
+        .join("\n");
+      return `<details class="out">
+  <summary><code>${escapeHtml(o.label)}</code> <span class="dim">${o.files.length} file${o.files.length === 1 ? "" : "s"} @ ${escapeHtml(shortAddress(o.version))}</span>${openButtons}</summary>
+${files}
+</details>`;
+    })
+    .join("\n");
+  return `<section>
+  <h2>Outputs <span class="dim">— published world-model at each node's last rendered version</span></h2>
+${blocks}
+</section>`;
+}
+
+/** `sha256:ab12…ef34` — keep addresses scannable. */
+function shortAddress(version: string): string {
+  const m = /^(sha256:)([0-9a-f]{64})$/.exec(version);
+  return m ? `${m[1]}${m[2]!.slice(0, 8)}…` : version;
+}
+
+/** Assets that get a live preview + open-in-tab: HTML documents and SVG. */
+function isPreviewableAsset(path: string): boolean {
+  return /\.(html?|svg)$/i.test(path);
+}
+
+/** The blob content-type the open-in-tab button stamps on the asset. */
+function assetContentType(path: string): string {
+  return /\.svg$/i.test(path) ? "image/svg+xml" : "text/html";
+}
+
+function renderOutputFile(
+  node: string,
+  f: WorldModelFileView,
+  assetId: string,
+): string {
+  const heading = `<p class="filepath"><code>${escapeHtml(f.path)}</code> <span class="dim">${f.bytes} B</span></p>`;
+  if (f.text === null) {
+    return `${heading}<p class="dim">binary — base64 in the state-dir's world-models/</p>`;
+  }
+  // An HTML/SVG asset gets a sandboxed live preview (no scripts — the sandbox
+  // attribute with no tokens blocks JS, forms, and top navigation) PLUS the
+  // escaped source underneath; its open-in-tab button lives on the NODE's
+  // summary row (visible while collapsed) and points here via `assetId` (see
+  // the OPEN note on the script for the trust boundary). Everything else
+  // renders as escaped text.
+  if (isPreviewableAsset(f.path)) {
+    return `${heading}
+<iframe class="preview" sandbox="" title="${escapeHtml(node)}/${escapeHtml(f.path)}" srcdoc="${escapeHtml(f.text)}"></iframe>
+<details><summary>view source</summary><pre id="${assetId}"><code>${escapeHtml(f.text)}</code></pre></details>`;
+  }
+  return `${heading}<pre><code>${escapeHtml(prettyMaybeJson(f.text))}</code></pre>`;
+}
+
+// --- inline assets -----------------------------------------------------------
+
+const CSS = `
+:root { color-scheme: dark; }
+* { box-sizing: border-box; }
+body {
+  margin: 0 auto; padding: 2rem 1.25rem 4rem; max-width: 60rem;
+  background: #0b0e14; color: #d7dce2;
+  font: 14px/1.55 "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+h1 { font-size: 1.25rem; margin: 0 0 .25rem; color: #fff; }
+h2 { font-size: 1rem; margin: 2.25rem 0 .75rem; color: #fff; border-bottom: 1px solid #1e2430; padding-bottom: .4rem; }
+h3 { font-size: .85rem; margin: 1.25rem 0 .4rem; color: #aeb7c2; text-transform: uppercase; letter-spacing: .06em; }
+.meta { margin: .15rem 0; font-size: .8rem; color: #aeb7c2; }
+.dim { color: #6b7585; font-weight: normal; font-size: .8rem; }
+.synthetic { color: #d9a64a; }
+.badge { padding: .1rem .5rem; border-radius: 99px; font-size: .75rem; vertical-align: middle; }
+.badge.ok { background: #103822; color: #57d98a; }
+.badge.bad { background: #3d1216; color: #ff6b6b; }
+.ok-text { color: #57d98a; }
+.bad-text { color: #ff6b6b; }
+section { margin-top: 1.5rem; }
+details { border: 1px solid #1e2430; border-radius: 8px; margin: .5rem 0; background: #0e121a; }
+details > summary { cursor: pointer; padding: .55rem .8rem; color: #c8d0da; user-select: none; }
+details[open] > summary { border-bottom: 1px solid #1e2430; }
+details > *:not(summary) { margin: .6rem .8rem; }
+details details { margin: .6rem .8rem; }
+pre { overflow-x: auto; padding: .75rem; background: #0a0d13; border-radius: 6px; font-size: .8rem; line-height: 1.5; }
+code { font-family: inherit; }
+table { border-collapse: collapse; width: 100%; font-size: .78rem; }
+th, td { text-align: left; padding: .25rem .55rem; border-bottom: 1px solid #161b25; vertical-align: top; }
+th { color: #6b7585; font-weight: 500; }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+tr.rendered td.status { color: #57d98a; }
+tr.skipped td { color: #5c6675; }
+tr.skipped td.status { color: #5c6675; }
+tr.failed td.status { color: #ff6b6b; }
+.copy, .open {
+  float: right; margin-left: .75rem; padding: .1rem .6rem; font: inherit; font-size: .72rem;
+  background: #18202e; color: #c8d0da; border: 1px solid #28324a; border-radius: 6px; cursor: pointer;
+}
+.copy:hover, .open:hover { background: #21304a; }
+.copy.done { color: #57d98a; border-color: #2a4a36; }
+.filepath { margin: .75rem .8rem .25rem; }
+.preview { width: 100%; height: 24rem; border: 1px solid #1e2430; border-radius: 6px; background: #fff; }
+.edges { list-style: none; padding-left: .25rem; font-size: .78rem; }
+.facet { color: #d9a64a; padding: 0 .2rem; }
+.tamper { border: 1px solid #5c1a21; background: #1d0d10; border-radius: 8px; padding: .6rem .9rem; color: #ff8a8a; }
+footer { margin-top: 3rem; font-size: .72rem; color: #4d5666; }
+`;
+
+const COPY_SCRIPT = `
+for (const btn of document.querySelectorAll(".copy")) {
+  btn.addEventListener("click", (ev) => {
+    ev.preventDefault(); ev.stopPropagation();
+    const pre = document.getElementById(btn.getAttribute("data-copy"));
+    if (!pre) return;
+    navigator.clipboard.writeText(pre.textContent).then(() => {
+      btn.textContent = "copied"; btn.classList.add("done");
+      setTimeout(() => { btn.textContent = "copy"; btn.classList.remove("done"); }, 1200);
+    });
+  });
+}
+// OPEN: view an HTML/SVG asset in its own tab via a blob: URL built from the
+// embedded source (pre.textContent un-escapes it). DELIBERATE trust boundary:
+// the inline preview is a no-token sandbox (scripts blocked), while open-in-tab
+// runs the artifact LIVE — an explicit user action, in an isolated blob origin
+// detached from this page via noopener. Blob URLs are never revoked here: the
+// artifact tab must survive reloads, and the cost is bounded by page lifetime.
+for (const btn of document.querySelectorAll(".open")) {
+  btn.addEventListener("click", (ev) => {
+    ev.preventDefault(); ev.stopPropagation();
+    const pre = document.getElementById(btn.getAttribute("data-open"));
+    if (!pre) return;
+    const type = btn.getAttribute("data-type") || "text/html";
+    const url = URL.createObjectURL(new Blob([pre.textContent], { type }));
+    window.open(url, "_blank", "noopener");
+  });
+}
+`;


### PR DESCRIPTION
Closes #139

## Summary

- New `reactor-devtools <state-dir> --export <file.html>` flag: renders a saved run as **one self-contained HTML file** — the gist view: copyable `.prose.md` contract on top, expandable receipt timeline in the middle, output assets below.
- `--source <file-or-dir>` embeds the contract block (opt-in, since reactor state-dirs carry no source snapshot today; state-dir `root.prose.md`/`sources/` auto-detect is wired for when they do). `--title` sets the page title.
- Output assets: JSON pretty-prints; `.html`/`.svg` assets get a live preview in a **no-token sandboxed iframe** (scripts blocked) plus an **open in tab** button on the collapsed summary row (a `blob:` URL from the embedded source, detached via `noopener`).
- Exit-code contract mirrors `--describe`: clean or legitimately-empty chain → 0; detected tamper → 1, with the file still written carrying the tamper verdict. Existing targets refused without `--force`.
- Pure formatter over the existing data layer (`openStateDir` → `buildSnapshot` / `describeStateDir` / `readNodeWorldModel`); re-derives nothing, adds no dependencies, changes no existing public surface.

## Use Case / Run Evidence

`agent-experience` — this came out of an agent session exploring how prose logs runs and asserts output-type contracts. The friction: a run's trust story (contract → chain-verified receipts → outputs) is only tellable to someone with the package installed and the state-dir on disk. The unit of sharing is a claim about the run, never the run itself. Full motivation in the linked issue.

Demonstrated on the shipped `masked-relay` fixture paired with its `skills/open-prose/examples/masked-relay/src/` contracts (12 sources, 77 receipts, 13 node outputs), and on a minimal chain-valid state-dir whose node publishes `report.html` (the "prose in → HTML out" story).

## Design Boundary

This belongs in `packages/reactor-devtools` (the keyless replay viewer): it is a presentation of what the harness already persists, exactly like the SPA and `--describe`. It does not touch the SDK, the `reactor` CLI, or VM/skill semantics. The one adjacent gap it names but does not implement: reactor state-dirs don't snapshot authored sources (the VM run-envelope convention) — that belongs in compile/run, and this PR's `--source` flag plus auto-detect bridges until then.

## Examples

```bash
reactor-devtools --example masked-relay --export run.html \
  --source skills/open-prose/examples/masked-relay/src \
  --title "Masked Relay — customer-signal fan-out"
# → reactor-devtools: exported 12 source file(s) + the run artifact + outputs
```

Without a contract source, the export states the absence honestly and stdout hints at `--source`; it never fabricates a contract.

## Testing

`pnpm -C packages/reactor-devtools test` (typecheck + `node --test`, keyless/offline by nature — no model calls in this package): **108/108 pass** on this branch in a clean worktree based on current `origin/main`. 12 new tests in `src/export/export.test.ts`:

- gist-view section ordering and content on the shipped `masked-relay` fixture (CLI-level, spawns `dist/cli.js` like `cli.test.ts`)
- `--source` embedding with HTML-escaping assertions (hostile `<script>` payload never appears live)
- end-to-end `.html` asset path: builds a chain-valid state-dir from real SDK primitives (`commitPublished` → `createReceipt` → `appendReceipt`), asserts the sandboxed iframe, the summary-row open button, and the `noopener` blob handler
- **tamper path**: edits a persisted receipt without re-stamping its `content_hash` → exit 1, file still written carrying the `chain ✗ TAMPERED` verdict
- `--force` overwrite contract, ambiguous-flag refusals (`--export` + `--describe`/`--copy-to`, `--source` without `--export`), missing flag values (`--export` with no value never falls through to the blocking server), missing or empty `--source` fails loudly with no half-export
- unit: `collectSources` (file / dir / `src/` child / `index.prose.md` ordering), self-containment (no external `src=`/`href=` URLs)

Also verified in a real browser (Chromium via Playwright, over both `http://` and `file://`): copy button puts the actual prose source on the clipboard, open-in-tab renders the artifact in its own tab without toggling the accordion, zero console errors, zero external requests; a hostile asset script executed nowhere (top window and sandboxed iframe both clean, zero dialogs, zero network).

An adversarial pre-PR audit pass reviewed the diff and exercised the binary; its actionable findings are folded in: missing-value flag refusal, loud empty-`--source` failure, basename-only state-dir in the shareable artifact (no absolute local paths), escaped receipt status, accurate script-inventory wording in docs, and the tamper-path test above.

## Residual Risk / Follow-ups

- **Open-in-tab runs the artifact live** (isolated blob origin, `noopener`) — a deliberate, documented trust boundary distinct from the always-sandboxed inline preview; an explicit user click, same model as viewing a raw gist file.
- Raw receipts are embedded up to 4 MB, then omitted with a named note pointing at the state-dir's `receipts.json` — no silent truncation.
- Output assets are not size-capped, and a previewable asset embeds twice (srcdoc + view-source) — fine for receipt-scale world-models; a cap with an honest omission note is a follow-up if large artifacts show up in practice.
- Follow-up (out of scope): snapshot `root.prose.md`/`sources/` into the state-dir at compile/run so every export carries its contract without `--source`.
- Follow-up (out of scope): a hosted/served variant of the same render (run permalinks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
