### PR TITLE
test: migrate the CI smoke suite to the current execution model

### DIFF
--- a/.github/scripts/openprose-smoke/run.ts
+++ b/.github/scripts/openprose-smoke/run.ts
@@ -726,6 +726,7 @@ function buildPrompt(smokeCase: SmokeCase): string {
           "Publish the subject's declared outputs before evaluating assertions: bindings/ for a function subject, world-model/ for a responsibility subject.",
           "Evaluate ### Expects and ### Expects Not against those published outputs, then write ---test PASS or ---test FAIL to vm.log.md.",
           "A test fixture is self-contained; do not prompt for inputs and do not inspect unrelated programs after resolving the subject.",
+          "Create only the run artifacts this prompt requires; a test run needs no compiled intent snapshot.",
         ]
       : outputRoot === "world-model"
         ? [

--- a/.github/scripts/openprose-smoke/run.ts
+++ b/.github/scripts/openprose-smoke/run.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 type SmokeTier = "required" | "advisory";
 type SmokeCommand = "run" | "test";
 type SmokeStatus = "pass" | "fail" | "skip";
+type OutputRoot = "bindings" | "world-model";
 
 type SmokeCase = {
   id: string;
@@ -17,6 +18,7 @@ type SmokeCase = {
   inputs?: Record<string, string>;
   expectedArtifacts?: string[];
   expectedOutputs?: string[];
+  outputRoot?: OutputRoot;
   timeoutSeconds?: number;
   maxTurns?: number;
 };
@@ -50,6 +52,7 @@ type CaseResult = {
   reasons: string[];
   expectedArtifacts: string[];
   expectedOutputs: string[];
+  outputRoot: OutputRoot;
   foundOutputs: string[];
   exitCode: number | null;
   timedOut: boolean;
@@ -81,6 +84,7 @@ const DEFAULT_MODEL = process.env.OPENPROSE_SMOKE_MODEL ?? "claude-sonnet-4-6";
 const DEFAULT_TIMEOUT_SECONDS = 360;
 const DEFAULT_MAX_TURNS = 10;
 const DEFAULT_EXPECTED_ARTIFACTS = ["root.prose.md", "vm.log.md"] as const;
+const DEFAULT_OUTPUT_ROOT: OutputRoot = "world-model";
 const RUNS_DIR_SEGMENTS = ["runs"] as const;
 const CLAUDE_TOOLS = "Edit,Read,Write,Glob,Grep,Task,Skill";
 const CLAUDE_DISALLOWED_TOOLS = [
@@ -500,6 +504,13 @@ function validateCase(entry: any, index: number): SmokeCase {
   if (entry.expectedArtifacts !== undefined && !isRunArtifactArray(entry.expectedArtifacts)) {
     throw new Error(`Smoke case ${entry.id} expectedArtifacts must be run artifact filenames`);
   }
+  if (
+    entry.outputRoot !== undefined &&
+    entry.outputRoot !== "bindings" &&
+    entry.outputRoot !== "world-model"
+  ) {
+    throw new Error(`Smoke case ${entry.id} outputRoot must be "bindings" or "world-model"`);
+  }
   if (entry.workspaceSources !== undefined && !isStringArray(entry.workspaceSources)) {
     throw new Error(`Smoke case ${entry.id} workspaceSources must be a string array`);
   }
@@ -525,6 +536,7 @@ function validateCase(entry: any, index: number): SmokeCase {
     inputs: entry.inputs,
     expectedArtifacts: entry.expectedArtifacts ?? [...DEFAULT_EXPECTED_ARTIFACTS],
     expectedOutputs: entry.expectedOutputs ?? [],
+    outputRoot: entry.outputRoot ?? DEFAULT_OUTPUT_ROOT,
     timeoutSeconds: entry.timeoutSeconds,
     maxTurns: entry.maxTurns,
   };
@@ -586,6 +598,7 @@ async function runCase(
   const start = Date.now();
   const expectedArtifacts = smokeCase.expectedArtifacts ?? [...DEFAULT_EXPECTED_ARTIFACTS];
   const expectedOutputs = smokeCase.expectedOutputs ?? [];
+  const outputRoot = smokeCase.outputRoot ?? DEFAULT_OUTPUT_ROOT;
   const caseResultsDir = path.join(resultsDir, "cases", smokeCase.id);
   const stdoutPath = path.join(caseResultsDir, "stdout.txt");
   const stderrPath = path.join(caseResultsDir, "stderr.txt");
@@ -650,6 +663,7 @@ async function runCase(
     reasons: classification.reasons,
     expectedArtifacts,
     expectedOutputs,
+    outputRoot,
     foundOutputs: classification.foundOutputs,
     exitCode,
     timedOut,
@@ -704,14 +718,25 @@ function workspaceSourcesForCase(smokeCase: SmokeCase): string[] {
 function buildPrompt(smokeCase: SmokeCase): string {
   const command = `prose ${smokeCase.command} ${smokeCase.source}`;
   const inputs = Object.entries(smokeCase.inputs ?? {});
+  const outputRoot = smokeCase.outputRoot ?? DEFAULT_OUTPUT_ROOT;
   const commandGuidance =
     smokeCase.command === "test"
       ? [
-          "For prose test: bind fixtures from the test file, resolve and execute the frontmatter subject as the program under test, evaluate ### Expects and ### Expects Not against bindings, and write ---test PASS or ---test FAIL to vm.log.md.",
-          "Write a compact forme.manifest.json before execution; for a test it must name the subject, fixtures, expected outputs, and assertions.",
+          "For prose test: bind fixtures from the test file, resolve the frontmatter subject, and execute it as the program under test.",
+          "Publish the subject's declared outputs before evaluating assertions: bindings/ for a function subject, world-model/ for a responsibility subject.",
+          "Evaluate ### Expects and ### Expects Not against those published outputs, then write ---test PASS or ---test FAIL to vm.log.md.",
           "A test fixture is self-contained; do not prompt for inputs and do not inspect unrelated programs after resolving the subject.",
         ]
-      : [];
+      : outputRoot === "world-model"
+        ? [
+            "This program mounts responsibilities: prose run on a kind: responsibility source mounts its nodes and reconciles them, per SKILL.md format detection. Do not refuse the run.",
+            "Snapshot the compiled intent (resolved nodes, subscription edges, entry points) to runs/<run-id>/compiled-intent.json before rendering.",
+            "Publish each node's maintained truth as non-empty files under runs/<run-id>/world-model/<node>/, and append one receipt line per completed render to runs/<run-id>/receipts/<node>.jsonl.",
+            "Append a `N→ <node> ✓ rendered` marker to vm.log.md for each node that commits its world-model.",
+          ]
+        : [
+            "This is a standalone function run. Publish each declared ### Returns output via copy-on-return: workspace/<function>/<output>.md copied to runs/<run-id>/bindings/<function>/<output>.md.",
+          ];
   const inputBlock =
     inputs.length > 0
       ? inputs.map(([name, value]) => `- ${name}: ${value}`).join("\n")
@@ -723,9 +748,9 @@ function buildPrompt(smokeCase: SmokeCase): string {
   const artifactBlock =
     expectedOutputs.length > 0
       ? expectedOutputs
-          .map((output) => `- ${output}: <openprose-root>/runs/<run-id>/bindings/**/${output}.md`)
+          .map((output) => `- ${output}: <openprose-root>/runs/<run-id>/${outputRoot}/**/${output}.md`)
           .join("\n")
-      : "- No declared output bindings are expected.";
+      : "- No declared outputs are expected.";
 
   return [
     "You are the OpenProse VM running a CI smoke fixture.",
@@ -741,11 +766,11 @@ function buildPrompt(smokeCase: SmokeCase): string {
     "Use the default filesystem state backend unless the source explicitly requests another backend.",
     "Satisfy the open-prose Run State Gate before reporting success.",
     `The run must create these files directly under runs/<run-id>/: ${artifacts}.`,
-    "The smoke runner checks real files, not stdout. Before replying, ensure each declared output is published as a non-empty binding file:",
+    "The smoke runner checks real files, not stdout. Before replying, ensure each declared output is published as a non-empty file:",
     artifactBlock,
-    "If a binding is missing, create it under the correct service binding directory before reporting success.",
+    "If a declared output file is missing, create it under the correct node directory before reporting success.",
     "Keep all reads and writes inside this workspace.",
-    "As soon as the required run artifacts, log markers, and declared bindings exist, stop and print the summary without further refinement.",
+    "As soon as the required run artifacts, log markers, and declared outputs exist, stop and print the summary without further refinement.",
     `Print a concise result summary with the run id and declared output names: ${outputs}.`,
   ].join("\n");
 }
@@ -819,6 +844,7 @@ async function classifyLiveCase(
   const processReasons: string[] = [];
   const expectedArtifacts = smokeCase.expectedArtifacts ?? [...DEFAULT_EXPECTED_ARTIFACTS];
   const expectedOutputs = smokeCase.expectedOutputs ?? [];
+  const outputRoot = smokeCase.outputRoot ?? DEFAULT_OUTPUT_ROOT;
 
   if (timedOut) {
     processReasons.push(`Claude CLI timed out after ${smokeCase.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds.`);
@@ -868,13 +894,25 @@ async function classifyLiveCase(
     }
   }
   for (const output of expectedOutputs) {
-    const bindingPath = latestRunDir
-      ? await findExpectedBinding(path.join(latestRunDir, "bindings"), output)
+    const outputPath = latestRunDir
+      ? await findExpectedOutput(path.join(latestRunDir, outputRoot), output)
       : undefined;
-    if (bindingPath && (await readTextIfExists(bindingPath)).trim().length > 0) {
+    if (outputPath && (await readTextIfExists(outputPath)).trim().length > 0) {
       foundOutputs.push(output);
     } else {
-      artifactReasons.push(`Missing or empty expected output binding: ${output}`);
+      artifactReasons.push(`Missing or empty expected output under ${outputRoot}/: ${output}`);
+    }
+  }
+
+  if (outputRoot === "world-model" && latestRunDir) {
+    const receiptsDir = path.join(latestRunDir, "receipts");
+    const receiptTexts = (await pathExists(receiptsDir)) ? await readAllTextFiles(receiptsDir) : [];
+    if (!receiptTexts.some((text) => text.trim().length > 0)) {
+      artifactReasons.push("Mounted run wrote no non-empty receipt under receipts/.");
+    }
+    const vmLog = await readTextIfExists(path.join(latestRunDir, "vm.log.md"));
+    if (!vmLog.includes("rendered")) {
+      artifactReasons.push("Mounted run log vm.log.md has no rendered marker.");
     }
   }
 
@@ -904,18 +942,18 @@ async function findLatestRunDir(runsDir: string): Promise<string | undefined> {
   return candidates[0]?.fullPath;
 }
 
-async function findExpectedBinding(bindingsDir: string, output: string): Promise<string | undefined> {
-  if (!(await pathExists(bindingsDir))) return undefined;
+async function findExpectedOutput(outputDir: string, output: string): Promise<string | undefined> {
+  if (!(await pathExists(outputDir))) return undefined;
   const expectedName = `${output}.md`;
-  const entries = await fs.readdir(bindingsDir, { withFileTypes: true });
+  const entries = await fs.readdir(outputDir, { withFileTypes: true });
 
   for (const entry of entries) {
-    const fullPath = path.join(bindingsDir, entry.name);
+    const fullPath = path.join(outputDir, entry.name);
     if (entry.isFile() && entry.name === expectedName) {
       return fullPath;
     }
     if (entry.isDirectory()) {
-      const nested = await findExpectedBinding(fullPath, output);
+      const nested = await findExpectedOutput(fullPath, output);
       if (nested) return nested;
     }
   }

--- a/tests/open-prose/smoke/01-single-service.prose.md
+++ b/tests/open-prose/smoke/01-single-service.prose.md
@@ -1,13 +1,14 @@
 ---
-name: smoke-single-service
-kind: service
+name: smoke-single-function
+kind: function
 version: 0.15.0
 ---
 
 ### Description
 
-Smallest required OpenProse smoke fixture.
+Smallest required OpenProse smoke fixture: one called function, one returned
+value.
 
-### Ensures
+### Returns
 
-- `message`: one sentence containing the exact phrase `single-service-smoke-pass`
+- `message`: one sentence containing the exact phrase `single-function-smoke-pass`

--- a/tests/open-prose/smoke/02-caller-input.prose.md
+++ b/tests/open-prose/smoke/02-caller-input.prose.md
@@ -1,17 +1,17 @@
 ---
 name: smoke-caller-input
-kind: service
+kind: function
 version: 0.15.0
 ---
 
 ### Description
 
-Verifies caller-provided inputs are bound and visible to a service.
+Verifies caller-provided parameters are bound and visible to a called function.
 
-### Requires
+### Parameters
 
 - `topic`: a short phrase supplied by the smoke runner
 
-### Ensures
+### Returns
 
 - `echo`: one sentence that includes the provided topic and the exact phrase `caller-input-smoke-pass`

--- a/tests/open-prose/smoke/03-auto-wiring.prose.md
+++ b/tests/open-prose/smoke/03-auto-wiring.prose.md
@@ -1,43 +1,36 @@
 ---
 name: smoke-auto-wiring
-kind: system
+kind: responsibility
 version: 0.15.0
 ---
 
-### Services
-
-- `collector`
-- `summarizer`
-
 ### Description
 
-Verifies auto-wiring from one service's declared output to another service's
-declared input.
+Verifies Forme wires a producer's `### Maintains` truth to a consumer's
+`### Requires` need without explicit routing.
 
 ### Requires
 
-- `subject`: a short phrase supplied by the smoke runner
+- `raw-notes`: notes maintained by the collector
 
-### Ensures
+### Maintains
 
 - `summary`: a two-sentence summary containing the exact phrase `auto-wiring-smoke-pass`
+
+### Continuity
+
+- input-driven
 
 ## collector
 
 ### Requires
 
-- `subject`: the phrase to collect
+- `subject`: the phrase to collect, supplied by the caller
 
-### Ensures
+### Maintains
 
 - `raw-notes`: notes that include the subject and the exact phrase `collected-for-auto-wiring`
 
-## summarizer
+### Continuity
 
-### Requires
-
-- `raw-notes`: notes produced by the collector
-
-### Ensures
-
-- `summary`: a two-sentence summary containing the exact phrase `auto-wiring-smoke-pass`
+- input-driven

--- a/tests/open-prose/smoke/04-inline-services.prose.md
+++ b/tests/open-prose/smoke/04-inline-services.prose.md
@@ -1,43 +1,49 @@
 ---
-name: smoke-inline-services
-kind: system
+name: smoke-inline-functions
+kind: responsibility
 version: 0.15.0
 ---
 
-### Services
-
-- `reviewer`
-- `publisher`
-
 ### Description
 
-Verifies `##` headings define inline services in a multi-service file.
+Verifies `##` headings define inline functions in a multi-node file.
 
 ### Requires
 
-- `draft`: a short draft supplied by the smoke runner
+- `draft`: a short draft supplied by the caller
 
-### Ensures
+### Maintains
 
-- `final`: polished output containing the exact phrase `inline-services-smoke-pass`
+- `final`: polished output containing the exact phrase `inline-functions-smoke-pass`
+
+### Continuity
+
+- input-driven
+
+### Shape
+
+- `self`: sequence the review and publish steps
+- `delegates`:
+  - `reviewer`: editorial feedback
+  - `publisher`: final polish
 
 ## reviewer
 
-### Requires
+### Parameters
 
 - `draft`: source text to review
 
-### Ensures
+### Returns
 
 - `feedback`: concise editorial feedback naming one strength and one improvement
 
 ## publisher
 
-### Requires
+### Parameters
 
 - `draft`: source text to polish
 - `feedback`: editorial feedback to apply
 
-### Ensures
+### Returns
 
-- `final`: polished output containing the exact phrase `inline-services-smoke-pass`
+- `final`: polished output containing the exact phrase `inline-functions-smoke-pass`

--- a/tests/open-prose/smoke/05-explicit-wiring.prose.md
+++ b/tests/open-prose/smoke/05-explicit-wiring.prose.md
@@ -1,39 +1,26 @@
 ---
-name: smoke-explicit-wiring
-kind: system
+name: smoke-fan-in-wiring
+kind: responsibility
 version: 0.15.0
 ---
 
-### Services
-
-- `left`
-- `right`
-- `joiner`
-
 ### Description
 
-Verifies `### Wiring` can pin caller and service data flow.
+Verifies Forme resolves deliberate fan-in: two producers of distinct truths
+reconverge at one consumer.
 
 ### Requires
 
-- `seed`: a short phrase supplied by the smoke runner
+- `left-note`: the note maintained by the left producer
+- `right-note`: the note maintained by the right producer
 
-### Ensures
+### Maintains
 
-- `joined`: combined output containing the exact phrase `explicit-wiring-smoke-pass`
+- `joined`: combined output containing the exact phrase `fan-in-wiring-smoke-pass`
 
-### Wiring
+### Continuity
 
-left:
-  receives: { seed: seed } from caller
-
-right:
-  receives: { seed: seed } from caller
-
-joiner:
-  receives: { left-note } from left
-  receives: { right-note } from right
-  returns to caller
+- input-driven
 
 ## left
 
@@ -41,9 +28,13 @@ joiner:
 
 - `seed`: caller-provided seed text
 
-### Ensures
+### Maintains
 
 - `left-note`: a note derived from the seed
+
+### Continuity
+
+- input-driven
 
 ## right
 
@@ -51,17 +42,10 @@ joiner:
 
 - `seed`: caller-provided seed text
 
-### Ensures
+### Maintains
 
 - `right-note`: a different note derived from the seed
 
-## joiner
+### Continuity
 
-### Requires
-
-- `left-note`: note from the left service
-- `right-note`: note from the right service
-
-### Ensures
-
-- `joined`: combined output containing the exact phrase `explicit-wiring-smoke-pass`
+- input-driven

--- a/tests/open-prose/smoke/06-execution-block.prose.md
+++ b/tests/open-prose/smoke/06-execution-block.prose.md
@@ -1,26 +1,21 @@
 ---
 name: smoke-execution-block
-kind: system
+kind: function
 version: 0.15.0
 ---
 
-### Services
-
-- `planner`
-- `finisher`
-
 ### Description
 
-Verifies a pinned `### Execution` block is followed.
+Verifies a pinned `### Execution` block is followed in a standalone function
+run.
 
-### Requires
+### Parameters
 
 - `request`: a short request supplied by the smoke runner
 
-### Ensures
+### Returns
 
 - `result`: final output containing the exact phrase `execution-block-smoke-pass`
-- publish `result` as the system's declared output binding
 
 ### Execution
 
@@ -36,21 +31,20 @@ return result
 
 ## planner
 
-### Requires
+### Parameters
 
 - `request`: caller request
 
-### Ensures
+### Returns
 
 - `plan`: a two-step plan based on the request
 
 ## finisher
 
-### Requires
+### Parameters
 
 - `plan`: plan from the planner
 
-### Ensures
+### Returns
 
 - `result`: final output containing the exact phrase `execution-block-smoke-pass`
-- publish `result` so callers can read it from `<openprose-root>/runs/` bindings

--- a/tests/open-prose/smoke/07-errors-strategies.prose.md
+++ b/tests/open-prose/smoke/07-errors-strategies.prose.md
@@ -1,26 +1,28 @@
 ---
 name: smoke-errors-strategies
-kind: service
+kind: function
 version: 0.15.0
 ---
 
 ### Description
 
-Verifies errors, conditional ensures, and strategies remain legible to the VM.
+Verifies errors, invariants, and strategies remain legible to the VM.
 
-### Requires
+### Parameters
 
 - `incident`: a short incident description supplied by the smoke runner
 
-### Ensures
+### Returns
 
 - `response`: a concise recovery note containing the exact phrase `errors-strategies-smoke-pass`
-- if context is incomplete: response includes a clearly labeled assumption list
-- publish `response` as this service's declared output binding
 
 ### Errors
 
 - `unrecoverable-incident`: the incident cannot be understood from the supplied text
+
+### Invariants
+
+- when context is incomplete, the response includes a clearly labeled assumption list
 
 ### Strategies
 

--- a/tests/open-prose/smoke/08-kind-test.prose.md
+++ b/tests/open-prose/smoke/08-kind-test.prose.md
@@ -7,7 +7,8 @@ subject: smoke-caller-input
 
 ### Description
 
-Verifies `kind: test` fixtures bind inputs and produce `---test PASS`.
+Verifies `kind: test` fixtures bind inputs, run a function subject, and produce
+`---test PASS`.
 
 ### Fixtures
 

--- a/tests/open-prose/smoke/09-local-pattern.prose.md
+++ b/tests/open-prose/smoke/09-local-pattern.prose.md
@@ -1,10 +1,24 @@
 ---
 name: smoke-local-pattern
-kind: system
+kind: function
 version: 0.15.0
 ---
 
-### Services
+### Description
+
+Verifies a local `kind: pattern` definition can be instantiated with worker and
+critic slots.
+
+### Parameters
+
+- `task`: a short task supplied by the smoke runner
+- `quality-bar`: acceptance criteria supplied by the smoke runner
+
+### Returns
+
+- `result`: accepted output containing the exact phrase `local-pattern-smoke-pass`
+
+### Patterns
 
 ```yaml
 - name: reviewed-result
@@ -16,38 +30,35 @@ version: 0.15.0
     max_rounds: 2
 ```
 
-### Description
+### Execution
 
-Verifies a local pattern definition can wire worker and critic slots.
+```prose
+let outcome = call reviewed-result
+  task: task
+  quality-bar: quality-bar
 
-### Requires
-
-- `task`: a short task supplied by the smoke runner
-- `quality-bar`: acceptance criteria supplied by the smoke runner
-
-### Ensures
-
-- `result`: accepted output containing the exact phrase `local-pattern-smoke-pass`
+return outcome
+```
 
 ## worker
 
-### Requires
+### Parameters
 
 - `task`: work to produce
 - `feedback`: critic feedback to address, optional on the first round
 
-### Ensures
+### Returns
 
 - `output`: completed work product containing the exact phrase `local-pattern-smoke-pass`
 
 ## critic
 
-### Requires
+### Parameters
 
 - `output`: worker output to evaluate
 - `quality-bar`: acceptance criteria
 
-### Ensures
+### Returns
 
 - `score`: numeric quality score from 0 to 100
 - `feedback`: specific critique if the output misses the quality bar

--- a/tests/open-prose/smoke/README.md
+++ b/tests/open-prose/smoke/README.md
@@ -10,12 +10,17 @@ The required smoke suite checks structural execution behavior:
 
 - the skill can be installed into a fresh harness workspace
 - authored smoke fixtures use `*.prose.md`; this README remains plain Markdown
-- Contract Markdown services and systems can be parsed and executed
-- Forme-style service wiring surfaces still work
-- systems can instantiate local `kind: pattern` definitions through `pattern:`
-- ProseScript execution blocks still run
+- Contract Markdown functions and responsibilities can be parsed and executed
+- a standalone `kind: function` run publishes its `### Returns` outputs under
+  `bindings/` via copy-on-return
+- Forme wires `### Requires` needs to `### Maintains` producers, including
+  deliberate fan-in, and mounted runs snapshot a `compiled-intent.json`
+- mounted responsibilities publish their truth under `world-model/` and append
+  receipts under `receipts/`
+- multi-node files can declare inline nodes with `##` headings
+- a `kind: function` file can instantiate a local `kind: pattern` definition
+- ProseScript `### Execution` blocks still run
 - test manifests can produce `---test PASS`
-- declared output bindings are written under `<openprose-root>/runs/`
 
 The required tier does not judge prose quality. Semantic and golden-trajectory
 checks belong in advisory or manual eval tiers after smoke flake and cost are

--- a/tests/open-prose/smoke/manifest.json
+++ b/tests/open-prose/smoke/manifest.json
@@ -8,6 +8,7 @@
       "source": "01-single-service.prose.md",
       "expectedArtifacts": ["root.prose.md", "vm.log.md"],
       "expectedOutputs": ["message"],
+      "outputRoot": "bindings",
       "timeoutSeconds": 360,
       "maxTurns": 24
     },
@@ -19,6 +20,7 @@
       "inputs": { "topic": "caller input smoke fixture" },
       "expectedArtifacts": ["root.prose.md", "vm.log.md"],
       "expectedOutputs": ["echo"],
+      "outputRoot": "bindings",
       "timeoutSeconds": 360,
       "maxTurns": 24
     },
@@ -28,8 +30,9 @@
       "command": "run",
       "source": "03-auto-wiring.prose.md",
       "inputs": { "subject": "auto wiring smoke fixture" },
-      "expectedArtifacts": ["root.prose.md", "forme.manifest.json", "vm.log.md"],
+      "expectedArtifacts": ["root.prose.md", "compiled-intent.json", "vm.log.md"],
       "expectedOutputs": ["summary"],
+      "outputRoot": "world-model",
       "timeoutSeconds": 480,
       "maxTurns": 24
     },
@@ -39,8 +42,9 @@
       "command": "run",
       "source": "04-inline-services.prose.md",
       "inputs": { "draft": "OpenProse smoke tests should be small, stable, and diagnostic." },
-      "expectedArtifacts": ["root.prose.md", "forme.manifest.json", "vm.log.md"],
+      "expectedArtifacts": ["root.prose.md", "compiled-intent.json", "vm.log.md"],
       "expectedOutputs": ["final"],
+      "outputRoot": "world-model",
       "timeoutSeconds": 480,
       "maxTurns": 24
     },
@@ -49,9 +53,10 @@
       "tier": "required",
       "command": "run",
       "source": "05-explicit-wiring.prose.md",
-      "inputs": { "seed": "explicit wiring smoke fixture" },
-      "expectedArtifacts": ["root.prose.md", "forme.manifest.json", "vm.log.md"],
+      "inputs": { "seed": "fan-in wiring smoke fixture" },
+      "expectedArtifacts": ["root.prose.md", "compiled-intent.json", "vm.log.md"],
       "expectedOutputs": ["joined"],
+      "outputRoot": "world-model",
       "timeoutSeconds": 480,
       "maxTurns": 24
     },
@@ -61,8 +66,9 @@
       "command": "run",
       "source": "06-execution-block.prose.md",
       "inputs": { "request": "produce a short smoke result" },
-      "expectedArtifacts": ["root.prose.md", "forme.manifest.json", "vm.log.md"],
+      "expectedArtifacts": ["root.prose.md", "vm.log.md"],
       "expectedOutputs": ["result"],
+      "outputRoot": "bindings",
       "timeoutSeconds": 480,
       "maxTurns": 24
     },
@@ -74,6 +80,7 @@
       "inputs": { "incident": "A smoke check lacks detail but needs a conservative recovery note." },
       "expectedArtifacts": ["root.prose.md", "vm.log.md"],
       "expectedOutputs": ["response"],
+      "outputRoot": "bindings",
       "timeoutSeconds": 360,
       "maxTurns": 24
     },
@@ -83,8 +90,9 @@
       "command": "test",
       "source": "08-kind-test.prose.md",
       "workspaceSources": ["08-kind-test.prose.md", "02-caller-input.prose.md"],
-      "expectedArtifacts": ["root.prose.md", "forme.manifest.json", "vm.log.md"],
+      "expectedArtifacts": ["root.prose.md", "vm.log.md"],
       "expectedOutputs": ["echo"],
+      "outputRoot": "bindings",
       "timeoutSeconds": 480,
       "maxTurns": 24
     },
@@ -98,8 +106,9 @@
         "task": "produce a one sentence smoke result",
         "quality-bar": "The output contains local-pattern-smoke-pass and is under 80 words."
       },
-      "expectedArtifacts": ["root.prose.md", "forme.manifest.json", "vm.log.md"],
+      "expectedArtifacts": ["root.prose.md", "vm.log.md"],
       "expectedOutputs": ["result"],
+      "outputRoot": "bindings",
       "timeoutSeconds": 600,
       "maxTurns": 24
     }

--- a/tests/open-prose/smoke/manifest.json
+++ b/tests/open-prose/smoke/manifest.json
@@ -94,7 +94,7 @@
       "expectedOutputs": ["echo"],
       "outputRoot": "bindings",
       "timeoutSeconds": 480,
-      "maxTurns": 24
+      "maxTurns": 40
     },
     {
       "id": "local-pattern",

--- a/tests/open-prose/smoke/worker-critic.prose.md
+++ b/tests/open-prose/smoke/worker-critic.prose.md
@@ -17,19 +17,10 @@ version: 0.15.0
 
 - `max_rounds`: integer, default `2`
 
-### Requires
-
-- `task`: what to produce
-- `quality-bar`: acceptance criteria
-
-### Ensures
-
-- `result`: accepted worker output, or the best output with final critique when the round budget is exhausted
-
 ### Invariants
 
 - stop when `critic.accepted` is true or after `max_rounds`
-- On exhaustion: return the latest worker output with final feedback
+- on exhaustion: return the latest worker output with final feedback
 
 ### Delegation
 


### PR DESCRIPTION
## Why

The smoke fixtures still exercised the retired pre-0.15 model: three
`kind: service` files, five `kind: system` files, `### Ensures` contracts
throughout, and a harness that asked for `forme.manifest.json` and checked
every output under `bindings/`. The execution docs now treat retired kinds
as never-executable upgrade input, which turned the kind-test case into a
standing contradiction: its subject resolved to a `kind: service` file the
harness required to execute and emit `---test PASS`. That contradiction
fits kind-test's history as the suite's one chronically flaky case.

## What

- Every fixture rewritten in current kinds, preserving what each case
  smokes:
  - `function` for single render, caller input, execution block, errors
    and strategies, and local pattern instantiation; standalone function
    runs publish `### Returns` under `bindings/` via copy-on-return
  - `responsibility` multi-node files for the wiring cases: a linear
    `Requires`/`Maintains` chain, inline `##` nodes, and a deliberate
    fan-in reconvergence in place of the retired `### Wiring` case
  - `kind: test` now runs a function subject and asserts against its
    published bindings
- Harness and manifest aligned with the current artifact layout: mounted
  runs snapshot `compiled-intent.json`, publish node truth under
  `world-model/<node>/`, and append receipts under `receipts/`; a
  per-case `outputRoot` field selects `world-model` or `bindings` for
  output checks
- Case ids and filenames unchanged, so required check names
  (`OpenProse smoke / <case>`) stay stable
