### PR TITLE
docs(spec): reference unshipped design notes as plain text

### DIFF
--- a/spec/01-Language.md
+++ b/spec/01-Language.md
@@ -22,7 +22,7 @@ ships:
   Reactor-Native Authoring Pattern**, **SKILL-bundled but harness-governed**:
   how to write `*.prose.md` so the harness's mechanisms engage. It bridges
   this doc and the Harness doc.
-- [ReactorFeedback.md](../history/ReactorFeedback.md) — **the
+- `ReactorFeedback.md` — **the
   decision log**, not shipped: the dialectic that produced the Harness doc;
   the clean statements live in the docs above.
 - [00-Tenets.md](./00-Tenets.md) — **the constitution**. When any
@@ -303,10 +303,10 @@ The current repository narrows the ground truth:
 - The current repo does not specify a product/business platform surface like
   Cloud billing, sprites, Constellation, or an investor narrative. The hosted
   product, public/social surface, and go-to-market motion are sketched in
-  [ContinuousOutcomes.md](../ideation/ContinuousOutcomes.md) (stale
+  `ContinuousOutcomes.md` (stale
   product ideation, not a live spec); the forward-looking subscription,
   royalty, and dependency-graph economics are sketched in
-  [SubscriptionsHypothetical.md](../ideation/SubscriptionsHypothetical.md)
+  `SubscriptionsHypothetical.md`
   (hypothetical, not a live spec and not load-bearing); the brand and design
   surface lives in `platform/apps/run/PRODUCT.md`. None of those documents are
   live OpenProse language/runtime material; this file remains the language and

--- a/spec/02-ReactorHarness.md
+++ b/spec/02-ReactorHarness.md
@@ -16,7 +16,7 @@ ships:
   Reactor-Native Authoring Pattern**, **SKILL-bundled but harness-governed**:
   how to write `*.prose.md` so this harness's mechanisms engage. It bridges
   the Language doc and this doc.
-- [ReactorFeedback.md](../history/ReactorFeedback.md) — **the
+- `ReactorFeedback.md` — **the
   decision log**, not shipped: the dialectic that produced this revision. This
   document is the clean statement and does not carry the dialectic.
 - [00-Tenets.md](./00-Tenets.md) — **the constitution**. When any

--- a/spec/03-ReactorPattern.md
+++ b/spec/03-ReactorPattern.md
@@ -17,7 +17,7 @@ ships:
   says **what the author writes** so the runtime can do it. It bridges the
   Language doc and the Harness doc and is the definitive guide to writing
   `*.prose.md` for a Reactor-class harness.
-- [ReactorFeedback.md](../history/ReactorFeedback.md) — **the
+- `ReactorFeedback.md` — **the
   decision log**, not shipped: the dialectic that produced the Harness doc;
   the clean statements live in the docs above and it does not repeat them.
 - [00-Tenets.md](./00-Tenets.md) — **the constitution**. When any


### PR DESCRIPTION
The spec docs linked ReactorFeedback.md, ContinuousOutcomes.md and SubscriptionsHypothetical.md through ../history/ and ../ideation/ paths that were never committed, so all five relative links were dead. The docs already describe these notes as not shipped, and spec/02 already references ContinuousOutcomes.md as backticked plain text, so the links become plain file names in the same style.

After the change a link checker over every tracked markdown file finds zero dead relative links in the repo. `pnpm test:skill` (411 passed) and `pnpm test:examples` (10 passed) are green.