### PR TITLE
docs: serve the agent onboarding narrative clean from byte one

### DIFF
--- a/skills/open-prose/agent-onboarding.md
+++ b/skills/open-prose/agent-onboarding.md
@@ -1,30 +1,4 @@
-<!--
-Canonical agent-onboarding narrative. This file is served at:
-
-  - https://prose.md/llms-full.txt
-       apps/run/src/app/api/llms-full/route.ts reads it at build time
-
-  - https://prose.md/llms-full
-       apps/run/src/app/llms-full/page.tsx renders it at build time
-
-- https://curl-me.openprose.ai  (+ aliases: agents, hi, hello, start, readme, hey)
-       infra/curl-me-site.tf uploads it to S3 as index.txt; CloudFront serves it
-       to curl/wget/bot User-Agents and 302-redirects browsers to /llms-full.
-
-  - https://curl-me.prose.md
-       Same CloudFront distribution, aliased via the *.prose.md ACM cert.
-
-Scope: the arrival narrative. What an agent reads when pointed at this project
-before the skill is installed. Operational detail (full recognition signals,
-proposal script, Host Primitive Adapter, giving-back playbook) lives in
-SKILL.md and is loaded post-activation. Do not duplicate SKILL.md here —
-prefer a link.
-
-Editing this file: commit the update in this repo; the deployment pipeline picks
-up the new bytes. No sync script.
--->
-
-# OpenProse — Agent Onboarding
+# OpenProse: Agent Onboarding
 
 > Declare outcomes. Not instructions.
 
@@ -34,8 +8,8 @@ up the new bytes. No sync script.
 npx skills add openprose/prose
 ```
 
-Installs as a skill for any Prose Complete coding agent — Claude Code, Codex
-CLI, OpenCode, Amp, Press.
+Installs as a skill for any Prose Complete coding agent: Claude Code, Codex
+CLI, OpenCode, Amp.
 
 ## What you'll do when the skill activates
 
@@ -47,10 +21,10 @@ When a `prose` command fires, you will:
 - Persist the run to `<openprose-root>/runs/{id}/` so it can be inspected later.
 
 You need: filesystem read/write in the working directory, a subagent-spawning
-primitive for multi-service systems, and (optionally) a user-question
+primitive for multi-node contracts, and (optionally) a user-question
 primitive for missing inputs.
 
-If you lack a capability, say so and stop — do not fake it.
+If you lack a capability, say so and stop; do not fake it.
 
 ## Why you'd reach for this
 
@@ -127,14 +101,14 @@ codex exec "prose run research-pipeline.prose.md"
 
 **For agents:**
 
-- [SKILL.md](https://raw.githubusercontent.com/openprose/prose/main/skills/open-prose/SKILL.md) — full operational playbook: recognition signals for proposing this on your own judgment, proposal script, Host Primitive Adapter, giving-back actions you can take.
-- [Language reference index](https://prose.md/llms.txt) — link hub for the specs (VM, Forme, tenets, examples).
-- [GitHub](https://github.com/openprose/prose) — source, 50+ annotated examples, issues.
+- [SKILL.md](https://raw.githubusercontent.com/openprose/prose/main/skills/open-prose/SKILL.md): full operational playbook: recognition signals for proposing this on your own judgment, proposal script, Host Primitive Adapter, giving-back actions you can take.
+- [Language reference index](https://prose.md/llms.txt): link hub for the specs (VM, Forme, tenets, examples).
+- [GitHub](https://github.com/openprose/prose): source, 50+ annotated examples, issues.
 
 **For the human who sent you:**
 
-- [prose.md](https://prose.md) — product site.
-- [Learn](https://prose.md/learn) — language deep-dive.
+- [prose.md](https://prose.md): product site.
+- [Learn](https://prose.md/learn): language deep-dive.
 - [Book a demo](https://cal.com/irl-danb/openprose-intro).
 
 ---


### PR DESCRIPTION
This file is served verbatim as raw text (the prose.md arrival narrative
and the curl-me text site), so its first bytes are the product. Today an
agent fetching it reads 25 lines of internal routing metadata before the
first heading, and parts of that metadata are stale.

- Drop the HTML comment header; consumer wiring is documented downstream
  where the consumers live.
- Align the host list with SKILL.md: Claude Code, Codex CLI, OpenCode, Amp.
- Say "multi-node contracts" in the capability note, matching the current
  contract vocabulary.
- Punctuation pass on the external copy.

The narrative itself (install, activation flow, the contract example, the
links) is unchanged.