### PR TITLE
release(reactor): reactor 0.3.2, reactor-cli 0.2.3, reactor-devtools 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threads `render_model`, `temperature`, and `reasoning_effort` into the render
   exactly like `run` and `serve`.
 
+## [reactor 0.3.2 / reactor-cli 0.2.3 / reactor-devtools 0.3.0] - 2026-08-12
+
+Reactor-train release (`reactor-v*` tag train). Each package publishes at its own
+version; the skill/plugin track is unaffected.
+
+### Fixed
+
+- **`@openprose/reactor-cli` 0.2.3 — reserved `@`-prefixed files no longer win the
+  structured-backing pick (#136, #153).** A render that wrote both the reserved
+  `@atomic.json` status file and its real structured backing (e.g. `sources.json`)
+  had the status file chosen, because `@` sorts before lowercase letters. The
+  canonicalizer then found none of the declared material paths and fingerprinted
+  every facet as `sha256("null")`, so nothing propagated downstream. `@`-prefixed
+  files are now excluded from the candidate set.
+- **`@openprose/reactor-cli` 0.2.3 — `reactor.yml`'s provider and temperature are
+  honored (#137, #138)**, an unset temperature is omitted rather than sent, and
+  render failure reasons are surfaced instead of swallowed.
+- **`@openprose/reactor` 0.3.2 — provider key material is scrubbed** from surfaced
+  render errors.
+- **`@openprose/reactor` 0.3.2 — height-ordered, dirty-count-gated reconciler drain
+  (MK-1).** The FIFO drain could render a diamond-shaped dependent before all its
+  parents settled, producing a transient glitch value and a redundant re-render.
+
+### Changed
+
+- **`@openprose/reactor-devtools` 0.3.0 — the replay viewer is re-skinned** to the
+  OpenProse machine surface (charcoal + gold, JetBrains Mono) and gains the
+  credibility-seam panels (version/reuse/footprint/skew).
+
 ## [0.15.0] - 2026-06-04 — open-prose skill & plugin
 
 Skill/plugin-track release. The `@openprose/prose-cli` CLI is unaffected and

--- a/packages/reactor-cli/package.json
+++ b/packages/reactor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/reactor-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openprose/prose.git",

--- a/packages/reactor-devtools/package.json
+++ b/packages/reactor-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/reactor-devtools",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openprose/prose.git",

--- a/packages/reactor/package.json
+++ b/packages/reactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprose/reactor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenProse Reactor runtime: fresh model spend scales with surprise, not the clock.",
   "type": "commonjs",
   "main": "./dist/index.js",


### PR DESCRIPTION
Cuts the `reactor-v*` train so the fix for #136 (landed in #153) actually reaches npm.

## Versions

| package | from | to |
| --- | --- | --- |
| `@openprose/reactor` | 0.3.1 | 0.3.2 |
| `@openprose/reactor-cli` | 0.2.2 | 0.2.3 |
| `@openprose/reactor-devtools` | 0.2.0 | 0.3.0 |

All three have unpublished changes since `reactor-v0.3.1-cli.0.2.2`. Fixes only for
the SDK and CLI (patch); the devtools re-skin is feature-bearing (minor).

## Contents

- **#136 / #153** — reserved `@`-prefixed files no longer win the structured-backing
  pick, so declared facets stop fingerprinting to `sha256("null")`.
- **#137 / #138** — `reactor.yml` provider + temperature honored, unset temperature
  omitted, render failure reasons surfaced.
- provider key material scrubbed from surfaced render errors.
- MK-1 height-ordered, dirty-count-gated reconciler drain.
- replay viewer re-skinned to the machine surface + credibility-seam panels.

## Verification

`pnpm test:reactor:offline` locally: SDK+devtools 496/496, CLI 209/210. The one
failure is environmental only — `readModelKey` walks up past the checkout and finds
a developer `.env` above the repo root, so `doctor` reports a live key where the test
asserts `absent`. No such ancestor `.env` exists in a CI checkout.

After merge: tag `reactor-v0.3.2-cli.0.2.3` to trigger the OIDC publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)