### PR TITLE
chore: harden dependency installs and CI execution paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# Third-party actions are pinned to immutable commit SHAs. SHAs never move on
+# their own, so this entry is what keeps them current — without it the pins rot.
+#
+# Only the github-actions ecosystem is enabled. npm version-update PRs are
+# deliberately off: frozen-lockfile installs plus the release cooldown in
+# pnpm-workspace.yaml already manage dependency drift, and a PR per release is
+# noise nobody reads. Dependabot *alerts* are enabled in repo settings and are
+# the signal layer we do want; automated *security-update* PRs are off for the
+# same reason — advisories get triaged against real exposure, not auto-patched.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # One PR for all action bumps instead of one per action.
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,14 @@ version: 2
 # Third-party actions are pinned to immutable commit SHAs. SHAs never move on
 # their own, so this entry is what keeps them current — without it the pins rot.
 #
+# GitHub-maintained actions (`actions/*`) stay on version tags. That is a decision
+# to extend trust to those repositories, not a claim that pinning them would buy
+# nothing: a tag is mutable, and anyone with push rights on the action's repo can
+# move it, so SHA-pinning `actions/*` would genuinely narrow the exposure. We take
+# the residual risk in exchange for a pin set small enough to keep honestly current
+# at this repo's size — stale pins nobody bumps are their own hazard. Worth
+# revisiting if the number of workflows or actions grows.
+#
 # Only the github-actions ecosystem is enabled. npm version-update PRs are
 # deliberately off: frozen-lockfile installs plus the release cooldown in
 # pnpm-workspace.yaml already manage dependency drift, and a PR per release is

--- a/.github/scripts/longcot/README.md
+++ b/.github/scripts/longcot/README.md
@@ -11,7 +11,7 @@ The GitHub Action lives at [`.github/workflows/longcot-bench.yml`](../../workflo
 Per run, the workflow:
 
 1. Clones LongCoT at the ref you pick, `uv sync`s its deps (includes `rdkit`, `chess`, `sympy`, the Python SDKs).
-2. `npm i -g @mariozechner/pi-coding-agent@<pi_version>` to get the `pi` binary.
+2. `npm i -g @mariozechner/pi-coding-agent@0.73.1` to get the `pi` binary. The version is hardcoded in the workflow; change it there.
 3. Runs `run_pi.py` (this directory) — our shim. For each selected question it shells out to:
    ```
    pi --mode json \
@@ -54,8 +54,7 @@ gh workflow run longcot-bench.yml \
 | `seed` | `0` | Shuffle seed. Same seed → same slice across runs. |
 | `concurrency` | `8` | Parallel pi subprocesses. Matches LongCoT's default `num_workers`. |
 | `system_prompt` | `You are a helpful assistant.` | Pi's default is a coding-agent prompt; we override so the model sees only the problem. |
-| `pi_version` | `latest` | npm tag/version for `@mariozechner/pi-coding-agent`. Pin to a version (e.g. `0.5.1`) for reproducibility. |
-| `longcot_ref` | `fb96494` (`main` @ 2026-04-20) | Git ref of LongCoT repo (branch/tag/SHA). Defaults to a pinned commit, not `main`: this job runs the checked-out repo's Python with five LLM provider keys in scope. Pass `main` explicitly to take upstream HEAD, or bump the default after reviewing the diff. |
+| `longcot_ref` | `fb96494` (`main` @ 2026-04-20) | Git ref of LongCoT repo (branch/tag/SHA). Defaults to a pinned commit, not `main`: this job runs the checked-out repo's Python with five LLM provider keys in scope. The clone target repository is fixed, so this only selects a ref within it. Pass `main` explicitly to take upstream HEAD, understanding that you are running unreviewed code with the keys attached. |
 | `run_eval` | `true` | If `false`, produce responses JSONL but skip scoring. |
 | `fallback_judge` | `true` | If `false`, pass `--no-fallback` to `run_eval.py` (disables Gemini judge for math/chem borderline cases). |
 

--- a/.github/scripts/longcot/README.md
+++ b/.github/scripts/longcot/README.md
@@ -55,7 +55,7 @@ gh workflow run longcot-bench.yml \
 | `concurrency` | `8` | Parallel pi subprocesses. Matches LongCoT's default `num_workers`. |
 | `system_prompt` | `You are a helpful assistant.` | Pi's default is a coding-agent prompt; we override so the model sees only the problem. |
 | `pi_version` | `latest` | npm tag/version for `@mariozechner/pi-coding-agent`. Pin to a version (e.g. `0.5.1`) for reproducibility. |
-| `longcot_ref` | `main` | Git ref of LongCoT repo (branch/tag/SHA). |
+| `longcot_ref` | `fb96494` (`main` @ 2026-04-20) | Git ref of LongCoT repo (branch/tag/SHA). Defaults to a pinned commit, not `main`: this job runs the checked-out repo's Python with five LLM provider keys in scope. Pass `main` explicitly to take upstream HEAD, or bump the default after reviewing the diff. |
 | `run_eval` | `true` | If `false`, produce responses JSONL but skip scoring. |
 | `fallback_judge` | `true` | If `false`, pass `--no-fallback` to `run_eval.py` (disables Gemini judge for math/chem borderline cases). |
 

--- a/.github/workflows/ci-examples-gate.yml
+++ b/.github/workflows/ci-examples-gate.yml
@@ -63,6 +63,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Dependency advisory audit (informational)
+        # Non-blocking on purpose: advisories here are dominated by deep
+        # transitive packages we do not control, and a permanently red gate
+        # teaches everyone to ignore it. Read the output; it is a signal, not
+        # a verdict.
+        run: pnpm audit --prod
+        continue-on-error: true
+
       - name: Build reactor + devtools (the example tests replay their dist)
         run: |
           pnpm --filter @openprose/reactor build

--- a/.github/workflows/ci-examples-gate.yml
+++ b/.github/workflows/ci-examples-gate.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-reactor-package.yml
+++ b/.github/workflows/ci-reactor-package.yml
@@ -131,7 +131,17 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        # Pinned to an exact version rather than tracking `latest`. This job holds an
+        # `id-token: write` credential that can publish under our name, so whatever npm
+        # we install here executes with that credential in scope — `latest` would hand a
+        # compromised npm release straight into it, and would roll us onto new majors
+        # untested. 11.19.0 clears the >=11.5.1 floor that OIDC trusted publishing needs
+        # (see the publish step below). Bump deliberately after reviewing the release.
+        # The version check makes a pin that did not take effect fail loudly here rather
+        # than surface as a confusing failure at publish time.
+        run: |
+          npm install -g npm@11.19.0
+          npm --version | grep -qx '11.19.0'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-reactor-package.yml
+++ b/.github/workflows/ci-reactor-package.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup Node.js for trusted publishing
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-reactor-package.yml
+++ b/.github/workflows/ci-reactor-package.yml
@@ -47,6 +47,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify registry signatures
+        # Blocking. Every installed dependency must carry a valid npm registry
+        # signature, so a tampered or unsigned tarball fails before we pack a
+        # release from it. npm only sees the tree reachable from the directory
+        # it runs in, and pnpm keeps each workspace package's dependencies under
+        # that package — so check the root plus every publishable package.
+        run: |
+          set -euo pipefail
+          for dir in . packages/reactor packages/reactor-cli packages/reactor-devtools; do
+            echo "::group::npm audit signatures (${dir})"
+            (cd "${dir}" && npm audit signatures)
+            echo "::endgroup::"
+          done
+
+      - name: Dependency advisory audit (informational)
+        # Non-blocking on purpose: advisories here are dominated by deep
+        # transitive packages we do not control, and a permanently red gate
+        # teaches everyone to ignore it. Signature verification above is the
+        # check that blocks; this one is a signal to read.
+        run: pnpm audit --prod
+        continue-on-error: true
+
       - name: Build reactor packages
         run: |
           pnpm --filter @openprose/reactor build

--- a/.github/workflows/longcot-bench.yml
+++ b/.github/workflows/longcot-bench.yml
@@ -60,22 +60,18 @@ on:
         description: "System prompt passed to pi"
         type: string
         default: "You are a helpful assistant."
-      pi_version:
-        description: "npm tag/version for @mariozechner/pi-coding-agent"
-        type: string
-        # Pinned to an exact version rather than a moving tag like `latest`: this job
-        # installs pi globally and then runs it with five LLM provider keys in scope,
-        # so a moving tag executes whatever was published most recently. The repo's 48h
-        # publish cooldown does not cover this — `minimumReleaseAge` in
-        # pnpm-workspace.yaml is a pnpm setting and this is a global npm install.
-        # Bump deliberately.
-        default: "0.73.1"
       longcot_ref:
         description: "git ref (branch/tag/sha) of LongHorizonReasoning/longcot to clone"
         type: string
         # Pinned to an immutable commit rather than `main`: this job executes the
         # checked-out repo's Python with five LLM provider keys in scope, so a moving ref
         # would run whatever landed upstream. Bump deliberately after reviewing the diff.
+        #
+        # This override stays free-form as a deliberate escape hatch for whoever is
+        # running the benchmark: `repository:` below is fixed, so the value can only
+        # select a ref inside LongHorizonReasoning/longcot, and getting code there is
+        # its own problem. Treat dispatching a non-default ref as running unreviewed
+        # code with the keys attached.
         default: "fb9649423f15f5b0091f8e988b100596cac592ca" # main @ 2026-04-20
       run_eval:
         description: "Run LongCoT scoring step after responses are generated"
@@ -116,14 +112,20 @@ jobs:
 
       - name: Install pi-mono
         shell: bash
-        # Dispatch inputs reach the script through the environment, never through
-        # `${{ }}` interpolation: expressions are substituted before bash parses the
-        # script, so an input containing shell syntax would run as code.
-        env:
-          LONGCOT_PI_VERSION: ${{ inputs.pi_version }}
+        # Hardcoded, with no dispatch override. npm accepts far more than a version
+        # after the `@` — `npm:other-package@1.0.0`, `github:owner/repo`, an https
+        # tarball URL, a local path — so any input reaching this position could
+        # redirect the install to an arbitrary package source, whose install scripts
+        # then run and whose binary is later executed with five LLM provider keys in
+        # scope. An allowlist would need editing to add a version, which is the same
+        # edit as changing the line below, so it buys nothing.
+        #
+        # Note the 48h publish cooldown does not protect this either:
+        # `minimumReleaseAge` in pnpm-workspace.yaml is a pnpm setting, and this is a
+        # global npm install. Bump deliberately after reviewing the release.
         run: |
           set -euo pipefail
-          npm install -g "@mariozechner/pi-coding-agent@$LONGCOT_PI_VERSION"
+          npm install -g "@mariozechner/pi-coding-agent@0.73.1"
           pi --version || pi --help | head -1
 
       - name: Setup uv

--- a/.github/workflows/longcot-bench.yml
+++ b/.github/workflows/longcot-bench.yml
@@ -67,7 +67,10 @@ on:
       longcot_ref:
         description: "git ref (branch/tag/sha) of LongHorizonReasoning/longcot to clone"
         type: string
-        default: "main"
+        # Pinned to an immutable commit rather than `main`: this job executes the
+        # checked-out repo's Python with five LLM provider keys in scope, so a moving ref
+        # would run whatever landed upstream. Bump deliberately after reviewing the diff.
+        default: "fb9649423f15f5b0091f8e988b100596cac592ca" # main @ 2026-04-20
       run_eval:
         description: "Run LongCoT scoring step after responses are generated"
         type: boolean
@@ -113,7 +116,7 @@ jobs:
           pi --version || pi --help | head -1
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/longcot-bench.yml
+++ b/.github/workflows/longcot-bench.yml
@@ -63,7 +63,13 @@ on:
       pi_version:
         description: "npm tag/version for @mariozechner/pi-coding-agent"
         type: string
-        default: "latest"
+        # Pinned to an exact version rather than a moving tag like `latest`: this job
+        # installs pi globally and then runs it with five LLM provider keys in scope,
+        # so a moving tag executes whatever was published most recently. The repo's 48h
+        # publish cooldown does not cover this — `minimumReleaseAge` in
+        # pnpm-workspace.yaml is a pnpm setting and this is a global npm install.
+        # Bump deliberately.
+        default: "0.73.1"
       longcot_ref:
         description: "git ref (branch/tag/sha) of LongHorizonReasoning/longcot to clone"
         type: string
@@ -110,9 +116,14 @@ jobs:
 
       - name: Install pi-mono
         shell: bash
+        # Dispatch inputs reach the script through the environment, never through
+        # `${{ }}` interpolation: expressions are substituted before bash parses the
+        # script, so an input containing shell syntax would run as code.
+        env:
+          LONGCOT_PI_VERSION: ${{ inputs.pi_version }}
         run: |
           set -euo pipefail
-          npm install -g "@mariozechner/pi-coding-agent@${{ inputs.pi_version }}"
+          npm install -g "@mariozechner/pi-coding-agent@$LONGCOT_PI_VERSION"
           pi --version || pi --help | head -1
 
       - name: Setup uv
@@ -143,19 +154,28 @@ jobs:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          LONGCOT_MODEL: ${{ inputs.model }}
+          LONGCOT_THINKING: ${{ inputs.thinking }}
+          LONGCOT_DOMAIN: ${{ inputs.domain }}
+          LONGCOT_DIFFICULTY: ${{ inputs.difficulty }}
+          LONGCOT_MAX_QUESTIONS: ${{ inputs.max_questions }}
+          LONGCOT_OFFSET: ${{ inputs.offset }}
+          LONGCOT_SEED: ${{ inputs.seed }}
+          LONGCOT_CONCURRENCY: ${{ inputs.concurrency }}
+          LONGCOT_SYSTEM_PROMPT: ${{ inputs.system_prompt }}
         run: |
           set -euo pipefail
           cd longcot
           uv run python ../.github/scripts/longcot/run_pi.py \
-            --model "${{ inputs.model }}" \
-            --thinking "${{ inputs.thinking }}" \
-            --domain "${{ inputs.domain }}" \
-            --difficulty "${{ inputs.difficulty }}" \
-            --max-questions "${{ inputs.max_questions }}" \
-            --offset "${{ inputs.offset }}" \
-            --seed "${{ inputs.seed }}" \
-            --concurrency "${{ inputs.concurrency }}" \
-            --system-prompt "${{ inputs.system_prompt }}" \
+            --model "$LONGCOT_MODEL" \
+            --thinking "$LONGCOT_THINKING" \
+            --domain "$LONGCOT_DOMAIN" \
+            --difficulty "$LONGCOT_DIFFICULTY" \
+            --max-questions "$LONGCOT_MAX_QUESTIONS" \
+            --offset "$LONGCOT_OFFSET" \
+            --seed "$LONGCOT_SEED" \
+            --concurrency "$LONGCOT_CONCURRENCY" \
+            --system-prompt "$LONGCOT_SYSTEM_PROMPT" \
             --output "$RESPONSES_PATH"
 
       - name: Run LongCoT eval
@@ -164,11 +184,12 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          LONGCOT_FALLBACK_JUDGE: ${{ inputs.fallback_judge }}
         run: |
           set -euo pipefail
           cd longcot
           EXTRA_ARGS=""
-          if [[ "${{ inputs.fallback_judge }}" == "false" ]]; then
+          if [[ "$LONGCOT_FALLBACK_JUDGE" == "false" ]]; then
             EXTRA_ARGS="--no-fallback"
           fi
           uv run python run_eval.py "$RESPONSES_PATH" --output "$RESULTS_PATH" $EXTRA_ARGS
@@ -176,6 +197,13 @@ jobs:
       - name: Write job summary
         if: always()
         shell: bash
+        env:
+          LONGCOT_MODEL: ${{ inputs.model }}
+          LONGCOT_THINKING: ${{ inputs.thinking }}
+          LONGCOT_DOMAIN: ${{ inputs.domain }}
+          LONGCOT_DIFFICULTY: ${{ inputs.difficulty }}
+          LONGCOT_MAX_QUESTIONS: ${{ inputs.max_questions }}
+          LONGCOT_RUN_EVAL: ${{ inputs.run_eval }}
         run: |
           set -euo pipefail
           {
@@ -183,15 +211,15 @@ jobs:
             echo ""
             echo "| Input | Value |"
             echo "| --- | --- |"
-            echo "| model | \`${{ inputs.model }}\` |"
-            echo "| thinking | \`${{ inputs.thinking }}\` |"
-            echo "| domain | \`${{ inputs.domain }}\` |"
-            echo "| difficulty | \`${{ inputs.difficulty }}\` |"
-            echo "| max_questions | \`${{ inputs.max_questions }}\` |"
+            echo "| model | \`$LONGCOT_MODEL\` |"
+            echo "| thinking | \`$LONGCOT_THINKING\` |"
+            echo "| domain | \`$LONGCOT_DOMAIN\` |"
+            echo "| difficulty | \`$LONGCOT_DIFFICULTY\` |"
+            echo "| max_questions | \`$LONGCOT_MAX_QUESTIONS\` |"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "${{ inputs.run_eval }}" == "true" ]]; then
+          if [[ "$LONGCOT_RUN_EVAL" == "true" ]]; then
             RESULTS_FILE="longcot/$RESULTS_PATH"
             if [[ -f "$RESULTS_FILE" ]]; then
               {

--- a/.github/workflows/longcot-rlmify.yml
+++ b/.github/workflows/longcot-rlmify.yml
@@ -59,7 +59,10 @@ on:
       longcot_ref:
         description: "git ref (branch/tag/sha) of LongHorizonReasoning/longcot to clone"
         type: string
-        default: "main"
+        # Pinned to an immutable commit rather than `main`: this job executes the
+        # checked-out repo's Python with five LLM provider keys in scope, so a moving ref
+        # would run whatever landed upstream. Bump deliberately after reviewing the diff.
+        default: "fb9649423f15f5b0091f8e988b100596cac592ca" # main @ 2026-04-20
       run_eval:
         description: "Run LongCoT scoring step after responses are generated"
         type: boolean
@@ -98,7 +101,7 @@ jobs:
           node-version: 22
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -130,7 +133,7 @@ jobs:
           rlmify --help | head -1
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/longcot-rlmify.yml
+++ b/.github/workflows/longcot-rlmify.yml
@@ -103,13 +103,19 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # Pinned rather than `latest`: this job runs bun and pi with five LLM provider
+          # keys in scope, so a moving version installs whatever shipped most recently.
+          bun-version: 1.3.14
 
       - name: Install pi-mono
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g "@mariozechner/pi-coding-agent@latest"
+          # Pinned for the same reason as the bun version above. The repo's 48h publish
+          # cooldown does not cover either one — `minimumReleaseAge` in
+          # pnpm-workspace.yaml is a pnpm setting, and these are npm and bun installs.
+          # Bump deliberately.
+          npm install -g "@mariozechner/pi-coding-agent@0.73.1"
           pi --version || pi --help | head -1
 
       - name: Install rlmify deps
@@ -161,18 +167,29 @@ jobs:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # Dispatch inputs reach the script through the environment, never through
+          # `${{ }}` interpolation: expressions are substituted before bash parses the
+          # script, so an input containing shell syntax would run as code.
+          LONGCOT_MODEL: ${{ inputs.model }}
+          LONGCOT_THINKING: ${{ inputs.thinking }}
+          LONGCOT_DOMAIN: ${{ inputs.domain }}
+          LONGCOT_DIFFICULTY: ${{ inputs.difficulty }}
+          LONGCOT_MAX_QUESTIONS: ${{ inputs.max_questions }}
+          LONGCOT_OFFSET: ${{ inputs.offset }}
+          LONGCOT_SEED: ${{ inputs.seed }}
+          LONGCOT_CONCURRENCY: ${{ inputs.concurrency }}
         run: |
           set -euo pipefail
           cd longcot
           uv run python ../.github/scripts/longcot/run_rlmify.py \
-            --model "${{ inputs.model }}" \
-            --thinking "${{ inputs.thinking }}" \
-            --domain "${{ inputs.domain }}" \
-            --difficulty "${{ inputs.difficulty }}" \
-            --max-questions "${{ inputs.max_questions }}" \
-            --offset "${{ inputs.offset }}" \
-            --seed "${{ inputs.seed }}" \
-            --concurrency "${{ inputs.concurrency }}" \
+            --model "$LONGCOT_MODEL" \
+            --thinking "$LONGCOT_THINKING" \
+            --domain "$LONGCOT_DOMAIN" \
+            --difficulty "$LONGCOT_DIFFICULTY" \
+            --max-questions "$LONGCOT_MAX_QUESTIONS" \
+            --offset "$LONGCOT_OFFSET" \
+            --seed "$LONGCOT_SEED" \
+            --concurrency "$LONGCOT_CONCURRENCY" \
             --repo-root "$GITHUB_WORKSPACE" \
             --log-dir "$RLMIFY_LOGS" \
             --output "$RESPONSES_PATH"
@@ -183,11 +200,12 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          LONGCOT_FALLBACK_JUDGE: ${{ inputs.fallback_judge }}
         run: |
           set -euo pipefail
           cd longcot
           EXTRA_ARGS=""
-          if [[ "${{ inputs.fallback_judge }}" == "false" ]]; then
+          if [[ "$LONGCOT_FALLBACK_JUDGE" == "false" ]]; then
             EXTRA_ARGS="--no-fallback"
           fi
           uv run python run_eval.py "$RESPONSES_PATH" --output "$RESULTS_PATH" $EXTRA_ARGS
@@ -195,6 +213,14 @@ jobs:
       - name: Write job summary
         if: always()
         shell: bash
+        env:
+          LONGCOT_MODEL: ${{ inputs.model }}
+          LONGCOT_THINKING: ${{ inputs.thinking }}
+          LONGCOT_DOMAIN: ${{ inputs.domain }}
+          LONGCOT_DIFFICULTY: ${{ inputs.difficulty }}
+          LONGCOT_MAX_QUESTIONS: ${{ inputs.max_questions }}
+          LONGCOT_CONCURRENCY: ${{ inputs.concurrency }}
+          LONGCOT_RUN_EVAL: ${{ inputs.run_eval }}
         run: |
           set -euo pipefail
           {
@@ -202,16 +228,16 @@ jobs:
             echo ""
             echo "| Input | Value |"
             echo "| --- | --- |"
-            echo "| model | \`${{ inputs.model }}\` |"
-            echo "| thinking | \`${{ inputs.thinking }}\` |"
-            echo "| domain | \`${{ inputs.domain }}\` |"
-            echo "| difficulty | \`${{ inputs.difficulty }}\` |"
-            echo "| max_questions | \`${{ inputs.max_questions }}\` |"
-            echo "| concurrency | \`${{ inputs.concurrency }}\` |"
+            echo "| model | \`$LONGCOT_MODEL\` |"
+            echo "| thinking | \`$LONGCOT_THINKING\` |"
+            echo "| domain | \`$LONGCOT_DOMAIN\` |"
+            echo "| difficulty | \`$LONGCOT_DIFFICULTY\` |"
+            echo "| max_questions | \`$LONGCOT_MAX_QUESTIONS\` |"
+            echo "| concurrency | \`$LONGCOT_CONCURRENCY\` |"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "${{ inputs.run_eval }}" == "true" ]]; then
+          if [[ "$LONGCOT_RUN_EVAL" == "true" ]]; then
             RESULTS_FILE="longcot/$RESULTS_PATH"
             if [[ -f "$RESULTS_FILE" ]]; then
               {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openprose-prose",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "build": "pnpm --filter @openprose/reactor build && pnpm --filter @openprose/reactor-cli build && pnpm --filter @openprose/reactor-devtools build",
     "test": "pnpm --filter @openprose/reactor test && pnpm --filter @openprose/reactor-cli test && pnpm --filter @openprose/reactor-devtools test && pnpm test:skill && pnpm test:examples",

--- a/packages/reactor-cli/README.md
+++ b/packages/reactor-cli/README.md
@@ -24,7 +24,7 @@ All three packages are live on npm. Prefer a **project-local** install (no root,
 no global binary collisions) and call the binaries through `npx`:
 
 ```sh
-npm install --save-dev @openprose/reactor-cli @openprose/reactor @openai/agents zod
+npm install --save-dev @openprose/reactor-cli @openprose/reactor "@openai/agents@^0.11.6" zod
 # then: `npx reactor …` / `npx reactor-devtools …`
 ```
 
@@ -40,12 +40,18 @@ binaries and is `EACCES`-prone on Linux/WSL (use a user prefix/nvm or `sudo`):
 ```sh
 npm i -g @openprose/reactor-cli @openprose/reactor-devtools
 # The live render also needs two peers:
-npm i -g @openprose/reactor @openai/agents zod
+npm i -g @openprose/reactor "@openai/agents@^0.11.6" zod
 ```
 
 > Zero *runtime* deps in the SDK core. The live render needs two peers
 > (`@openai/agents`, `zod`); `doctor`, `init`, the whole observability suite, and
 > the `reactor-devtools` replay need neither.
+>
+> The `@openai/agents` range is capped at `0.11.x` on purpose — under 0.x semver
+> a caret does not cross the minor line, and each `@openai/agents` minor has
+> carried breaking changes. Installing it unpinned resolves a newer minor and
+> fails peer resolution. Widen the peer range in `package.json` when upgrading
+> deliberately.
 >
 > Requires **Node >=20** (matches the SDK's `engines` floor).
 
@@ -180,7 +186,7 @@ ingress/proxy that adds auth):
 ```dockerfile
 FROM node:22-slim
 RUN npm i -g @openprose/reactor @openprose/reactor-cli @openprose/reactor-devtools \
-    && npm i -g @openai/agents zod
+    && npm i -g "@openai/agents@^0.11.6" zod
 WORKDIR /app
 COPY . .
 EXPOSE 8080

--- a/packages/reactor-cli/package.json
+++ b/packages/reactor-cli/package.json
@@ -39,8 +39,8 @@
     "commander": "^12.0.0"
   },
   "peerDependencies": {
-    "@openai/agents": "*",
-    "zod": "*"
+    "@openai/agents": "^0.11.6",
+    "zod": "^4.4.3"
   },
   "peerDependenciesMeta": {
     "@openai/agents": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: 3.0.81
         version: 3.0.81(zod@4.4.3)
       '@openai/agents':
-        specifier: '*'
+        specifier: ^0.11.6
         version: 0.11.6(ws@8.21.0)(zod@4.4.3)
       '@openai/agents-extensions':
         specifier: 0.11.6
@@ -51,7 +51,7 @@ importers:
         specifier: ^12.0.0
         version: 12.1.0
       zod:
-        specifier: '*'
+        specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@types/node':
@@ -582,66 +582,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - "packages/*"
   - "skills/open-prose/examples/*"
+
+# Freshly published versions are not resolvable for 48h (supply-chain cooldown).
+# Urgent security fix needed sooner? Add the package to minimumReleaseAgeExclude,
+# install, then remove it — a reviewable config change, not a standing hole.
+minimumReleaseAge: 2880
+minimumReleaseAgeExclude: []


### PR DESCRIPTION
Four routes a compromised upstream could take into this repo, closed together. Nothing here changes what anything resolves to — resolved versions and integrity hashes are untouched.

## Why

pnpm 9 runs every dependency's install lifecycle script and has no allow-list model, so every PR executed install hooks from the whole dependency tree. Separately, two peer ranges were `*`, which any future major satisfies, including a hijacked one.

CI consumed third-party actions by tags their maintainers can move, and the benchmark jobs were the sharpest case: they cloned an external repo at whatever `main` pointed to, installed pi and bun at whatever the registry served that minute, and interpolated dispatch inputs directly into shell — all while five provider secrets (ANTHROPIC, OPENAI, OPENROUTER, XAI, GOOGLE, the last through two env vars) were in scope.

And the publish job, which holds an `id-token` credential that can publish under our name, installed `npm@latest` before using it.

## What changed

- **`package.json`** — pnpm `9.15.0` → `10.34.5`. pnpm 10 blocks lifecycle scripts by default and carries the fix for the fail-open integrity check in CVE-2026-50021.
- **`pnpm-workspace.yaml`** — `minimumReleaseAge: 2880` makes freshly published versions unresolvable for 48h, the window in which registry compromises are typically caught and yanked. `minimumReleaseAgeExclude` is the escape hatch for an urgent fix: a reviewable config change, not a standing hole.
- **`packages/reactor-cli/package.json`** — `@openai/agents` and `zod` peers go from `*` to carets on the versions the lockfile already resolved. The README install lines are pinned to match.
- **`ci-reactor-package.yml`** — `npm audit signatures` as a blocking step, plus a non-blocking `pnpm audit --prod`. The publish job pins npm rather than tracking `latest`, with a check that fails there rather than confusing someone at publish time.
- **`longcot-bench.yml`, `longcot-rlmify.yml`** — dispatch inputs travel through the step environment as quoted variables instead of being interpolated into `run:`, which is the pattern GitHub documents for inline scripts. pi, bun, and the LongCoT checkout are all pinned.
- **workflows** — `pnpm/action-setup`, `astral-sh/setup-uv`, and `oven-sh/setup-bun` pinned to the SHAs their floating tags already resolved to.
- **`.github/dependabot.yml`** (new) — monthly grouped action bumps, which is what keeps those SHAs from rotting.
- **`pnpm-lock.yaml`** — specifier lines for the two peers, plus `libc` metadata on rollup's Linux binaries that pnpm 10 records and 9 did not. No `version:` line moves.

## Four things worth a reviewer's attention

**The signature check runs per publishable package, not once at the root.** npm only walks the tree reachable from its working directory, and pnpm keeps each workspace package's dependencies under that package — so a root-only call would gate the root's dev tooling and none of what we actually ship.

**`^0.11.6` caps at `0.11.x`, not `0.x`.** Under 0.x semver a caret is tighter than it usually implies. That matters to consumers: registry `latest` for `@openai/agents` is 0.14.3, which does not satisfy the new range, so the README install lines are pinned to match — otherwise the documented project-local install would fail peer resolution. Widen the peer range deliberately at the next upgrade.

**The 48h cooldown does not cover the benchmark jobs' tools.** `minimumReleaseAge` is a pnpm setting; pi arrives through `npm install -g` and bun through an action. Those needed explicit version pins, not the cooldown.

**`actions/*` stay on version tags, and that is a trust decision rather than a claim that pinning them is pointless.** Tags are mutable and anyone with push rights on an action's repository can move one, so SHA-pinning `actions/*` would genuinely narrow exposure. We take the residual risk to keep the pin set small enough to stay honestly current — stale pins nobody bumps are their own hazard. Worth revisiting as the number of workflows grows.

## Verify

```bash
pnpm install --frozen-lockfile                      # passes: nothing re-resolves
(cd packages/reactor-cli && npm audit signatures)
```

For the workflows, confirm no `${{ inputs.* }}` expression remains inside any `run:` block, and that every `$LONGCOT_*` referenced in a script is declared in that step's `env:`.
