### PR TITLE
docs: specify the gate statement in the ProseScript grammar

### DIFF
--- a/skills/open-prose/prose.md
+++ b/skills/open-prose/prose.md
@@ -818,6 +818,8 @@ Runtime delegation and `gate()` share the same yield/resume shape:
 
 Both are coroutine-style interruptions where the VM mediates between the yielding render and an external actor.
 
+The ProseScript statement form for gates (`gate expression`, optionally bound with `let`) is specified in the Gates section of `prosescript.md`.
+
 ---
 
 ## The Copy-on-Return Mechanism

--- a/skills/open-prose/prosescript.md
+++ b/skills/open-prose/prosescript.md
@@ -122,7 +122,8 @@ agent_property  ::= "model:" expression NEWLINE
 shape_property  ::= ("self" | "delegates" | "prohibited") ":" expression NEWLINE
 
 statement       ::= binding | assignment | return_stmt
-                  | call_stmt | session_stmt | resume_stmt | do_block | do_call
+                  | call_stmt | session_stmt | resume_stmt | gate_stmt
+                  | do_block | do_call
                   | parallel_block | repeat_block | for_block | loop_block
                   | if_stmt | choice_block | try_block | throw_stmt
 
@@ -152,6 +153,8 @@ session_expr    ::= "session" ( string | ":" identifier | identifier ":" identif
                     property_block?
 resume_stmt     ::= ["let" target "="] resume_expr NEWLINE?
 resume_expr     ::= "resume" ":" identifier property_block?
+gate_stmt       ::= ["let" target "="] gate_expr NEWLINE?
+gate_expr       ::= "gate" expression
 
 property_block  ::= NEWLINE INDENT property+ DEDENT
 property         ::= identifier ":" expression NEWLINE
@@ -385,6 +388,41 @@ Validation:
 | Duplicate property | Error |
 | Invalid shape property | Error |
 | Direct `session` in `### Execution` when an equivalent `function` exists | Warning |
+
+## Gates
+
+A `gate` yields the run to a human operator and blocks until the operator
+responds. Use it for decisions the render must not absorb: approvals, rulings,
+and anything irreversible.
+
+```prose
+let acceptance = gate "operator reads the decision sheet and rules per item"
+
+gate "confirm the deployment plan before it is applied"
+```
+
+The payload expression is presented to the operator. When the statement is
+bound with `let`, the operator's response becomes the bound value.
+
+Gate forms:
+
+| Form | Meaning |
+|------|---------|
+| `gate "prompt"` | Yield to the operator with a prompt, discard the response |
+| `let x = gate "prompt"` | Yield to the operator, bind the response |
+| `gate reference` | Yield with a structured payload, such as a decision sheet |
+
+Like `call`, `session`, and `resume`, a gate is an implicit yield point; there
+is no `await` keyword in ProseScript. The runtime delegation comparison in
+`prose.md` describes the same interaction at the VM protocol level as
+`await gate(payload)` → response. Unlike runtime delegation, the wait is
+indefinite: a gate resumes only on operator input.
+
+Validation:
+
+| Check | Result |
+|-------|--------|
+| `gate` without a payload expression | Error |
 
 ## Variables And Context
 
@@ -825,7 +863,8 @@ Execution has three phases:
 2. Validate names, scopes, target contracts, inputs, outputs, loop bounds, and
    surface-specific restrictions.
 3. Execute in source order, using the Prose VM from `prose.md` for function
-   calls, sessions, state, bindings, retries, and final result publication.
+   calls, sessions, gates, state, bindings, retries, and final result
+   publication.
 
 Contract Markdown `### Execution`:
 


### PR DESCRIPTION
Resolves #147

**Problem**

`prose.md` documents `gate()` as a first class VM primitive and the bundled session-to-prose extractor mandates emitting gate points, but the ProseScript grammar has no production for it. The only specification anywhere is the comparison table in the runtime delegation section, which describes the VM protocol as `await gate(payload)`. As #147 reports, a generator and an independent reviewer produced three different surface forms in a single run because there was nothing to lint against.

**Change**

`prosescript.md` gains `gate_stmt ::= ["let" target "="] gate_expr NEWLINE?` with `gate_expr ::= "gate" expression`, the statement alternation entry, a Gates section in the style of the surrounding sections (intro, example, forms table, validation table), and a mention of gates in the execution model's phase 3 list. `prose.md` gains one line after the gate vs runtime delegation table pointing to the new grammar section.

**Why the statement form and not `await gate(...)`**

ProseScript has no `await` keyword anywhere in the grammar. The three existing primitives that yield to an external actor (`call`, `session`, `resume`) are all statement forms with an optional `let` binding, and the VM awaits implicitly. A gate is the same class of primitive, so the grammar follows that precedent. The new section states explicitly that `await gate(payload)` in the comparison table is the VM protocol description of the same interaction, so the two documents no longer read as conflicting. If a different surface form is intended, happy to adjust.

**Checks**

`pnpm test:skill` (411 passed, includes the skill meta conformance suite that asserts on the grammar productions), `pnpm test:examples` (10 passed) and `pnpm --filter @openprose/reactor-cli test:offline` (210 passed, 1 skipped) are green after the change.
