### PR TITLE
feat(reactor-cli): add OrcaRouter as a named built-in provider

### DIFF
--- a/packages/reactor-cli/README.md
+++ b/packages/reactor-cli/README.md
@@ -228,6 +228,11 @@ reactors: []                   # optional: a multi-reactor host (see below)
 Global flags `--state-dir`, `--project`, `--json`, `--offline` override the file
 on every command.
 
+The built-in providers are `openrouter` (the default), `openai`, `anthropic`,
+`google`, and `orcarouter`; each supplies its own endpoint and key env var
+(`ORCAROUTER_API_KEY` for OrcaRouter). To point at any other OpenAI-compatible
+endpoint, set `base_url` + `api_key_env` explicitly.
+
 ### Sandbox
 
 The `sandbox` block is the render **threat-model** knob:

--- a/packages/reactor-cli/src/__tests__/provider-plan.test.ts
+++ b/packages/reactor-cli/src/__tests__/provider-plan.test.ts
@@ -35,6 +35,16 @@ describe('resolveProviderPlan', () => {
     assert.equal(google.custom, true);
   });
 
+  it('resolves the orcarouter built-in to the OrcaRouter gateway base URL + key env', () => {
+    const orcarouter = resolveProviderPlan({ provider: 'orcarouter' });
+    assert.equal(orcarouter.provider, 'orcarouter');
+    assert.equal(orcarouter.baseURL, 'https://api.orcarouter.ai/v1');
+    assert.equal(orcarouter.apiKeyEnv, 'ORCAROUTER_API_KEY');
+    assert.equal(orcarouter.transport, 'openai-compat');
+    // A non-default provider: the CLI builds + injects the scoped provider.
+    assert.equal(orcarouter.custom, true);
+  });
+
   it('routes the anthropic built-in through the NATIVE adapter (no compat base URL)', () => {
     const anthropic = resolveProviderPlan({ provider: 'anthropic' });
     assert.equal(anthropic.apiKeyEnv, 'ANTHROPIC_API_KEY');

--- a/packages/reactor-cli/src/commands/init.ts
+++ b/packages/reactor-cli/src/commands/init.ts
@@ -132,10 +132,10 @@ state:
   dir: ./.reactor
 
 model:
-  # Provider: openrouter (default) | openai | anthropic | google | <custom>.
+  # Provider: openrouter (default) | openai | anthropic | google | orcarouter | <custom>.
   # A built-in supplies its own endpoint + key env (OPENROUTER_API_KEY,
-  # OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY). To use another vendor,
-  # set base_url + api_key_env. See docs: /cli/configuration#choosing-a-model-provider
+  # OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, ORCAROUTER_API_KEY).
+  # To use another vendor, set base_url + api_key_env. See docs: /cli/configuration#choosing-a-model-provider
   provider: openrouter
   render_model: google/gemini-3.5-flash
   compile_model: google/gemini-3.5-flash

--- a/packages/reactor-cli/src/config.ts
+++ b/packages/reactor-cli/src/config.ts
@@ -40,7 +40,7 @@ export interface ModelConfig {
   readonly max_turns: number;
   /**
    * Override the provider's OpenAI-compatible base URL. Optional: a built-in
-   * provider (openrouter/openai/anthropic/google) supplies its own. Set this (with
+   * provider (openrouter/openai/anthropic/google/orcarouter) supplies its own. Set this (with
    * {@link api_key_env}) to point at any other OpenAI-compatible endpoint.
    */
   readonly base_url?: string;

--- a/packages/reactor-cli/src/model/provider-plan.ts
+++ b/packages/reactor-cli/src/model/provider-plan.ts
@@ -93,6 +93,10 @@ const KNOWN_PROVIDERS: Readonly<Record<string, KnownProvider>> = Object.freeze({
     baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
     apiKeyEnv: 'GEMINI_API_KEY',
   },
+  orcarouter: {
+    baseURL: 'https://api.orcarouter.ai/v1',
+    apiKeyEnv: 'ORCAROUTER_API_KEY',
+  },
 });
 
 /** The provider labels the CLI knows out of the box (for error guidance). */


### PR DESCRIPTION
This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats `openrouter`-style aggregators. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What & why

`packages/reactor-cli`'s `KNOWN_PROVIDERS` registry documents its extension mechanism ("Add a row as new vendors are asked for in the wild"). This PR adds one row for `orcarouter`:

- `baseURL: https://api.orcarouter.ai/v1`
- `apiKeyEnv: ORCAROUTER_API_KEY`

so a `reactor.yml` with `model.provider: orcarouter` resolves the OrcaRouter gateway base URL + key env through the exact same `openai-compat` (Chat Completions) path the existing `openrouter` / `openai` / `google` built-ins use — `buildLiveProvider` injects a scoped `OpenAIProvider` with `useResponses: false`, unchanged.

## Changes

- `src/model/provider-plan.ts` — add `orcarouter` to `KNOWN_PROVIDERS` (base URL + key env)
- `src/commands/init.ts` — scaffold `reactor.yml` comment lists `orcarouter` + `ORCAROUTER_API_KEY`
- `src/config.ts` — `base_url` docstring lists `orcarouter`
- `README.md` — built-in provider list includes `orcarouter`
- `src/__tests__/provider-plan.test.ts` — new unit test asserting the orcarouter plan

## Verification

- `pnpm --filter @openprose/reactor-cli typecheck` — clean
- `pnpm --filter @openprose/reactor-cli build:test` — clean
- provider-plan suite: **10/10 pass** (baseline 9/9 + new orcarouter test)
- Full `node --test` over `dist-test`: **210 pass / 1 fail** — the single failure is the `contract-images` symlink-cycle test on Windows (`EPERM: operation not permitted, symlink`), a pre-existing platform limitation unrelated to this change
- **L3 live** with a real OrcaRouter key: `resolveProviderPlan({ provider: 'orcarouter' })` → `https://api.orcarouter.ai/v1` + `ORCAROUTER_API_KEY`; `reactor doctor --live` smoke render OK (model `anthropic/claude-haiku-4.5`, 38 tokens); a structured render + function tool through the gateway returned 1872 tokens
- `reactor init` scaffold → `reactor.yml` documents the `orcarouter` provider; `doctor` recognizes `ORCAROUTER_API_KEY`

## Notes

No behavior change for existing users: `openrouter` remains the default, and the SDK's lazy default-OpenRouter path is untouched (`custom: true` only for non-default providers).
