### PR TITLE
Normalize OpenProse source metadata for strict lint

### DIFF
--- a/packages/co/evals/agent-readiness.eval.prose.md
+++ b/packages/co/evals/agent-readiness.eval.prose.md
@@ -1,6 +1,7 @@
 ---
 name: agent-readiness.eval
 kind: test
+version: 0.15.0
 subject: agent-readiness
 tier: service
 contract_version: v1

--- a/packages/co/evals/company-repo-checker.eval.prose.md
+++ b/packages/co/evals/company-repo-checker.eval.prose.md
@@ -1,6 +1,7 @@
 ---
 name: company-repo-checker.eval
 kind: test
+version: 0.15.0
 subject: company-repo-checker
 tier: function
 contract_version: v1

--- a/packages/co/services/agent-readiness.prose.md
+++ b/packages/co/services/agent-readiness.prose.md
@@ -1,6 +1,7 @@
 ---
 name: agent-readiness
 kind: function
+version: 0.15.0
 ---
 
 

--- a/packages/co/systems/company-repo-checker/index.prose.md
+++ b/packages/co/systems/company-repo-checker/index.prose.md
@@ -1,6 +1,7 @@
 ---
 name: company-repo-checker
 kind: function
+version: 0.15.0
 ---
 
 
@@ -210,4 +211,3 @@ return report
 - list failures before counts
 - preserve exact file paths and contract names from inspector outputs
 - do not downgrade hard failures to warnings
-```

--- a/packages/reactor-cli/examples/agent-observatory/attention-queue.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/attention-queue.prose.md
@@ -1,6 +1,7 @@
 ---
 name: attention-queue
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/agent-observatory/claude-sessions.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/claude-sessions.prose.md
@@ -1,6 +1,7 @@
 ---
 name: claude-sessions
 kind: gateway
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/agent-observatory/dashboard.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/dashboard.prose.md
@@ -1,6 +1,7 @@
 ---
 name: dashboard
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/agent-observatory/decisions-log.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/decisions-log.prose.md
@@ -1,6 +1,7 @@
 ---
 name: decisions-log
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/agent-observatory/eng-backlog.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/eng-backlog.prose.md
@@ -1,6 +1,7 @@
 ---
 name: eng-backlog
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/agent-observatory/session-signal.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/session-signal.prose.md
@@ -1,6 +1,7 @@
 ---
 name: session-signal
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/agent-observatory/use-case-guide.prose.md
+++ b/packages/reactor-cli/examples/agent-observatory/use-case-guide.prose.md
@@ -1,6 +1,7 @@
 ---
 name: use-case-guide
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/gateway-connector/digest.prose.md
+++ b/packages/reactor-cli/examples/gateway-connector/digest.prose.md
@@ -1,6 +1,7 @@
 ---
 name: digest
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/gateway-connector/inbox.prose.md
+++ b/packages/reactor-cli/examples/gateway-connector/inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inbox
 kind: gateway
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/quickstart/digest.prose.md
+++ b/packages/reactor-cli/examples/quickstart/digest.prose.md
@@ -1,6 +1,7 @@
 ---
 name: digest
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/examples/quickstart/inbox.prose.md
+++ b/packages/reactor-cli/examples/quickstart/inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inbox
 kind: gateway
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/src/__tests__/__fixtures__/gateway-project/digest.prose.md
+++ b/packages/reactor-cli/src/__tests__/__fixtures__/gateway-project/digest.prose.md
@@ -1,6 +1,7 @@
 ---
 name: digest
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor-cli/src/__tests__/__fixtures__/gateway-project/inbox.prose.md
+++ b/packages/reactor-cli/src/__tests__/__fixtures__/gateway-project/inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inbox
 kind: gateway
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor/src/adapters/agent-compile/__fixtures__/smallest-project/competitor-monitor.prose.md
+++ b/packages/reactor/src/adapters/agent-compile/__fixtures__/smallest-project/competitor-monitor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: competitor-monitor
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/reactor/src/adapters/agent-compile/__fixtures__/smallest-project/weekly-brief.prose.md
+++ b/packages/reactor/src/adapters/agent-compile/__fixtures__/smallest-project/weekly-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: weekly-brief
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/std/delivery/email-notifier.prose.md
+++ b/packages/std/delivery/email-notifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: email-notifier
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/delivery/email-renderer.prose.md
+++ b/packages/std/delivery/email-renderer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: email-renderer
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/delivery/file-writer.prose.md
+++ b/packages/std/delivery/file-writer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: file-writer
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/delivery/html-renderer.prose.md
+++ b/packages/std/delivery/html-renderer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: html-renderer
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/delivery/human-gate.prose.md
+++ b/packages/std/delivery/human-gate.prose.md
@@ -1,6 +1,7 @@
 ---
 name: human-gate
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/delivery/slack-notifier.prose.md
+++ b/packages/std/delivery/slack-notifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: slack-notifier
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/delivery/webhook-notifier.prose.md
+++ b/packages/std/delivery/webhook-notifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: webhook-notifier
 kind: function
+version: 0.15.0
 ---
 
 ### Shape

--- a/packages/std/evals/contract-grader.prose.md
+++ b/packages/std/evals/contract-grader.prose.md
@@ -1,6 +1,7 @@
 ---
 name: contract-grader
 kind: function
+version: 0.15.0
 ---
 
 # Contract Grader

--- a/packages/std/evals/cross-run-differ.prose.md
+++ b/packages/std/evals/cross-run-differ.prose.md
@@ -1,6 +1,7 @@
 ---
 name: cross-run-differ
 kind: function
+version: 0.15.0
 ---
 
 # Cross-Run Differ

--- a/packages/std/evals/eval-calibrator.prose.md
+++ b/packages/std/evals/eval-calibrator.prose.md
@@ -1,6 +1,7 @@
 ---
 name: eval-calibrator
 kind: function
+version: 0.15.0
 ---
 
 # Eval Calibrator

--- a/packages/std/evals/inspector.prose.md
+++ b/packages/std/evals/inspector.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inspector
 kind: function
+version: 0.15.0
 ---
 
 # Post-Run Inspector

--- a/packages/std/evals/platform-improver.prose.md
+++ b/packages/std/evals/platform-improver.prose.md
@@ -1,6 +1,7 @@
 ---
 name: platform-improver
 kind: function
+version: 0.15.0
 ---
 
 # Platform Improver

--- a/packages/std/evals/prose-contributor.prose.md
+++ b/packages/std/evals/prose-contributor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: prose-contributor
 kind: function
+version: 0.15.0
 ---
 
 # Prose Contributor

--- a/packages/std/evals/regression-tracker.prose.md
+++ b/packages/std/evals/regression-tracker.prose.md
@@ -1,6 +1,7 @@
 ---
 name: regression-tracker
 kind: responsibility
+version: 0.15.0
 ---
 
 # Regression Tracker

--- a/packages/std/evals/system-improver.prose.md
+++ b/packages/std/evals/system-improver.prose.md
@@ -1,6 +1,7 @@
 ---
 name: system-improver
 kind: function
+version: 0.15.0
 ---
 
 # System Improver

--- a/packages/std/memory/project-memory.prose.md
+++ b/packages/std/memory/project-memory.prose.md
@@ -1,6 +1,7 @@
 ---
 name: project-memory
 kind: function
+version: 0.15.0
 ---
 
 ### Runtime

--- a/packages/std/memory/user-memory.prose.md
+++ b/packages/std/memory/user-memory.prose.md
@@ -1,6 +1,7 @@
 ---
 name: user-memory
 kind: function
+version: 0.15.0
 ---
 
 ### Runtime

--- a/packages/std/ops/diagnose.prose.md
+++ b/packages/std/ops/diagnose.prose.md
@@ -1,6 +1,7 @@
 ---
 name: diagnose
 kind: function
+version: 0.15.0
 ---
 
 ### Parameters

--- a/packages/std/ops/lint.prose.md
+++ b/packages/std/ops/lint.prose.md
@@ -1,6 +1,7 @@
 ---
 name: lint
 kind: function
+version: 0.15.0
 ---
 
 ### Parameters

--- a/packages/std/ops/preflight.prose.md
+++ b/packages/std/ops/preflight.prose.md
@@ -1,6 +1,7 @@
 ---
 name: preflight
 kind: function
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/std/ops/profiler.prose.md
+++ b/packages/std/ops/profiler.prose.md
@@ -1,6 +1,7 @@
 ---
 name: profiler
 kind: function
+version: 0.15.0
 ---
 
 ### Goal

--- a/packages/std/ops/prose-author.incident-response.test.prose.md
+++ b/packages/std/ops/prose-author.incident-response.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-incident-response
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.launch-readiness.test.prose.md
+++ b/packages/std/ops/prose-author.launch-readiness.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-launch-readiness
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.parallel-research-approval.test.prose.md
+++ b/packages/std/ops/prose-author.parallel-research-approval.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-parallel-research-approval
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.prose.md
+++ b/packages/std/ops/prose-author.prose.md
@@ -1,6 +1,7 @@
 ---
 name: prose-author
 kind: function
+version: 0.15.0
 ---
 
 # Prose Author

--- a/packages/std/ops/prose-author.pseudocode-loop.test.prose.md
+++ b/packages/std/ops/prose-author.pseudocode-loop.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-pseudocode-loop
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.shape-root-guidance.test.prose.md
+++ b/packages/std/ops/prose-author.shape-root-guidance.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-shape-root-guidance
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.test.prose.md
+++ b/packages/std/ops/prose-author.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-release-readiness
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.unresolved-intent.test.prose.md
+++ b/packages/std/ops/prose-author.unresolved-intent.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-unresolved-intent
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/prose-author.user-global-memory.test.prose.md
+++ b/packages/std/ops/prose-author.user-global-memory.test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: test-prose-author-user-global-memory
 kind: test
+version: 0.15.0
 subject: prose-author
 ---
 

--- a/packages/std/ops/status.prose.md
+++ b/packages/std/ops/status.prose.md
@@ -1,6 +1,7 @@
 ---
 name: status
 kind: function
+version: 0.15.0
 ---
 
 ### Parameters

--- a/packages/std/ops/wire.prose.md
+++ b/packages/std/ops/wire.prose.md
@@ -1,6 +1,7 @@
 ---
 name: wire
 kind: function
+version: 0.15.0
 ---
 
 Run Forme wiring to produce a manifest. This function implements the Forme wiring layer's

--- a/packages/std/patterns/assumption-miner.prose.md
+++ b/packages/std/patterns/assumption-miner.prose.md
@@ -1,6 +1,7 @@
 ---
 name: assumption-miner
 kind: pattern
+version: 0.15.0
 ---
 
 # Assumption Miner

--- a/packages/std/patterns/blind-review.prose.md
+++ b/packages/std/patterns/blind-review.prose.md
@@ -1,6 +1,7 @@
 ---
 name: blind-review
 kind: pattern
+version: 0.15.0
 ---
 
 # Blind Review

--- a/packages/std/patterns/coherence-probe.prose.md
+++ b/packages/std/patterns/coherence-probe.prose.md
@@ -1,6 +1,7 @@
 ---
 name: coherence-probe
 kind: pattern
+version: 0.15.0
 ---
 
 # Coherence Probe

--- a/packages/std/patterns/contrastive-probe.prose.md
+++ b/packages/std/patterns/contrastive-probe.prose.md
@@ -1,6 +1,7 @@
 ---
 name: contrastive-probe
 kind: pattern
+version: 0.15.0
 ---
 
 # Contrastive Probe

--- a/packages/std/patterns/dialectic.prose.md
+++ b/packages/std/patterns/dialectic.prose.md
@@ -1,6 +1,7 @@
 ---
 name: dialectic
 kind: pattern
+version: 0.15.0
 ---
 
 # Dialectic

--- a/packages/std/patterns/ensemble-synthesizer.prose.md
+++ b/packages/std/patterns/ensemble-synthesizer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: ensemble-synthesizer
 kind: pattern
+version: 0.15.0
 ---
 
 # Ensemble-Synthesizer

--- a/packages/std/patterns/fallback-chain.prose.md
+++ b/packages/std/patterns/fallback-chain.prose.md
@@ -1,6 +1,7 @@
 ---
 name: fallback-chain
 kind: pattern
+version: 0.15.0
 ---
 
 # Fallback Chain

--- a/packages/std/patterns/fan-out.prose.md
+++ b/packages/std/patterns/fan-out.prose.md
@@ -1,6 +1,7 @@
 ---
 name: fan-out
 kind: pattern
+version: 0.15.0
 ---
 
 # Fan-Out

--- a/packages/std/patterns/guard.prose.md
+++ b/packages/std/patterns/guard.prose.md
@@ -1,6 +1,7 @@
 ---
 name: guard
 kind: pattern
+version: 0.15.0
 ---
 
 # Guard

--- a/packages/std/patterns/map-reduce.prose.md
+++ b/packages/std/patterns/map-reduce.prose.md
@@ -1,6 +1,7 @@
 ---
 name: map-reduce
 kind: pattern
+version: 0.15.0
 ---
 
 # Map-Reduce

--- a/packages/std/patterns/oversight.prose.md
+++ b/packages/std/patterns/oversight.prose.md
@@ -1,6 +1,7 @@
 ---
 name: oversight
 kind: pattern
+version: 0.15.0
 ---
 
 # Oversight

--- a/packages/std/patterns/pipeline.prose.md
+++ b/packages/std/patterns/pipeline.prose.md
@@ -1,6 +1,7 @@
 ---
 name: pipeline
 kind: pattern
+version: 0.15.0
 ---
 
 # Pipeline

--- a/packages/std/patterns/proposer-adversary.prose.md
+++ b/packages/std/patterns/proposer-adversary.prose.md
@@ -1,6 +1,7 @@
 ---
 name: proposer-adversary
 kind: pattern
+version: 0.15.0
 ---
 
 # Proposer-Adversary

--- a/packages/std/patterns/race.prose.md
+++ b/packages/std/patterns/race.prose.md
@@ -1,6 +1,7 @@
 ---
 name: race
 kind: pattern
+version: 0.15.0
 ---
 
 # Race

--- a/packages/std/patterns/ratchet.prose.md
+++ b/packages/std/patterns/ratchet.prose.md
@@ -1,6 +1,7 @@
 ---
 name: ratchet
 kind: pattern
+version: 0.15.0
 ---
 
 # Ratchet

--- a/packages/std/patterns/refine.prose.md
+++ b/packages/std/patterns/refine.prose.md
@@ -1,6 +1,7 @@
 ---
 name: refine
 kind: pattern
+version: 0.15.0
 ---
 
 # Refine

--- a/packages/std/patterns/retry-with-learning.prose.md
+++ b/packages/std/patterns/retry-with-learning.prose.md
@@ -1,6 +1,7 @@
 ---
 name: retry-with-learning
 kind: pattern
+version: 0.15.0
 ---
 
 # Retry With Learning

--- a/packages/std/patterns/stochastic-probe.prose.md
+++ b/packages/std/patterns/stochastic-probe.prose.md
@@ -1,6 +1,7 @@
 ---
 name: stochastic-probe
 kind: pattern
+version: 0.15.0
 ---
 
 # Stochastic Probe

--- a/packages/std/patterns/worker-critic.prose.md
+++ b/packages/std/patterns/worker-critic.prose.md
@@ -1,6 +1,7 @@
 ---
 name: worker-critic
 kind: pattern
+version: 0.15.0
 ---
 
 # Worker-Critic

--- a/packages/std/roles/classifier.prose.md
+++ b/packages/std/roles/classifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: classifier
 kind: function
+version: 0.15.0
 ---
 
 # Classifier

--- a/packages/std/roles/critic.prose.md
+++ b/packages/std/roles/critic.prose.md
@@ -1,6 +1,7 @@
 ---
 name: critic
 kind: function
+version: 0.15.0
 ---
 
 # Critic

--- a/packages/std/roles/extractor.prose.md
+++ b/packages/std/roles/extractor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: extractor
 kind: function
+version: 0.15.0
 ---
 
 # Extractor

--- a/packages/std/roles/formatter.prose.md
+++ b/packages/std/roles/formatter.prose.md
@@ -1,6 +1,7 @@
 ---
 name: formatter
 kind: function
+version: 0.15.0
 ---
 
 # Formatter

--- a/packages/std/roles/planner.prose.md
+++ b/packages/std/roles/planner.prose.md
@@ -1,6 +1,7 @@
 ---
 name: planner
 kind: function
+version: 0.15.0
 ---
 
 # Planner

--- a/packages/std/roles/researcher.prose.md
+++ b/packages/std/roles/researcher.prose.md
@@ -1,6 +1,7 @@
 ---
 name: researcher
 kind: function
+version: 0.15.0
 ---
 
 # Researcher

--- a/packages/std/roles/router.prose.md
+++ b/packages/std/roles/router.prose.md
@@ -1,6 +1,7 @@
 ---
 name: router
 kind: function
+version: 0.15.0
 ---
 
 # Router

--- a/packages/std/roles/summarizer.prose.md
+++ b/packages/std/roles/summarizer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: summarizer
 kind: function
+version: 0.15.0
 ---
 
 # Summarizer

--- a/packages/std/roles/verifier.prose.md
+++ b/packages/std/roles/verifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: verifier
 kind: function
+version: 0.15.0
 ---
 
 # Verifier

--- a/packages/std/roles/writer.prose.md
+++ b/packages/std/roles/writer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: writer
 kind: function
+version: 0.15.0
 ---
 
 # Writer

--- a/skills/open-prose/agent-onboarding.md
+++ b/skills/open-prose/agent-onboarding.md
@@ -26,7 +26,7 @@ up the new bytes. No sync script.
 
 # OpenProse — Agent Onboarding
 
-> Declare outcomes. Not instructions.
+> Stop scripting agents. Declare them.
 
 ## Install
 

--- a/skills/open-prose/agent-onboarding.md
+++ b/skills/open-prose/agent-onboarding.md
@@ -26,7 +26,7 @@ up the new bytes. No sync script.
 
 # OpenProse — Agent Onboarding
 
-> Stop scripting agents. Declare them.
+> Declare outcomes. Not instructions.
 
 ## Install
 

--- a/skills/open-prose/compiler/index.prose.md
+++ b/skills/open-prose/compiler/index.prose.md
@@ -1,6 +1,7 @@
 ---
 name: openprose-compiler
 kind: function
+version: 0.15.0
 ---
 
 # OpenProse Compiler

--- a/skills/open-prose/examples/agent-observatory/src/agent-dashboard-html.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/agent-dashboard-html.prose.md
@@ -1,6 +1,7 @@
 ---
 name: agent-dashboard-html
 kind: responsibility
+version: 0.15.0
 ---
 
 # Agent Dashboard (HTML)

--- a/skills/open-prose/examples/agent-observatory/src/agent-index-markdown.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/agent-index-markdown.prose.md
@@ -1,6 +1,7 @@
 ---
 name: agent-index-markdown
 kind: responsibility
+version: 0.15.0
 ---
 
 # Agent Index (Markdown)

--- a/skills/open-prose/examples/agent-observatory/src/concept-clusterer.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/concept-clusterer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: concept-clusterer
 kind: responsibility
+version: 0.15.0
 ---
 
 # Concept Clusterer

--- a/skills/open-prose/examples/agent-observatory/src/runtime-adapter.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/runtime-adapter.prose.md
@@ -1,6 +1,7 @@
 ---
 name: runtime-adapter
 kind: responsibility
+version: 0.15.0
 ---
 
 # Runtime Adapter [runtime]

--- a/skills/open-prose/examples/agent-observatory/src/runtime-watch.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/runtime-watch.prose.md
@@ -1,6 +1,7 @@
 ---
 name: runtime-watch
 kind: gateway
+version: 0.15.0
 ---
 
 # Runtime Watch

--- a/skills/open-prose/examples/agent-observatory/src/session-ledger.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/session-ledger.prose.md
@@ -1,6 +1,7 @@
 ---
 name: session-ledger
 kind: responsibility
+version: 0.15.0
 ---
 
 # Session Ledger

--- a/skills/open-prose/examples/agent-observatory/src/session-summary.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/session-summary.prose.md
@@ -1,6 +1,7 @@
 ---
 name: session-summary
 kind: responsibility
+version: 0.15.0
 ---
 
 # Session Summary [session]

--- a/skills/open-prose/examples/agent-observatory/src/session-to-prose.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/session-to-prose.prose.md
@@ -1,6 +1,7 @@
 ---
 name: session-to-prose
 kind: responsibility
+version: 0.15.0
 ---
 
 # Session → Prose

--- a/skills/open-prose/examples/agent-observatory/src/workstream-index.prose.md
+++ b/skills/open-prose/examples/agent-observatory/src/workstream-index.prose.md
@@ -1,6 +1,7 @@
 ---
 name: workstream-index
 kind: responsibility
+version: 0.15.0
 ---
 
 # Workstream Index

--- a/skills/open-prose/examples/auto-pocock/src/auto-pocock.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/auto-pocock.prose.md
@@ -1,6 +1,7 @@
 ---
 name: auto-pocock
 kind: function
+version: 0.15.0
 ---
 
 # Auto-Pocock

--- a/skills/open-prose/examples/auto-pocock/src/decide-plan.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/decide-plan.prose.md
@@ -1,6 +1,7 @@
 ---
 name: decide-plan
 kind: function
+version: 0.15.0
 ---
 
 # Decide Plan

--- a/skills/open-prose/examples/auto-pocock/src/ensure-skills.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/ensure-skills.prose.md
@@ -1,6 +1,7 @@
 ---
 name: ensure-skills
 kind: function
+version: 0.15.0
 ---
 
 # Ensure Skills

--- a/skills/open-prose/examples/auto-pocock/src/grill-plan.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/grill-plan.prose.md
@@ -1,6 +1,7 @@
 ---
 name: grill-plan
 kind: function
+version: 0.15.0
 ---
 
 # Grill Plan

--- a/skills/open-prose/examples/auto-pocock/src/implement-tdd.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/implement-tdd.prose.md
@@ -1,6 +1,7 @@
 ---
 name: implement-tdd
 kind: function
+version: 0.15.0
 ---
 
 # Implement TDD

--- a/skills/open-prose/examples/auto-pocock/src/produce-issues.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/produce-issues.prose.md
@@ -1,6 +1,7 @@
 ---
 name: produce-issues
 kind: function
+version: 0.15.0
 ---
 
 # Produce Issues

--- a/skills/open-prose/examples/auto-pocock/src/produce-prd.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/produce-prd.prose.md
@@ -1,6 +1,7 @@
 ---
 name: produce-prd
 kind: function
+version: 0.15.0
 ---
 
 # Produce PRD

--- a/skills/open-prose/examples/auto-pocock/src/review-and-commit.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/review-and-commit.prose.md
@@ -1,6 +1,7 @@
 ---
 name: review-and-commit
 kind: function
+version: 0.15.0
 ---
 
 # Review And Commit

--- a/skills/open-prose/examples/auto-pocock/src/triage-and-pick.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/triage-and-pick.prose.md
@@ -1,6 +1,7 @@
 ---
 name: triage-and-pick
 kind: function
+version: 0.15.0
 ---
 
 # Triage And Pick

--- a/skills/open-prose/examples/auto-pocock/src/verify-slice.prose.md
+++ b/skills/open-prose/examples/auto-pocock/src/verify-slice.prose.md
@@ -1,6 +1,7 @@
 ---
 name: verify-slice
 kind: function
+version: 0.15.0
 ---
 
 # Verify Slice

--- a/skills/open-prose/examples/basic-unit-suite/src/alert-projection.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/alert-projection.prose.md
@@ -1,6 +1,7 @@
 ---
 name: alert-projection
 kind: responsibility
+version: 0.15.0
 ---
 
 # Alert Projection

--- a/skills/open-prose/examples/basic-unit-suite/src/alert-state.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/alert-state.prose.md
@@ -1,6 +1,7 @@
 ---
 name: alert-state
 kind: responsibility
+version: 0.15.0
 ---
 
 # Alert State

--- a/skills/open-prose/examples/basic-unit-suite/src/count-summary.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/count-summary.prose.md
@@ -1,6 +1,7 @@
 ---
 name: count-summary
 kind: responsibility
+version: 0.15.0
 ---
 
 # Count Summary

--- a/skills/open-prose/examples/basic-unit-suite/src/count-trend.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/count-trend.prose.md
@@ -1,6 +1,7 @@
 ---
 name: count-trend
 kind: responsibility
+version: 0.15.0
 ---
 
 # Count Trend

--- a/skills/open-prose/examples/basic-unit-suite/src/counter-events.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/counter-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: counter-events
 kind: gateway
+version: 0.15.0
 ---
 
 # Counter Events

--- a/skills/open-prose/examples/basic-unit-suite/src/executive-snapshot.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/executive-snapshot.prose.md
@@ -1,6 +1,7 @@
 ---
 name: executive-snapshot
 kind: responsibility
+version: 0.15.0
 ---
 
 # Executive Snapshot

--- a/skills/open-prose/examples/basic-unit-suite/src/format-alert-copy.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/format-alert-copy.prose.md
@@ -1,6 +1,7 @@
 ---
 name: format-alert-copy
 kind: function
+version: 0.15.0
 ---
 
 # Format Alert Copy

--- a/skills/open-prose/examples/basic-unit-suite/src/raw-event-auditor.prose.md
+++ b/skills/open-prose/examples/basic-unit-suite/src/raw-event-auditor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: raw-event-auditor
 kind: responsibility
+version: 0.15.0
 ---
 
 # Raw Event Auditor

--- a/skills/open-prose/examples/competitor-activity/src/competitor-activity-monitor.prose.md
+++ b/skills/open-prose/examples/competitor-activity/src/competitor-activity-monitor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: competitor-activity-monitor
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG01RG50R40M30E20918
 ---
 

--- a/skills/open-prose/examples/compliance-evidence-tracker/src/collect-control-scope.prose.md
+++ b/skills/open-prose/examples/compliance-evidence-tracker/src/collect-control-scope.prose.md
@@ -1,6 +1,7 @@
 ---
 name: collect-control-scope
 kind: function
+version: 0.15.0
 ---
 
 # Collect Control Scope

--- a/skills/open-prose/examples/compliance-evidence-tracker/src/compliance-evidence-current.prose.md
+++ b/skills/open-prose/examples/compliance-evidence-tracker/src/compliance-evidence-current.prose.md
@@ -1,6 +1,7 @@
 ---
 name: compliance-evidence-current
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG0HWJNASC5MQ2YC1H68
 ---
 

--- a/skills/open-prose/examples/compliance-evidence-tracker/src/evidence-review-events.prose.md
+++ b/skills/open-prose/examples/compliance-evidence-tracker/src/evidence-review-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: evidence-review-events
 kind: gateway
+version: 0.15.0
 ---
 
 # Evidence Review Events

--- a/skills/open-prose/examples/compliance-evidence-tracker/src/inspect-evidence.prose.md
+++ b/skills/open-prose/examples/compliance-evidence-tracker/src/inspect-evidence.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inspect-evidence
 kind: function
+version: 0.15.0
 ---
 
 # Inspect Evidence

--- a/skills/open-prose/examples/compliance-evidence-tracker/src/prepare-gap-brief.prose.md
+++ b/skills/open-prose/examples/compliance-evidence-tracker/src/prepare-gap-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: prepare-gap-brief
 kind: function
+version: 0.15.0
 ---
 
 # Prepare Gap Brief

--- a/skills/open-prose/examples/content-performance-loop/src/content-learning-cycle.prose.md
+++ b/skills/open-prose/examples/content-performance-loop/src/content-learning-cycle.prose.md
@@ -1,6 +1,7 @@
 ---
 name: content-learning-cycle
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG0DZJ18924CJ2A9H750
 ---
 

--- a/skills/open-prose/examples/content-performance-loop/src/diagnose-content-lessons.prose.md
+++ b/skills/open-prose/examples/content-performance-loop/src/diagnose-content-lessons.prose.md
@@ -1,6 +1,7 @@
 ---
 name: diagnose-content-lessons
 kind: function
+version: 0.15.0
 ---
 
 # Diagnose Content Lessons

--- a/skills/open-prose/examples/content-performance-loop/src/normalize-performance-signals.prose.md
+++ b/skills/open-prose/examples/content-performance-loop/src/normalize-performance-signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: normalize-performance-signals
 kind: function
+version: 0.15.0
 ---
 
 # Normalize Performance Signals

--- a/skills/open-prose/examples/content-performance-loop/src/prepare-editorial-brief.prose.md
+++ b/skills/open-prose/examples/content-performance-loop/src/prepare-editorial-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: prepare-editorial-brief
 kind: function
+version: 0.15.0
 ---
 
 # Prepare Editorial Brief

--- a/skills/open-prose/examples/content-performance-loop/src/prioritize-next-actions.prose.md
+++ b/skills/open-prose/examples/content-performance-loop/src/prioritize-next-actions.prose.md
@@ -1,6 +1,7 @@
 ---
 name: prioritize-next-actions
 kind: function
+version: 0.15.0
 ---
 
 # Prioritize Next Actions

--- a/skills/open-prose/examples/content-performance-loop/src/weekly-performance-review.prose.md
+++ b/skills/open-prose/examples/content-performance-loop/src/weekly-performance-review.prose.md
@@ -1,6 +1,7 @@
 ---
 name: weekly-performance-review
 kind: gateway
+version: 0.15.0
 ---
 
 # Weekly Performance Review

--- a/skills/open-prose/examples/customer-risk-radar/src/assess-risk.prose.md
+++ b/skills/open-prose/examples/customer-risk-radar/src/assess-risk.prose.md
@@ -1,6 +1,7 @@
 ---
 name: assess-risk
 kind: function
+version: 0.15.0
 ---
 
 # Assess Risk

--- a/skills/open-prose/examples/customer-risk-radar/src/collect-account-signals.prose.md
+++ b/skills/open-prose/examples/customer-risk-radar/src/collect-account-signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: collect-account-signals
 kind: function
+version: 0.15.0
 ---
 
 # Collect Account Signals

--- a/skills/open-prose/examples/customer-risk-radar/src/customer-risk-maintained.prose.md
+++ b/skills/open-prose/examples/customer-risk-radar/src/customer-risk-maintained.prose.md
@@ -1,6 +1,7 @@
 ---
 name: customer-risk-maintained
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG0XVMH2AA9D64TKJFA0
 ---
 

--- a/skills/open-prose/examples/customer-risk-radar/src/customer-risk-review.prose.md
+++ b/skills/open-prose/examples/customer-risk-radar/src/customer-risk-review.prose.md
@@ -1,6 +1,7 @@
 ---
 name: customer-risk-review
 kind: gateway
+version: 0.15.0
 ---
 
 # Customer Risk Review

--- a/skills/open-prose/examples/customer-risk-radar/src/recommend-actions.prose.md
+++ b/skills/open-prose/examples/customer-risk-radar/src/recommend-actions.prose.md
@@ -1,6 +1,7 @@
 ---
 name: recommend-actions
 kind: function
+version: 0.15.0
 ---
 
 # Recommend Actions

--- a/skills/open-prose/examples/declared-skills/src/invoice-extractor.prose.md
+++ b/skills/open-prose/examples/declared-skills/src/invoice-extractor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: invoice-extractor
 kind: function
+version: 0.15.0
 ---
 
 # Invoice Extractor

--- a/skills/open-prose/examples/declared-tools/src/json-verifier.prose.md
+++ b/skills/open-prose/examples/declared-tools/src/json-verifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: json-verifier
 kind: function
+version: 0.15.0
 ---
 
 # JSON Verifier

--- a/skills/open-prose/examples/feedback-pulse/src/feedback-inbox.prose.md
+++ b/skills/open-prose/examples/feedback-pulse/src/feedback-inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: feedback-inbox
 kind: gateway
+version: 0.15.0
 ---
 
 # Feedback Inbox

--- a/skills/open-prose/examples/feedback-pulse/src/theme-tagger.prose.md
+++ b/skills/open-prose/examples/feedback-pulse/src/theme-tagger.prose.md
@@ -1,6 +1,7 @@
 ---
 name: theme-tagger
 kind: responsibility
+version: 0.15.0
 ---
 
 # Theme Tagger

--- a/skills/open-prose/examples/feedback-pulse/src/voice-of-customer.prose.md
+++ b/skills/open-prose/examples/feedback-pulse/src/voice-of-customer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: voice-of-customer
 kind: responsibility
+version: 0.15.0
 ---
 
 # Voice of Customer

--- a/skills/open-prose/examples/feedback-pulse/src/weekly-pulse.prose.md
+++ b/skills/open-prose/examples/feedback-pulse/src/weekly-pulse.prose.md
@@ -1,6 +1,7 @@
 ---
 name: weekly-pulse
 kind: responsibility
+version: 0.15.0
 ---
 
 # Weekly Pulse

--- a/skills/open-prose/examples/forme-fixpoint/src/contract-registry.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/contract-registry.prose.md
@@ -1,5 +1,7 @@
 ---
+name: contract-registry
 kind: responsibility
+version: 0.15.0
 id: contract-registry
 ---
 

--- a/skills/open-prose/examples/forme-fixpoint/src/contract-source-files.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/contract-source-files.prose.md
@@ -1,5 +1,7 @@
 ---
+name: contract-source-files
 kind: gateway
+version: 0.15.0
 id: contract-source-files
 ---
 

--- a/skills/open-prose/examples/forme-fixpoint/src/operator-pins.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/operator-pins.prose.md
@@ -1,5 +1,7 @@
 ---
+name: operator-pins
 kind: gateway
+version: 0.15.0
 id: operator-pins
 ---
 

--- a/skills/open-prose/examples/forme-fixpoint/src/schedule-plan.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/schedule-plan.prose.md
@@ -1,5 +1,7 @@
 ---
+name: schedule-plan
 kind: responsibility
+version: 0.15.0
 id: schedule-plan
 ---
 

--- a/skills/open-prose/examples/forme-fixpoint/src/topology-change-reporter.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/topology-change-reporter.prose.md
@@ -1,5 +1,7 @@
 ---
+name: topology-change-reporter
 kind: responsibility
+version: 0.15.0
 id: topology-change-reporter
 ---
 

--- a/skills/open-prose/examples/forme-fixpoint/src/topology-maintainer.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/topology-maintainer.prose.md
@@ -1,5 +1,7 @@
 ---
+name: topology-maintainer
 kind: responsibility
+version: 0.15.0
 id: topology-maintainer
 ---
 

--- a/skills/open-prose/examples/forme-fixpoint/src/topology-safety-auditor.prose.md
+++ b/skills/open-prose/examples/forme-fixpoint/src/topology-safety-auditor.prose.md
@@ -1,5 +1,7 @@
 ---
+name: topology-safety-auditor
 kind: responsibility
+version: 0.15.0
 id: topology-safety-auditor
 ---
 

--- a/skills/open-prose/examples/github-star-enricher/src/company-resolver.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/company-resolver.prose.md
@@ -1,6 +1,7 @@
 ---
 name: company-resolver
 kind: responsibility
+version: 0.15.0
 ---
 
 # Company Resolver

--- a/skills/open-prose/examples/github-star-enricher/src/github-footprint-mapper.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/github-footprint-mapper.prose.md
@@ -1,6 +1,7 @@
 ---
 name: github-footprint-mapper
 kind: responsibility
+version: 0.15.0
 ---
 
 # GitHub Footprint Mapper

--- a/skills/open-prose/examples/github-star-enricher/src/human-review-events.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/human-review-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: human-review-events
 kind: gateway
+version: 0.15.0
 ---
 
 # Human Review Events

--- a/skills/open-prose/examples/github-star-enricher/src/intent-safety-scorer.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/intent-safety-scorer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: intent-safety-scorer
 kind: responsibility
+version: 0.15.0
 ---
 
 # Intent & Safety Scorer

--- a/skills/open-prose/examples/github-star-enricher/src/outreach-packet.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/outreach-packet.prose.md
@@ -1,6 +1,7 @@
 ---
 name: outreach-packet
 kind: responsibility
+version: 0.15.0
 ---
 
 # Outreach Packet

--- a/skills/open-prose/examples/github-star-enricher/src/person-resolver.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/person-resolver.prose.md
@@ -1,6 +1,7 @@
 ---
 name: person-resolver
 kind: responsibility
+version: 0.15.0
 ---
 
 # Person Resolver

--- a/skills/open-prose/examples/github-star-enricher/src/sample-program-builder.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/sample-program-builder.prose.md
@@ -1,6 +1,7 @@
 ---
 name: sample-program-builder
 kind: responsibility
+version: 0.15.0
 ---
 
 # Sample Program Builder

--- a/skills/open-prose/examples/github-star-enricher/src/star-events.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/star-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: star-events
 kind: gateway
+version: 0.15.0
 ---
 
 # GitHub Star Events

--- a/skills/open-prose/examples/github-star-enricher/src/stargazer-registry.prose.md
+++ b/skills/open-prose/examples/github-star-enricher/src/stargazer-registry.prose.md
@@ -1,6 +1,7 @@
 ---
 name: stargazer-registry
 kind: responsibility
+version: 0.15.0
 ---
 
 # Stargazer Registry

--- a/skills/open-prose/examples/implementation-pipeline/src/construction-lane.prose.md
+++ b/skills/open-prose/examples/implementation-pipeline/src/construction-lane.prose.md
@@ -1,6 +1,7 @@
 ---
 name: construction-lane
 kind: responsibility
+version: 0.15.0
 ---
 
 # Construction Lane

--- a/skills/open-prose/examples/implementation-pipeline/src/construction-review.prose.md
+++ b/skills/open-prose/examples/implementation-pipeline/src/construction-review.prose.md
@@ -1,6 +1,7 @@
 ---
 name: construction-review
 kind: responsibility
+version: 0.15.0
 ---
 
 # Construction Review

--- a/skills/open-prose/examples/implementation-pipeline/src/foundation-builder.prose.md
+++ b/skills/open-prose/examples/implementation-pipeline/src/foundation-builder.prose.md
@@ -1,6 +1,7 @@
 ---
 name: foundation-builder
 kind: responsibility
+version: 0.15.0
 ---
 
 # Foundation Builder

--- a/skills/open-prose/examples/implementation-pipeline/src/implementation-work-plan.prose.md
+++ b/skills/open-prose/examples/implementation-pipeline/src/implementation-work-plan.prose.md
@@ -1,6 +1,7 @@
 ---
 name: implementation-work-plan
 kind: responsibility
+version: 0.15.0
 ---
 
 # Implementation Work Plan

--- a/skills/open-prose/examples/implementation-pipeline/src/integration-builder.prose.md
+++ b/skills/open-prose/examples/implementation-pipeline/src/integration-builder.prose.md
@@ -1,6 +1,7 @@
 ---
 name: integration-builder
 kind: responsibility
+version: 0.15.0
 ---
 
 # Integration Builder

--- a/skills/open-prose/examples/implementation-pipeline/src/planning-corpus.prose.md
+++ b/skills/open-prose/examples/implementation-pipeline/src/planning-corpus.prose.md
@@ -1,6 +1,7 @@
 ---
 name: planning-corpus
 kind: gateway
+version: 0.15.0
 ---
 
 # Planning Corpus

--- a/skills/open-prose/examples/inbox-triage/src/classifier.prose.md
+++ b/skills/open-prose/examples/inbox-triage/src/classifier.prose.md
@@ -1,6 +1,7 @@
 ---
 name: classifier
 kind: responsibility
+version: 0.15.0
 ---
 
 # Classifier

--- a/skills/open-prose/examples/inbox-triage/src/digest.prose.md
+++ b/skills/open-prose/examples/inbox-triage/src/digest.prose.md
@@ -1,6 +1,7 @@
 ---
 name: digest
 kind: responsibility
+version: 0.15.0
 ---
 
 # Daily Digest

--- a/skills/open-prose/examples/inbox-triage/src/inbox-stream.prose.md
+++ b/skills/open-prose/examples/inbox-triage/src/inbox-stream.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inbox-stream
 kind: gateway
+version: 0.15.0
 ---
 
 # Inbox Stream

--- a/skills/open-prose/examples/inbox-triage/src/threader.prose.md
+++ b/skills/open-prose/examples/inbox-triage/src/threader.prose.md
@@ -1,6 +1,7 @@
 ---
 name: threader
 kind: responsibility
+version: 0.15.0
 ---
 
 # Threader

--- a/skills/open-prose/examples/incident-briefing-room/src/assess-customer-impact.prose.md
+++ b/skills/open-prose/examples/incident-briefing-room/src/assess-customer-impact.prose.md
@@ -1,6 +1,7 @@
 ---
 name: assess-customer-impact
 kind: function
+version: 0.15.0
 ---
 
 # Assess Customer Impact

--- a/skills/open-prose/examples/incident-briefing-room/src/collect-incident-signals.prose.md
+++ b/skills/open-prose/examples/incident-briefing-room/src/collect-incident-signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: collect-incident-signals
 kind: function
+version: 0.15.0
 ---
 
 # Collect Incident Signals

--- a/skills/open-prose/examples/incident-briefing-room/src/draft-incident-brief.prose.md
+++ b/skills/open-prose/examples/incident-briefing-room/src/draft-incident-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: draft-incident-brief
 kind: function
+version: 0.15.0
 ---
 
 # Draft Incident Brief

--- a/skills/open-prose/examples/incident-briefing-room/src/incident-channel-current.prose.md
+++ b/skills/open-prose/examples/incident-briefing-room/src/incident-channel-current.prose.md
@@ -1,6 +1,7 @@
 ---
 name: incident-channel-current
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG0NSK9D9P6WW3JEHV7G
 ---
 

--- a/skills/open-prose/examples/incident-briefing-room/src/incident-events.prose.md
+++ b/skills/open-prose/examples/incident-briefing-room/src/incident-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: incident-events
 kind: gateway
+version: 0.15.0
 ---
 
 # Incident Events

--- a/skills/open-prose/examples/incident-briefing-room/src/review-incident-actions.prose.md
+++ b/skills/open-prose/examples/incident-briefing-room/src/review-incident-actions.prose.md
@@ -1,6 +1,7 @@
 ---
 name: review-incident-actions
 kind: function
+version: 0.15.0
 ---
 
 # Review Incident Actions

--- a/skills/open-prose/examples/masked-relay/src/critic-strong.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/critic-strong.prose.md
@@ -1,6 +1,7 @@
 ---
 name: critic-strong
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/critic-weak.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/critic-weak.prose.md
@@ -1,6 +1,7 @@
 ---
 name: critic-weak
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/diversity-auditor.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/diversity-auditor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: diversity-auditor
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/expander-1.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/expander-1.prose.md
@@ -1,6 +1,7 @@
 ---
 name: expander-1
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/expander-2.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/expander-2.prose.md
@@ -1,6 +1,7 @@
 ---
 name: expander-2
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/insight-synthesizer.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/insight-synthesizer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: insight-synthesizer
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/scout-desire.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/scout-desire.prose.md
@@ -1,6 +1,7 @@
 ---
 name: scout-desire
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/scout-friction.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/scout-friction.prose.md
@@ -1,6 +1,7 @@
 ---
 name: scout-friction
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/scout-price.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/scout-price.prose.md
@@ -1,6 +1,7 @@
 ---
 name: scout-price
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/signal-inbox.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/signal-inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: signal-inbox
 kind: gateway
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/signal-ledger.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/signal-ledger.prose.md
@@ -1,6 +1,7 @@
 ---
 name: signal-ledger
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/masked-relay/src/viewport-masker.prose.md
+++ b/skills/open-prose/examples/masked-relay/src/viewport-masker.prose.md
@@ -1,6 +1,7 @@
 ---
 name: viewport-masker
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/monorepo-ci/src/merge-gate.prose.md
+++ b/skills/open-prose/examples/monorepo-ci/src/merge-gate.prose.md
@@ -1,5 +1,7 @@
 ---
+name: merge-gate
 kind: responsibility
+version: 0.15.0
 id: gate.merge
 ---
 

--- a/skills/open-prose/examples/monorepo-ci/src/package-build.prose.md
+++ b/skills/open-prose/examples/monorepo-ci/src/package-build.prose.md
@@ -1,5 +1,7 @@
 ---
+name: package-build
 kind: responsibility
+version: 0.15.0
 id: build.pkg-core
 ---
 

--- a/skills/open-prose/examples/monorepo-ci/src/package-test.prose.md
+++ b/skills/open-prose/examples/monorepo-ci/src/package-test.prose.md
@@ -1,5 +1,7 @@
 ---
+name: package-test
 kind: responsibility
+version: 0.15.0
 id: test.pkg-api
 ---
 

--- a/skills/open-prose/examples/monorepo-ci/src/workspace.prose.md
+++ b/skills/open-prose/examples/monorepo-ci/src/workspace.prose.md
@@ -1,5 +1,7 @@
 ---
+name: workspace
 kind: gateway
+version: 0.15.0
 id: gateway.workspace
 ---
 

--- a/skills/open-prose/examples/oblique-weave/src/adversary.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/adversary.prose.md
@@ -1,6 +1,7 @@
 ---
 name: adversary
 kind: responsibility
+version: 0.15.0
 ---
 
 # Adversary

--- a/skills/open-prose/examples/oblique-weave/src/analogist.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/analogist.prose.md
@@ -1,6 +1,7 @@
 ---
 name: analogist
 kind: responsibility
+version: 0.15.0
 ---
 
 # Analogist

--- a/skills/open-prose/examples/oblique-weave/src/constraint-breaker.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/constraint-breaker.prose.md
@@ -1,6 +1,7 @@
 ---
 name: constraint-breaker
 kind: responsibility
+version: 0.15.0
 ---
 
 # Constraint Breaker

--- a/skills/open-prose/examples/oblique-weave/src/novelty-auditor.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/novelty-auditor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: novelty-auditor
 kind: responsibility
+version: 0.15.0
 ---
 
 # Novelty Auditor

--- a/skills/open-prose/examples/oblique-weave/src/oblique-thread-ledger.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/oblique-thread-ledger.prose.md
@@ -1,6 +1,7 @@
 ---
 name: oblique-ledger
 kind: responsibility
+version: 0.15.0
 ---
 
 # Oblique Thread Ledger

--- a/skills/open-prose/examples/oblique-weave/src/product-signal-inbox.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/product-signal-inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: signals
 kind: gateway
+version: 0.15.0
 ---
 
 # Product Signal Inbox

--- a/skills/open-prose/examples/oblique-weave/src/signal-ledger.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/signal-ledger.prose.md
@@ -1,6 +1,7 @@
 ---
 name: signal-ledger
 kind: responsibility
+version: 0.15.0
 ---
 
 # Signal Ledger

--- a/skills/open-prose/examples/oblique-weave/src/surprising-bet-memo.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/surprising-bet-memo.prose.md
@@ -1,6 +1,7 @@
 ---
 name: surprising-bet
 kind: responsibility
+version: 0.15.0
 ---
 
 # Surprising Bet Memo

--- a/skills/open-prose/examples/oblique-weave/src/viewport-policy.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/viewport-policy.prose.md
@@ -1,6 +1,7 @@
 ---
 name: viewport-policy
 kind: responsibility
+version: 0.15.0
 ---
 
 # Viewport Policy

--- a/skills/open-prose/examples/oblique-weave/src/weave-config.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/weave-config.prose.md
@@ -1,6 +1,7 @@
 ---
 name: weave-config
 kind: gateway
+version: 0.15.0
 ---
 
 # Weave Config

--- a/skills/open-prose/examples/oblique-weave/src/weirdness-keeper.prose.md
+++ b/skills/open-prose/examples/oblique-weave/src/weirdness-keeper.prose.md
@@ -1,6 +1,7 @@
 ---
 name: weirdness-keeper
 kind: responsibility
+version: 0.15.0
 ---
 
 # Weirdness Keeper

--- a/skills/open-prose/examples/press-desk/src/briefing.prose.md
+++ b/skills/open-prose/examples/press-desk/src/briefing.prose.md
@@ -1,6 +1,7 @@
 ---
 name: briefing
 kind: responsibility
+version: 0.15.0
 ---
 
 # Leadership Briefing

--- a/skills/open-prose/examples/press-desk/src/opportunity-register.prose.md
+++ b/skills/open-prose/examples/press-desk/src/opportunity-register.prose.md
@@ -1,6 +1,7 @@
 ---
 name: opportunity-register
 kind: responsibility
+version: 0.15.0
 ---
 
 # Opportunity Register

--- a/skills/open-prose/examples/press-desk/src/press-inbox.prose.md
+++ b/skills/open-prose/examples/press-desk/src/press-inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: press-inbox
 kind: gateway
+version: 0.15.0
 ---
 
 # Press Inbox

--- a/skills/open-prose/examples/press-desk/src/relevance-filter.prose.md
+++ b/skills/open-prose/examples/press-desk/src/relevance-filter.prose.md
@@ -1,6 +1,7 @@
 ---
 name: relevance-filter
 kind: responsibility
+version: 0.15.0
 ---
 
 # Relevance Filter

--- a/skills/open-prose/examples/release-readiness/src/assess-release-risk.prose.md
+++ b/skills/open-prose/examples/release-readiness/src/assess-release-risk.prose.md
@@ -1,6 +1,7 @@
 ---
 name: assess-release-risk
 kind: function
+version: 0.15.0
 ---
 
 # Assess Release Risk

--- a/skills/open-prose/examples/release-readiness/src/collect-release-evidence.prose.md
+++ b/skills/open-prose/examples/release-readiness/src/collect-release-evidence.prose.md
@@ -1,6 +1,7 @@
 ---
 name: collect-release-evidence
 kind: function
+version: 0.15.0
 ---
 
 # Collect Release Evidence

--- a/skills/open-prose/examples/release-readiness/src/draft-release-brief.prose.md
+++ b/skills/open-prose/examples/release-readiness/src/draft-release-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: draft-release-brief
 kind: function
+version: 0.15.0
 ---
 
 # Draft Release Brief

--- a/skills/open-prose/examples/release-readiness/src/release-candidate-ready.prose.md
+++ b/skills/open-prose/examples/release-readiness/src/release-candidate-ready.prose.md
@@ -1,6 +1,7 @@
 ---
 name: release-candidate-ready
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG0SYKXFT085146H258R
 ---
 

--- a/skills/open-prose/examples/release-readiness/src/release-readiness-events.prose.md
+++ b/skills/open-prose/examples/release-readiness/src/release-readiness-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: release-readiness-events
 kind: gateway
+version: 0.15.0
 ---
 
 # Release Readiness Events

--- a/skills/open-prose/examples/renewal-risk/src/account-signals.prose.md
+++ b/skills/open-prose/examples/renewal-risk/src/account-signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: account-signals
 kind: gateway
+version: 0.15.0
 ---
 
 # Account Signals

--- a/skills/open-prose/examples/renewal-risk/src/rank-alerts.prose.md
+++ b/skills/open-prose/examples/renewal-risk/src/rank-alerts.prose.md
@@ -1,6 +1,7 @@
 ---
 name: rank-alerts
 kind: function
+version: 0.15.0
 ---
 
 # Rank Alerts

--- a/skills/open-prose/examples/renewal-risk/src/renewal-alert-feed.prose.md
+++ b/skills/open-prose/examples/renewal-risk/src/renewal-alert-feed.prose.md
@@ -1,6 +1,7 @@
 ---
 name: renewal-alert-feed
 kind: responsibility
+version: 0.15.0
 ---
 
 # Renewal Alert Feed

--- a/skills/open-prose/examples/renewal-risk/src/renewal-risk.prose.md
+++ b/skills/open-prose/examples/renewal-risk/src/renewal-risk.prose.md
@@ -1,6 +1,7 @@
 ---
 name: renewal-risk
 kind: responsibility
+version: 0.15.0
 ---
 
 # Renewal Risk

--- a/skills/open-prose/examples/renewal-risk/src/score-account-health.prose.md
+++ b/skills/open-prose/examples/renewal-risk/src/score-account-health.prose.md
@@ -1,6 +1,7 @@
 ---
 name: score-account-health
 kind: function
+version: 0.15.0
 ---
 
 # Score Account Health

--- a/skills/open-prose/examples/research-inbox-triage/src/action-planner.prose.md
+++ b/skills/open-prose/examples/research-inbox-triage/src/action-planner.prose.md
@@ -1,6 +1,7 @@
 ---
 name: action-planner
 kind: function
+version: 0.15.0
 ---
 
 # Action Planner

--- a/skills/open-prose/examples/research-inbox-triage/src/inbox-gateway.prose.md
+++ b/skills/open-prose/examples/research-inbox-triage/src/inbox-gateway.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inbox-gateway
 kind: gateway
+version: 0.15.0
 ---
 
 # Inbox Gateway

--- a/skills/open-prose/examples/research-inbox-triage/src/inbox-ingestor.prose.md
+++ b/skills/open-prose/examples/research-inbox-triage/src/inbox-ingestor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: inbox-ingestor
 kind: function
+version: 0.15.0
 ---
 
 # Inbox Ingestor

--- a/skills/open-prose/examples/research-inbox-triage/src/priority-scorer.prose.md
+++ b/skills/open-prose/examples/research-inbox-triage/src/priority-scorer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: priority-scorer
 kind: function
+version: 0.15.0
 ---
 
 # Priority Scorer

--- a/skills/open-prose/examples/research-inbox-triage/src/research-inbox-responsibility.prose.md
+++ b/skills/open-prose/examples/research-inbox-triage/src/research-inbox-responsibility.prose.md
@@ -1,6 +1,7 @@
 ---
 name: research-inbox-responsibility
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG15XNS7AYBXG62RK3CG
 ---
 

--- a/skills/open-prose/examples/research-inbox-triage/src/topic-clusterer.prose.md
+++ b/skills/open-prose/examples/research-inbox-triage/src/topic-clusterer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: topic-clusterer
 kind: function
+version: 0.15.0
 ---
 
 # Topic Clusterer

--- a/skills/open-prose/examples/research-tree/src/finding.prose.md
+++ b/skills/open-prose/examples/research-tree/src/finding.prose.md
@@ -1,6 +1,7 @@
 ---
 name: finding
 kind: responsibility
+version: 0.15.0
 ---
 
 # Finding (a leaf of the research tree)

--- a/skills/open-prose/examples/research-tree/src/root-synthesis.prose.md
+++ b/skills/open-prose/examples/research-tree/src/root-synthesis.prose.md
@@ -1,6 +1,7 @@
 ---
 name: root-synthesis
 kind: responsibility
+version: 0.15.0
 ---
 
 # Root Synthesis (the apex of the research tree)

--- a/skills/open-prose/examples/research-tree/src/sources-gateway.prose.md
+++ b/skills/open-prose/examples/research-tree/src/sources-gateway.prose.md
@@ -1,6 +1,7 @@
 ---
 name: sources-gateway
 kind: gateway
+version: 0.15.0
 ---
 
 # Sources Gateway

--- a/skills/open-prose/examples/research-tree/src/sub-synthesis.prose.md
+++ b/skills/open-prose/examples/research-tree/src/sub-synthesis.prose.md
@@ -1,6 +1,7 @@
 ---
 name: sub-synthesis
 kind: responsibility
+version: 0.15.0
 ---
 
 # Sub-Synthesis (an interior node of the research tree)

--- a/skills/open-prose/examples/stargazer-outreach/src/collect-new-stargazers.prose.md
+++ b/skills/open-prose/examples/stargazer-outreach/src/collect-new-stargazers.prose.md
@@ -1,6 +1,7 @@
 ---
 name: collect-new-stargazers
 kind: function
+version: 0.15.0
 ---
 
 # Collect New Stargazers

--- a/skills/open-prose/examples/stargazer-outreach/src/draft-outreach.prose.md
+++ b/skills/open-prose/examples/stargazer-outreach/src/draft-outreach.prose.md
@@ -1,6 +1,7 @@
 ---
 name: draft-outreach
 kind: function
+version: 0.15.0
 ---
 
 # Draft Outreach

--- a/skills/open-prose/examples/stargazer-outreach/src/enrich-stargazer.prose.md
+++ b/skills/open-prose/examples/stargazer-outreach/src/enrich-stargazer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: enrich-stargazer
 kind: function
+version: 0.15.0
 ---
 
 # Enrich Stargazer

--- a/skills/open-prose/examples/stargazer-outreach/src/github-star-events.prose.md
+++ b/skills/open-prose/examples/stargazer-outreach/src/github-star-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: github-star-events
 kind: gateway
+version: 0.15.0
 ---
 
 # GitHub Star Events

--- a/skills/open-prose/examples/stargazer-outreach/src/high-intent-stargazer-outreach.prose.md
+++ b/skills/open-prose/examples/stargazer-outreach/src/high-intent-stargazer-outreach.prose.md
@@ -1,6 +1,7 @@
 ---
 name: high-intent-stargazer-outreach
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG19TPD9V8D5N6PV3DDR
 ---
 

--- a/skills/open-prose/examples/stargazer-outreach/src/qualify-stargazer.prose.md
+++ b/skills/open-prose/examples/stargazer-outreach/src/qualify-stargazer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: qualify-stargazer
 kind: function
+version: 0.15.0
 ---
 
 # Qualify Stargazer

--- a/skills/open-prose/examples/support-inbox-router/src/bug-board.prose.md
+++ b/skills/open-prose/examples/support-inbox-router/src/bug-board.prose.md
@@ -1,6 +1,7 @@
 ---
 name: bug-board
 kind: responsibility
+version: 0.15.0
 ---
 
 # Bug Board

--- a/skills/open-prose/examples/support-inbox-router/src/docs-gap-tracker.prose.md
+++ b/skills/open-prose/examples/support-inbox-router/src/docs-gap-tracker.prose.md
@@ -1,6 +1,7 @@
 ---
 name: docs-gap-tracker
 kind: responsibility
+version: 0.15.0
 ---
 
 # Docs Gap Tracker

--- a/skills/open-prose/examples/support-inbox-router/src/roadmap-signals.prose.md
+++ b/skills/open-prose/examples/support-inbox-router/src/roadmap-signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: roadmap-signals
 kind: responsibility
+version: 0.15.0
 ---
 
 # Roadmap Signals

--- a/skills/open-prose/examples/support-inbox-router/src/router.prose.md
+++ b/skills/open-prose/examples/support-inbox-router/src/router.prose.md
@@ -1,6 +1,7 @@
 ---
 name: router
 kind: responsibility
+version: 0.15.0
 ---
 
 # Channel Router

--- a/skills/open-prose/examples/support-inbox-router/src/support-inbox.prose.md
+++ b/skills/open-prose/examples/support-inbox-router/src/support-inbox.prose.md
@@ -1,6 +1,7 @@
 ---
 name: support-inbox
 kind: gateway
+version: 0.15.0
 ---
 
 # Support Inbox

--- a/skills/open-prose/examples/support-inbox-router/src/triage.prose.md
+++ b/skills/open-prose/examples/support-inbox-router/src/triage.prose.md
@@ -1,6 +1,7 @@
 ---
 name: triage
 kind: responsibility
+version: 0.15.0
 ---
 
 # Triage

--- a/skills/open-prose/examples/surprise-cost/src/digest.prose.md
+++ b/skills/open-prose/examples/surprise-cost/src/digest.prose.md
@@ -1,6 +1,7 @@
 ---
 name: digest
 kind: responsibility
+version: 0.15.0
 ---
 
 # Digest

--- a/skills/open-prose/examples/surprise-cost/src/render-digest-line.prose.md
+++ b/skills/open-prose/examples/surprise-cost/src/render-digest-line.prose.md
@@ -1,6 +1,7 @@
 ---
 name: render-digest-line
 kind: function
+version: 0.15.0
 ---
 
 # Render Digest Line

--- a/skills/open-prose/examples/surprise-cost/src/signals.prose.md
+++ b/skills/open-prose/examples/surprise-cost/src/signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: signals
 kind: gateway
+version: 0.15.0
 ---
 
 # Signals

--- a/skills/open-prose/examples/tamper-forge/src/chain-auditor.prose.md
+++ b/skills/open-prose/examples/tamper-forge/src/chain-auditor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: chain-auditor
 kind: responsibility
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/tamper-forge/src/ledger-feed.prose.md
+++ b/skills/open-prose/examples/tamper-forge/src/ledger-feed.prose.md
@@ -1,6 +1,7 @@
 ---
 name: ledger-feed
 kind: gateway
+version: 0.15.0
 ---
 
 ### Goal

--- a/skills/open-prose/examples/vendor-renewal-watch/src/collect-renewal-signals.prose.md
+++ b/skills/open-prose/examples/vendor-renewal-watch/src/collect-renewal-signals.prose.md
@@ -1,6 +1,7 @@
 ---
 name: collect-renewal-signals
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG11RN54TMANB5EP2SB9
 ---
 

--- a/skills/open-prose/examples/vendor-renewal-watch/src/prepare-renewal-brief.prose.md
+++ b/skills/open-prose/examples/vendor-renewal-watch/src/prepare-renewal-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: prepare-renewal-brief
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG11RN54TMANB5EP2SBA
 ---
 

--- a/skills/open-prose/examples/vendor-renewal-watch/src/renewal-review-events.prose.md
+++ b/skills/open-prose/examples/vendor-renewal-watch/src/renewal-review-events.prose.md
@@ -1,6 +1,7 @@
 ---
 name: renewal-review-events
 kind: gateway
+version: 0.15.0
 ---
 
 # Renewal Review Events

--- a/skills/open-prose/examples/vendor-renewal-watch/src/score-vendor-renewal.prose.md
+++ b/skills/open-prose/examples/vendor-renewal-watch/src/score-vendor-renewal.prose.md
@@ -1,6 +1,7 @@
 ---
 name: score-vendor-renewal
 kind: function
+version: 0.15.0
 ---
 
 # Score Vendor Renewal

--- a/skills/open-prose/examples/vendor-renewal-watch/src/vendor-renewals-prepared.prose.md
+++ b/skills/open-prose/examples/vendor-renewal-watch/src/vendor-renewals-prepared.prose.md
@@ -1,6 +1,7 @@
 ---
 name: vendor-renewals-prepared
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG11RN54TMANB5EP2SB8
 ---
 

--- a/tests/open-prose/compiler/fixtures/ambiguous-fulfillment/customer-intake.prose.md
+++ b/tests/open-prose/compiler/fixtures/ambiguous-fulfillment/customer-intake.prose.md
@@ -1,6 +1,7 @@
 ---
 name: customer-intake
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG05XGS38E1W8124GK2G
 ---
 

--- a/tests/open-prose/compiler/fixtures/ambiguous-fulfillment/outreach-source.prose.md
+++ b/tests/open-prose/compiler/fixtures/ambiguous-fulfillment/outreach-source.prose.md
@@ -1,6 +1,7 @@
 ---
 name: outreach-source
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG05XGS38E1W8124GK3B
 ---
 

--- a/tests/open-prose/compiler/fixtures/ambiguous-fulfillment/research-source.prose.md
+++ b/tests/open-prose/compiler/fixtures/ambiguous-fulfillment/research-source.prose.md
@@ -1,6 +1,7 @@
 ---
 name: research-source
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG05XGS38E1W8124GK3A
 ---
 

--- a/tests/open-prose/compiler/fixtures/invalid-responsibility/missing-maintains.prose.md
+++ b/tests/open-prose/compiler/fixtures/invalid-responsibility/missing-maintains.prose.md
@@ -1,6 +1,7 @@
 ---
 name: request-routing
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG09THD5RR34D1P70X3R
 ---
 

--- a/tests/open-prose/compiler/fixtures/multi-facet/competitor-monitor.prose.md
+++ b/tests/open-prose/compiler/fixtures/multi-facet/competitor-monitor.prose.md
@@ -1,6 +1,7 @@
 ---
 name: competitor-monitor
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG01RG50R40M30E2FACE7
 ---
 

--- a/tests/open-prose/compiler/fixtures/multi-facet/funding-brief.prose.md
+++ b/tests/open-prose/compiler/fixtures/multi-facet/funding-brief.prose.md
@@ -1,6 +1,7 @@
 ---
 name: funding-brief
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG01RG50R40M30E2BR1EF0
 ---
 

--- a/tests/open-prose/responsibility-runtime/01-stargazer-responsibility.prose.md
+++ b/tests/open-prose/responsibility-runtime/01-stargazer-responsibility.prose.md
@@ -1,6 +1,7 @@
 ---
 name: high-intent-stargazer-outreach
 kind: responsibility
+version: 0.15.0
 id: 067NC4KG01RG50R40M30E20918
 ---
 

--- a/tests/open-prose/responsibility-runtime/02-stargazer-gateway.prose.md
+++ b/tests/open-prose/responsibility-runtime/02-stargazer-gateway.prose.md
@@ -1,5 +1,6 @@
 ---
 kind: gateway
+version: 0.15.0
 name: stargazer-events
 ---
 

--- a/tests/open-prose/responsibility-runtime/stargazer-outreach/index.prose.md
+++ b/tests/open-prose/responsibility-runtime/stargazer-outreach/index.prose.md
@@ -1,6 +1,7 @@
 ---
 name: stargazer-outreach
 kind: system
+version: 0.15.0
 ---
 
 # Stargazer Outreach

--- a/tests/open-prose/responsibility-runtime/stargazer-outreach/outreach-drafter.prose.md
+++ b/tests/open-prose/responsibility-runtime/stargazer-outreach/outreach-drafter.prose.md
@@ -1,6 +1,7 @@
 ---
 name: outreach-drafter
 kind: service
+version: 0.15.0
 ---
 
 ### Requires

--- a/tests/open-prose/responsibility-runtime/stargazer-outreach/profile-enricher.prose.md
+++ b/tests/open-prose/responsibility-runtime/stargazer-outreach/profile-enricher.prose.md
@@ -1,6 +1,7 @@
 ---
 name: profile-enricher
 kind: service
+version: 0.15.0
 ---
 
 ### Requires

--- a/tests/open-prose/responsibility-runtime/stargazer-outreach/program-proposer.prose.md
+++ b/tests/open-prose/responsibility-runtime/stargazer-outreach/program-proposer.prose.md
@@ -1,6 +1,7 @@
 ---
 name: program-proposer
 kind: service
+version: 0.15.0
 ---
 
 ### Requires

--- a/tests/open-prose/responsibility-runtime/stargazer-outreach/sample-runner.prose.md
+++ b/tests/open-prose/responsibility-runtime/stargazer-outreach/sample-runner.prose.md
@@ -1,6 +1,7 @@
 ---
 name: sample-runner
 kind: service
+version: 0.15.0
 ---
 
 ### Requires

--- a/tests/open-prose/responsibility-runtime/stargazer-outreach/stargazer-fetcher.prose.md
+++ b/tests/open-prose/responsibility-runtime/stargazer-outreach/stargazer-fetcher.prose.md
@@ -1,6 +1,7 @@
 ---
 name: stargazer-fetcher
 kind: service
+version: 0.15.0
 ---
 
 ### Requires

--- a/tests/open-prose/smoke/01-single-service.prose.md
+++ b/tests/open-prose/smoke/01-single-service.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-single-service
 kind: service
+version: 0.15.0
 ---
 
 ### Description

--- a/tests/open-prose/smoke/02-caller-input.prose.md
+++ b/tests/open-prose/smoke/02-caller-input.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-caller-input
 kind: service
+version: 0.15.0
 ---
 
 ### Description

--- a/tests/open-prose/smoke/03-auto-wiring.prose.md
+++ b/tests/open-prose/smoke/03-auto-wiring.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-auto-wiring
 kind: system
+version: 0.15.0
 ---
 
 ### Services

--- a/tests/open-prose/smoke/04-inline-services.prose.md
+++ b/tests/open-prose/smoke/04-inline-services.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-inline-services
 kind: system
+version: 0.15.0
 ---
 
 ### Services

--- a/tests/open-prose/smoke/05-explicit-wiring.prose.md
+++ b/tests/open-prose/smoke/05-explicit-wiring.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-explicit-wiring
 kind: system
+version: 0.15.0
 ---
 
 ### Services

--- a/tests/open-prose/smoke/06-execution-block.prose.md
+++ b/tests/open-prose/smoke/06-execution-block.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-execution-block
 kind: system
+version: 0.15.0
 ---
 
 ### Services

--- a/tests/open-prose/smoke/07-errors-strategies.prose.md
+++ b/tests/open-prose/smoke/07-errors-strategies.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-errors-strategies
 kind: service
+version: 0.15.0
 ---
 
 ### Description

--- a/tests/open-prose/smoke/08-kind-test.prose.md
+++ b/tests/open-prose/smoke/08-kind-test.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-kind-test
 kind: test
+version: 0.15.0
 subject: smoke-caller-input
 ---
 

--- a/tests/open-prose/smoke/09-local-pattern.prose.md
+++ b/tests/open-prose/smoke/09-local-pattern.prose.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-local-pattern
 kind: system
+version: 0.15.0
 ---
 
 ### Services

--- a/tests/open-prose/smoke/worker-critic.prose.md
+++ b/tests/open-prose/smoke/worker-critic.prose.md
@@ -1,6 +1,7 @@
 ---
 name: worker-critic
 kind: pattern
+version: 0.15.0
 ---
 
 ### Slots


### PR DESCRIPTION
## Summary

This PR brings the checked-in OpenProse source corpus into alignment with the current `prose-lint` expectations.

- Adds `version: 0.15.0` to tracked `.prose.md` source files that were missing the official source version.
- Adds stable `name:` fields to 11 example contracts that already had `kind`/`id` metadata but no `name`.
- Removes one stray trailing code fence from `packages/co/systems/company-repo-checker/index.prose.md`.
- Aligns the agent onboarding tagline with the committed skill metadata test.

The large file count is expected: most changes are a one-line metadata stamp across existing OpenProse source files.

## Use Case / Run Evidence

After updating `prose-lint` to understand the current OpenProse language surface, I ran it against the current `openprose/prose` checkout in strict mode. That deterministic pass surfaced source-hygiene issues in the official corpus:

- tracked `.prose.md` files missing `version`
- a small set of current examples missing stable `name`
- one malformed Markdown fence in `company-repo-checker`

Those are useful findings because the repository itself is the canonical example library for future agents and contributors. If official examples do not satisfy the current linter, downstream harnesses and agent workflows have less reliable feedback when they author or update OpenProse contracts.

While validating the branch from a clean ref, `bun run test:skill` also caught an onboarding-copy mismatch: `tests/open-prose/skill-meta/skill-meta.test.ts` expected `Declare outcomes. Not instructions.`, while the source still had the previous tagline. This PR aligns the source with the test-backed current wording.

## Design Boundary

This PR intentionally stays at the source hygiene layer.

It does not change:

- OpenProse language semantics
- Reactor runtime behavior
- compiler behavior
- linter implementation
- example execution logic

The metadata updates live in the source files because `version` and `name` are contract identity metadata. The company-repo-checker change fixes malformed Markdown in the affected contract. The onboarding change lives in the skill-facing document because the existing test already makes that copy part of the expected agent arrival narrative.

Broader warning-class authoring improvements are left out of scope so this remains a focused pass/fail hygiene PR rather than a broad rewrite of examples and standard contracts.

## Examples

Most files only gain:

```yaml
version: 0.15.0
```

The 11 examples that lacked a stable name gain a `name:` that matches the existing contract identity, for example:

```yaml
name: workspace
kind: responsibility
version: 0.15.0
```

The company repo checker contract drops a final unmatched code fence so the Markdown structure is valid.

## Testing

Validated locally on `codex/fix-example-lint-hygiene` at `a2f1d79`.

- `git diff --check origin/main...HEAD`
- `cargo run --quiet --manifest-path /home/raw/openprose/prose-lint/Cargo.toml -- lint --profile strict $(git ls-files '*.prose.md')`
  - exit 0
  - 0 errors
  - warning-only remainder: 14 `MDW005`, 1 `MDW011`, 6 `MDW012`, 21 `MDW014`
- `bun run test:skill`
  - 27 files passed
  - 409 tests passed
- `bun run test:examples`
  - 17 files passed
  - 210 tests passed
  - offline eval harness: 10 tests passed
- `bun run lint`
  - exit 0
  - selected packages currently have no lint scripts

## Residual Risk / Follow-ups

Residual risk is mostly review ergonomics: the diff touches many files because the metadata update is repo-wide. I mitigated that by checking the exact diff shape:

- 260 `version: 0.15.0` additions
- 11 `name:` additions
- 1 removed stray closing code fence
- 1 onboarding tagline alignment

Remaining `prose-lint` warnings are intentionally not fixed here. They are warning-class contract-quality improvements and should be handled in separate, smaller PRs if we decide to tighten those authoring expectations.

Follow-up: consider adding a pinned `prose-lint` gate to the repo's local preflight/CI path so `openprose/prose` continuously proves that its checked-in `.prose.md` corpus stays compatible with the current language surface. That should be a separate change because it needs toolchain decisions: how `prose-lint` is pinned or installed, whether warning classes should fail, and which local or hosted gates should own the check.
