### PR TITLE
ci: run the skill conformance gate on every pull request

### DIFF
--- a/.github/workflows/ci-skill.yml
+++ b/.github/workflows/ci-skill.yml
@@ -1,25 +1,15 @@
 name: CI - Skill conformance
 
-# Runs the OpenProse conformance suites under tests/open-prose/** on every PR
-# that touches the skill, the spec, the example corpus, the std/co contract
-# libraries, or the gate's own wiring. The suites read Markdown off disk and
-# make string assertions: no build step, no model key, no network.
+# Runs the OpenProse conformance suites under tests/open-prose/**. The suites
+# read Markdown off disk and make string assertions: no build step, no model
+# key, no network, well under a minute.
+#
+# There is deliberately no path filter. This job is the required status check
+# on main, and a required check that never reports leaves a pull request
+# waiting on it forever — so every pull request runs it, whatever it touches.
 
 on:
   pull_request:
-    paths:
-      - "skills/**"
-      - "spec/**"
-      - "tests/**"
-      - "packages/std/**"
-      - "packages/co/**"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "vitest.config.ts"
-      - ".github/workflows/ci-skill.yml"
   push:
     branches: [main]
 
@@ -32,6 +22,7 @@ permissions:
 
 jobs:
   skill:
+    # NOTE: this job name is the required status check on main — do not rename.
     name: CI - Skill conformance
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
This job is about to become the required status check on `main`. A path-filtered required check never reports on a pull request outside its filter, and GitHub has no "only if it ran" option — the pull request just waits on a check that will never arrive. Today that would strand anything touching only `scripts/`, `CHANGELOG.md`, `.github/**`, `assets/`, `.version-bump.json`, `AGENTS.md` or `RELEASE.md`.

Removing the filter is cheaper than adding an always-running aggregate job. The suites read Markdown off disk and make string assertions — no build step, no model key, no network — so running them unconditionally costs well under a minute. The Reactor repository's workflow is unfiltered for the same reason.

Nothing changes about what runs, only when. The job name is marked do-not-rename, since it is what the branch rule will reference.