### PR TITLE
fix: exclude reserved @ prefixed files from the structured backing pick

### DIFF
--- a/packages/reactor-cli/src/__tests__/run-core-projection.test.ts
+++ b/packages/reactor-cli/src/__tests__/run-core-projection.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Structured projection on the RUN path — offline.
+ *
+ * A render that writes both the reserved `@atomic.json` status file and the
+ * actual structured backing (e.g. `sources.json`) must project the backing,
+ * not the status: `@` (0x40) sorts before lowercase letters, so the naive
+ * lexicographic pick chose `@atomic.json`, the canonicalizer found none of
+ * the declared material paths, and every facet fingerprinted to
+ * sha256("null") (issue #136).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { LoadedCompileIR } from '../compile/ir-cache';
+import { buildProjectTruthFor, type ProjectFiles } from '../run/run-core';
+
+const TEXT_ENCODER = new TextEncoder();
+
+function irWithFacets(node: string, facets: string[]): LoadedCompileIR {
+  return {
+    perNode: {
+      [node]: { compiled: { canonicalizer: { facets } } },
+    },
+  } as unknown as LoadedCompileIR;
+}
+
+function bytes(value: unknown): Uint8Array {
+  return TEXT_ENCODER.encode(JSON.stringify(value));
+}
+
+describe('buildProjectTruthFor structured backing pick', () => {
+  const sources = { sources: [{ source_id: 'email', content_fingerprint: 'sha256:abc' }] };
+  const atomicStatus = { status: 'ok', reason: null };
+
+  it('projects the structured backing, not the reserved @atomic.json status', () => {
+    const project = buildProjectTruthFor(irWithFacets('n', ['sources']), 'n');
+    const files: ProjectFiles = {
+      '@atomic.json': bytes(atomicStatus),
+      'sources.json': bytes(sources),
+    };
+    assert.deepEqual(project(files), sources);
+  });
+
+  it('still prefers a state/ file over other candidates', () => {
+    const project = buildProjectTruthFor(irWithFacets('n', ['sources']), 'n');
+    const files: ProjectFiles = {
+      '@atomic.json': bytes(atomicStatus),
+      'sources.json': bytes({ stale: true }),
+      'state/n.json': bytes(sources),
+    };
+    assert.deepEqual(project(files), sources);
+  });
+
+  it('projects empty when only reserved files are present', () => {
+    const project = buildProjectTruthFor(irWithFacets('n', ['sources']), 'n');
+    const files: ProjectFiles = { '@atomic.json': bytes(atomicStatus) };
+    assert.deepEqual(project(files), {});
+  });
+
+  it('ignores reserved files in nested directories too', () => {
+    const project = buildProjectTruthFor(irWithFacets('n', ['sources']), 'n');
+    const files: ProjectFiles = {
+      'out/@atomic.json': bytes(atomicStatus),
+      'sources.json': bytes(sources),
+    };
+    assert.deepEqual(project(files), sources);
+  });
+});

--- a/packages/reactor-cli/src/run/run-core.ts
+++ b/packages/reactor-cli/src/run/run-core.ts
@@ -321,10 +321,14 @@ export function buildProjectTruthFor(
  */
 function projectStructuredJson(files: ProjectFiles): ProjectTruth {
   // Prefer a `state/*.json` file (the documented structured-backing convention);
-  // fall back to any single `.json` file. A stable lexicographic pick keeps the
+  // fall back to any single `.json` file. Reserved `@`-prefixed files are never
+  // structured backing (`@atomic.json` is the render status, and `@` sorts
+  // before lowercase letters, so it would shadow the real backing and every
+  // declared facet would reduce to null). A stable lexicographic pick keeps the
   // projection deterministic when several are present.
   const jsonPaths = Object.keys(files)
     .filter((p) => p.endsWith('.json'))
+    .filter((p) => !(p.split('/').pop() ?? p).startsWith('@'))
     .sort();
   const statePath = jsonPaths.find((p) => p.startsWith('state/'));
   const chosen = statePath ?? jsonPaths[0];


### PR DESCRIPTION
## What

`projectStructuredJson` now skips reserved `@` prefixed files when picking the structured backing. The pick stays lexicographic and deterministic for everything else, and the `state/` preference is unchanged.

## Why

Resolves #136. A render that writes both `@atomic.json` and the real backing (for example `sources.json`) had the status file win the pick, because `@` sorts before lowercase letters. The canonicalizer then found none of the declared material paths and every facet fingerprinted to `sha256("null")`, so nothing propagated downstream.

## Testing

Offline gates only, no model calls, all green: `pnpm -C packages/reactor-cli test:offline` (typecheck plus 211 node test cases), `pnpm test:reactor:offline` (all three packages), `pnpm test:skill` (27 files, 409 tests) and `pnpm test:examples` (210 tests plus the eval harness). New regression tests in `run-core-projection.test.ts` cover the shadowing case, the `state/` preference, the reserved only case and nested reserved files. Reverting the fix makes exactly the three relevant tests fail.
