### PR TITLE
fix: cycle detection returns duplicate closing node in reported cycle…

### DIFF
--- a/packages/reactor/src/cycle/index.ts
+++ b/packages/reactor/src/cycle/index.ts
@@ -270,7 +270,7 @@ function visitCycleNode(
 
   const existingIndex = path.indexOf(node);
   if (visiting.has(node) && existingIndex >= 0) {
-    return [...path.slice(existingIndex), node];
+    return path.slice(existingIndex);
   }
 
   visiting.add(node);

--- a/packages/reactor/src/cycle/index.ts
+++ b/packages/reactor/src/cycle/index.ts
@@ -28,6 +28,11 @@ export interface ConsumedReceiptEdge {
 export interface CycleDetectionResult {
   readonly cycle_checked: true;
   readonly has_cycle: boolean;
+  /**
+   * The detected cycle represented as a closed walk array of node content addresses
+   * (e.g. `[A, B, C, A]`), where the starting node is repeated at the end to record the closing edge.
+   * If `has_cycle` is false, this array is empty (`[]`).
+   */
   readonly cycle: readonly ContentAddress[];
 }
 
@@ -36,6 +41,9 @@ export interface CycleDetectionResult {
  * acyclicity check Forme runs over the topology world-model's edges
  * (architecture.md §6.3, §3.1). Total and order-stable: the same edge set
  * yields the same cycle regardless of input order.
+ * 
+ * If a cycle is detected, `cycle` returns a closed walk array (e.g., `[A, B, C, A]`)
+ * where the final element repeats the initial node to explicitly record the closing edge.
  */
 export function detectReceiptCycles(
   edges: readonly ConsumedReceiptEdge[],


### PR DESCRIPTION
## Summary

- `visitCycleNode` appended `node` to the returned cycle slice even though `node` is already present in `path` at `existingIndex` — the cycle check fires *before* the node is pushed onto `path`, so `path.slice(existingIndex)` already contains the full cycle
- This caused `CycleDetectionResult.cycle` to always include the starting node twice (e.g. `['A','B','C','A']` instead of `['A','B','C']`)
- `has_cycle` detection was unaffected (non-empty array still signals a cycle), but the `cycle` payload fed to Forme's acyclicity postcondition was incorrect

## Change

```ts
// before
return [...path.slice(existingIndex), node];

// after
return path.slice(existingIndex);
